### PR TITLE
Update docs: From Items to ItemsSource for collection-based controls in Avalonia 11.

### DIFF
--- a/docs/basics/data/data-binding/compiled-bindings.md
+++ b/docs/basics/data/data-binding/compiled-bindings.md
@@ -106,7 +106,7 @@ If you have compiled bindings enabled in the root node (via `x:CompileBindings="
 In some cases the target type of the binding expression cannot be automatically evaluated. In such cases you muss provide an explicite type cast in the binding expression.
 
 ```markup
-<ItemsRepeater Items="{Binding MyItems}">
+<ItemsRepeater ItemsSource="{Binding MyItems}">
 <ItemsRepeater.ItemTemplate>
     <DataTemplate>
     <StackPanel Orientation="Horizontal">

--- a/docs/concepts/reactiveui/binding-to-sorted-filtered-list.md
+++ b/docs/concepts/reactiveui/binding-to-sorted-filtered-list.md
@@ -48,7 +48,7 @@ Now that the `_sourceCache` is created and populated and the `ReadOnlyObservable
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-    <TreeView Items="{Binding TestViewModels}">
+    <TreeView ItemsSource="{Binding TestViewModels}">
         <TreeView.DataTemplates>
             !-- DataTemplate Definitions -->
         </TreeView.DataTemplates> 

--- a/docs/guides/custom-controls/how-to-create-attached-properties.md
+++ b/docs/guides/custom-controls/how-to-create-attached-properties.md
@@ -130,7 +130,7 @@ This example UI shows how to use the attached property. After making the namespa
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:MyApp.Behaviors"
              x:Class="MyApp.Views.TestView">
-    <ListBox Items="{Binding Accounts}"
+    <ListBox ItemsSource="{Binding Accounts}"
              SelectedIndex="{Binding SelectedAccountIdx, Mode=TwoWay}"
              loc:DoubleTappedBehav.Command="{Binding EditCommand}"
              loc:DoubleTappedBehav.CommandParameter="test77"

--- a/docs/guides/data-binding/binding-classes.md
+++ b/docs/guides/data-binding/binding-classes.md
@@ -22,7 +22,7 @@ In this example, two styles with class selectors have been defined. These give a
 
 ```xml title='XAML'
 <StackPanel Margin="20">
-  <ListBox Items="{Binding ItemList}">
+  <ListBox ItemsSource="{Binding ItemList}">
     <ListBox.Styles>
       <Style Selector="TextBlock.class1">
         <Setter Property="Background" Value="OrangeRed" />

--- a/docs/guides/data-binding/how-to-bind-tabs.md
+++ b/docs/guides/data-binding/how-to-bind-tabs.md
@@ -6,7 +6,7 @@ title: How To Bind Tabs
 
 ## Binding Support Example
 
-You can dynamically create tab items with **data binding**. To do this, bind the `Items` property of a tab control to an array of objects representing the tab header and content.&#x20;
+You can dynamically create tab items with **data binding**. To do this, bind the `ItemsSource` property of a tab control to an array of objects representing the tab header and content.&#x20;
 
 You can then use a **data template** to display the objects.
 
@@ -36,10 +36,10 @@ DataContext = new TabItemModel[] {
 
 The `TabStrip` header content is defined by ItemTemplate property, while `TabItem`'s content is defined by ContentTemplate property.
 
-Finally create a `TabControl` and bind its Items property to the DataContext.
+Finally create a `TabControl` and bind its `ItemsSource` property to the DataContext.
 
 ```markup
-<TabControl Items="{Binding}">
+<TabControl ItemsSource="{Binding}">
     <TabControl.ItemTemplate>
       <DataTemplate>
         <TextBlock Text="{Binding Header}" />

--- a/docs/guides/data-binding/how-to-bind-to-a-collection.md
+++ b/docs/guides/data-binding/how-to-bind-to-a-collection.md
@@ -35,7 +35,7 @@ public class ViewModel : ObservableObject
 In your view, you can bind this `ObservableCollection` to a `ListBox` like so:
 
 ```xml
-<ListBox Items="{Binding Items}"/>
+<ListBox ItemsSource="{Binding Items}"/>
 ```
 
 ## Binding to an ObservableCollection of Complex Objects
@@ -91,7 +91,7 @@ public class ViewModel : ObservableObject
 You can bind this `ObservableCollection` to a `ListBox` in your view, and use a `DataTemplate` to specify how each `Person` should be presented:
 
 ```xml
-<ListBox Items="{Binding People}">
+<ListBox ItemsSource="{Binding People}">
     <ListBox.ItemTemplate>
         <DataTemplate>
             <StackPanel Orientation="Horizontal">

--- a/docs/guides/development-guides/data-validation.md
+++ b/docs/guides/development-guides/data-validation.md
@@ -109,7 +109,7 @@ To display the validation messages, Avalonia has a control called [`DataValidati
           </Style>
         </Canvas.Styles>
         <ToolTip.Tip>
-          <ItemsControl Items="{Binding}"/>
+          <ItemsControl ItemsSource="{Binding}"/>
         </ToolTip.Tip>
         <Path Data="M14,7 A7,7 0 0,0 0,7 M0,7 A7,7 0 1,0 14,7 M7,3l0,5 M7,9l0,2" 
               Stroke="Red" 

--- a/docs/reference/built-in-data-binding-converters.md
+++ b/docs/reference/built-in-data-binding-converters.md
@@ -33,7 +33,7 @@ For example, as the integer zero is converted to false (by the the function `Con
 
 ```markup
 <Panel>
-  <ListBox Items="{Binding Items}"/>
+  <ListBox ItemsSource="{Binding Items}"/>
   <TextBlock IsVisible="{Binding !Items.Count}">No results found</TextBlock>
 </Panel>
 ```
@@ -44,7 +44,7 @@ You can use this to hide a control when a collection is empty (count is zero), l
 
 ```markup
 <Panel>
-  <ListBox Items="{Binding Items}" IsVisible="{Binding !!Items.Count}"/>
+  <ListBox ItemsSource="{Binding Items}" IsVisible="{Binding !!Items.Count}"/>
 </Panel>
 ```
 

--- a/docs/reference/controls/buttons/splitbutton.md
+++ b/docs/reference/controls/buttons/splitbutton.md
@@ -81,7 +81,7 @@ A common use case of a `SplitButton` is for coloring text within an editor. Pres
              Command="{Binding ChangeColorCommand}">
   <SplitButton.Flyout>
     <Flyout Placement="Bottom">
-      <ListBox Items="{Binding AvailableColors}" 
+      <ListBox ItemsSource="{Binding AvailableColors}" 
                SelectedItem="{Binding SelectedColor}" 
                Height="200" Width="200" >
         <ListBox.ItemsPanel>

--- a/docs/reference/controls/datagrid/README.md
+++ b/docs/reference/controls/datagrid/README.md
@@ -58,7 +58,7 @@ You will probably use these properties most often:
 | Property                | Description                                                                                                                     |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `AutoGenerateColumns`   | Whether the columns will automatically generate from the bound items data source property names. (Default is false.)            |
-| `Items`                 | The bound collection that is used as the data source for the control.                                                           |
+| `ItemsSource`           | The bound collection that is used as the data source for the control.                                                           |
 | `IsReadOnly`            | Sets the binding direction to one-way when true. The default is false - the grid will accept changes to the bound data.         |
 | `CanUserReorderColumns` | Indicates whether the user can change the column display order by dragging column headers with the pointer. (Default is false.) |
 | `CanUserResizeColumns`  | Indicates whether the user can adjust column widths using the pointer. (Default is false.)                                      |
@@ -71,7 +71,7 @@ This example will generate a basic data grid, with column header names auto-gene
 
 
 ```xml
-<DataGrid Margin="20" Items="{Binding People}" 
+<DataGrid Margin="20" ItemsSource="{Binding People}" 
           AutoGenerateColumns="True" IsReadOnly="True" 
           GridLinesVisibility="All"
           BorderThickness="1" BorderBrush="Gray">
@@ -130,7 +130,7 @@ These examples use the MVVM pattern with data binding to an `ObservableCollectio
 Property names from the item class will generally not make good column names. This example adds custom header names to the grid. It also allows column reordering and resizing and disallows the default column sorting option:
 
 ```markup
-<DataGrid Margin="20" Items="{Binding People}"
+<DataGrid Margin="20" ItemsSource="{Binding People}"
           IsReadOnly="True"
           CanUserReorderColumns="True"
           CanUserResizeColumns="True"
@@ -151,7 +151,7 @@ This example shows how the data grid can accept changes and update the underlyin
 
 
 ```xml
-<DataGrid Margin="20" Items="{Binding People}"        
+<DataGrid Margin="20" ItemsSource="{Binding People}"        
           GridLinesVisibility="All"
           BorderThickness="1" BorderBrush="Gray">
   <DataGrid.Columns>

--- a/docs/reference/controls/datagrid/datagridcolumns.md
+++ b/docs/reference/controls/datagrid/datagridcolumns.md
@@ -57,7 +57,7 @@ This example improves a data grid by expanding two columns equally across the wi
    <Design.DataContext>
        <vm:MainWindowViewModel/>
   </Design.DataContext>
-  <DataGrid Margin="20" Items="{Binding People}"
+  <DataGrid Margin="20" ItemsSource="{Binding People}"
           IsReadOnly="True"
           GridLinesVisibility="All"
           BorderThickness="1" BorderBrush="Gray">

--- a/docs/reference/controls/detailed-reference/datagrid/data-grid-template-columns.md
+++ b/docs/reference/controls/detailed-reference/datagrid/data-grid-template-columns.md
@@ -24,7 +24,7 @@ This example adds a numeric up-down control when the age property for a person i
 <Window ...
   xmlns:model="using:AvaloniaControls.Models" >
   
-  <DataGrid Margin="20" Items="{Binding People}"
+  <DataGrid Margin="20" ItemsSource="{Binding People}"
           GridLinesVisibility="All"
           BorderThickness="1" BorderBrush="Gray">
     <DataGrid.Columns>

--- a/docs/reference/controls/detailed-reference/treeview-1.md
+++ b/docs/reference/controls/detailed-reference/treeview-1.md
@@ -15,7 +15,7 @@ This example uses a MVVM pattern view model to hold some hierarchical data based
 
 
 ```xml
-<TreeView Items="{Binding Nodes}">
+<TreeView ItemsSource="{Binding Nodes}">
   <TreeView.ItemTemplate>
     <TreeDataTemplate ItemsSource="{Binding SubNodes}">
       <TextBlock Text="{Binding Title}"/>
@@ -89,7 +89,7 @@ This is a development of the previous example with multiple root nodes, a revise
 
 ```xml
 <TreeView Margin="10"
-          Items="{Binding Nodes}" 
+          ItemsSource="{Binding Nodes}" 
           SelectedItems="{Binding SelectedNodes}"
           SelectionMode="Multiple">
   <TreeView.ItemTemplate>

--- a/docs/reference/controls/itemscontrol.md
+++ b/docs/reference/controls/itemscontrol.md
@@ -14,7 +14,7 @@ To see the full list of _Avalonia UI_ built-in repeating data controls, see [her
 
 You will probably use these properties most often:
 
-<table><thead><tr><th width="316">Property</th><th>Description</th></tr></thead><tbody><tr><td><code>Items</code></td><td>The bound collection that is used as the data source for the control.</td></tr><tr><td><code>ItemsControl.ItemTemplate</code></td><td>Attached property element to contain the data template for an individual item. </td></tr></tbody></table>
+<table><thead><tr><th width="316">Property</th><th>Description</th></tr></thead><tbody><tr><td><code>ItemsSource</code></td><td>The bound collection that is used as the data source for the control.</td></tr><tr><td><code>ItemsControl.ItemTemplate</code></td><td>Attached property element to contain the data template for an individual item. </td></tr></tbody></table>
 
 ## Example
 
@@ -25,7 +25,7 @@ This example binds an observable collection of crockery items to an items contro
 ```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">List of crockery:</TextBlock>
-  <ItemsControl Items="{Binding CrockeryList}" >
+  <ItemsControl ItemsSource="{Binding CrockeryList}" >
     <ItemsControl.ItemTemplate>
     <DataTemplate>
       <Border Margin="0,10,0,0"

--- a/docs/reference/controls/itemsrepeater.md
+++ b/docs/reference/controls/itemsrepeater.md
@@ -7,7 +7,7 @@ description: REFERENCE - Built-in Controls
 The items repeater can display repeating data from a bound data source. It has both a layout template and a data template.&#x20;
 
 :::info
-The items repeater is a port of the UWP `ItemsRepeater` control. For further information see [here](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/items-repeater). The only difference is that the data source in the _Avalonia UI_ control is called `Items` (not `ItemsSource`).&#x20;
+The items repeater is a port of the UWP `ItemsRepeater` control. For further information see [here](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/items-repeater).&#x20;
 :::
 
 The default layout template is a vertical stack layout, so that items appear in a vertical list.
@@ -21,7 +21,7 @@ This example binds an observable collection of crockery items to an items repeat
 ```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">List of crockery:</TextBlock>
-  <ItemsRepeater  Items="{Binding CrockeryList}" >
+  <ItemsRepeater  ItemsSource="{Binding CrockeryList}" >
     <ItemsRepeater.ItemTemplate>
     <DataTemplate>
       <Border Margin="0,10,0,0"
@@ -94,7 +94,7 @@ By default an items repeater will render the items in a vertical stack layout. Y
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">List of crockery:</TextBlock>
   <ScrollViewer HorizontalScrollBarVisibility="Auto">
-    <ItemsRepeater Items="{Binding CrockeryList}" Margin="0 20">
+    <ItemsRepeater ItemsSource="{Binding CrockeryList}" Margin="0 20">
       <ItemsRepeater.Layout>
         <StackLayout Spacing="40"
             Orientation="Horizontal" />

--- a/docs/tutorials/music-store-app/add-items-to-users-collection.md
+++ b/docs/tutorials/music-store-app/add-items-to-users-collection.md
@@ -54,7 +54,7 @@ xmlns:views="clr-namespace:Avalonia.MusicStore.Views"
 - Under the button element, add the XAML as shown:
 
 ```xml
-<ItemsControl Margin="0 40 0 0" Items="{Binding Albums}">
+<ItemsControl Margin="0 40 0 0" ItemsSource="{Binding Albums}">
   <ItemsControl.ItemsPanel>
     <ItemsPanelTemplate>
       <WrapPanel />

--- a/docs/tutorials/music-store-app/album-view.md
+++ b/docs/tutorials/music-store-app/album-view.md
@@ -122,7 +122,7 @@ To tidy up the list, follow this procedure:
 - Add the `<ListBox.ItemsPanel>` XAML shown:&#x20;
 
 ```markup
-<ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}"
+<ListBox ItemsSource="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}"
     Background="Transparent" Margin="0 20">
     <ListBox.ItemsPanel>
         <ItemsPanelTemplate>

--- a/docs/tutorials/music-store-app/mock-search.md
+++ b/docs/tutorials/music-store-app/mock-search.md
@@ -121,7 +121,7 @@ Next to bind these properties to the list box in the view, follow this procedure
 - Add the binding expressions shown to the `<ListBox>` element:
 
 ```
-<ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" />
+<ListBox ItemsSource="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" />
 ```
 
 ## Mock Data


### PR DESCRIPTION
Docs were still referring to Items on v11, so here's another low-hanging fruit.