### PR TITLE
Update documentation to reflect the removal of IControl on Avalonia 11.

### DIFF
--- a/docs/concepts/templates/implement-idatatemplate.md
+++ b/docs/concepts/templates/implement-idatatemplate.md
@@ -9,7 +9,7 @@ If you need take more control over a data template in code, you can write a clas
 To use the `IDataTemplate`interface you must implement the following two members in your data template class:
 
 * `public bool Match(object data) { ... }` - implement this member to check whether the provided bound data matches your `IDataTemplate` or not. Return true if the bound data type matches, otherwise false.
-* `public IControl Build(object param) { ... }` - implement this member to build and return the control that will present your data.
+* `public Control Build(object param) { ... }` - implement this member to build and return the control that will present your data.
 
 ## Example
 
@@ -20,7 +20,7 @@ using Avalonia.Controls.Templates;
 ...
 public class MyDataTemplate : IDataTemplate
 {
-    public IControl Build(object param)
+    public Control Build(object param)
     {
         return new TextBlock() { Text = (string)param };
     }

--- a/docs/concepts/view-locator.md
+++ b/docs/concepts/view-locator.md
@@ -24,7 +24,7 @@ public class ViewLocator : IDataTemplate
 {
     public bool SupportsRecycling => false;
 
-    public IControl Build(object data)
+    public Control Build(object data)
     {
         var name = data.GetType().FullName.Replace("ViewModel", "View");
         var type = Type.GetType(name);

--- a/docs/guides/development-guides/how-to-implement-multi-page-apps.md
+++ b/docs/guides/development-guides/how-to-implement-multi-page-apps.md
@@ -17,7 +17,7 @@ that is added by the Avalonia MVVM solution template.&#x20;
 ```csharp
 public class ViewLocator : IDataTemplate
 {
-    public IControl? Build(object? data)
+    public Control? Build(object? data)
     {
         if (data==null) return null;
         var name = data.GetType().FullName!.Replace("ViewModel", "View");

--- a/docs/tutorials/todo-list-app/locating-views.md
+++ b/docs/tutorials/todo-list-app/locating-views.md
@@ -18,7 +18,7 @@ namespace ToDoList
 {
     public class ViewLocator : IDataTemplate
     {
-        public IControl Build(object data)
+        public Control Build(object data)
         {
             var name = data.GetType().FullName!.Replace("ViewModel", "View");
             var type = Type.GetType(name);


### PR DESCRIPTION
Hello. 

The docs for v11 retained references to IControl, which was removed. So this quick PR patches those.