### PR TITLE
Add npm install command to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,17 @@ The two suggested workflows are:
   </div>
   ```
 
-  ## Local setup
+## Local setup
 
 ### Requirements
 
 - **Node version 16.14**
+
+### Setup
+
+```
+npm install
+```
 
 ### Starting 
 


### PR DESCRIPTION
This was missing and is required for `npm run start` to work.