### PR TITLE
Some fixes

### DIFF
--- a/docs/basics/user-interface/styling/themes/fluent.md
+++ b/docs/basics/user-interface/styling/themes/fluent.md
@@ -11,7 +11,7 @@ Avalonia Fluent theme is inspired by Microsoft's Fluent Design System, which is 
 
 ## How to use
 
-As a first step, [Avalonia.Themes.Fluent](https://www.nuget.org/packages/Avalonia.Themes.Fluent/) nuget package needs to be installed. 
+As a first step, [Avalonia.Themes.Fluent](https://www.nuget.org/packages/Avalonia.Themes.Fluent/) nuget package needs to be installed.
 
 :::info
 On how to add a nuget package, you can follow steps from the Nuget page or [Visual Studio](https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio), [Rider](https://www.jetbrains.com/help/rider/Using_NuGet.html) documentation.
@@ -68,9 +68,9 @@ To do so, you need to define
     // highlight-start
       <FluentTheme.Palettes>
         <!-- Palette for Light theme variant -->
-        <ColorPaletteResources x:Key="Light" AccentColor="Green" RegionColor="White" ErrorText="Red" />
+        <ColorPaletteResources x:Key="Light" Accent="Green" RegionColor="White" ErrorText="Red" />
         <!-- Palette for Dark theme variant -->
-        <ColorPaletteResources x:Key="Dark" AccentColor="DarkGreen" RegionColor="Black" ErrorText="Yellow" />
+        <ColorPaletteResources x:Key="Dark" Accent="DarkGreen" RegionColor="Black" ErrorText="Yellow" />
       </FluentTheme.Palettes>
     // highlight-end
     </FluentTheme>
@@ -78,12 +78,12 @@ To do so, you need to define
 </Application>
 ```
 
-While `ColorPaletteResources` has many color properties that can be overriden independently for each variant, it is possible to redefine only minimal set of what's needed, and keep everything else as per defaults. As in examples above, only a couple of colors are overriden.
+While `ColorPaletteResources` has many color properties that can be overridden independently for each variant, it is possible to redefine only minimal set of what's needed, and keep everything else as per defaults. As in examples above, only a couple of colors are overridden.
 
-If AccentColor is not overriden, Avalonia uses platform OS accent color if available.
-Also, AccentColor supports bindings and can be changed in runtime. But not other properties, as they are read once after app started and are statically used for performance reasons.
+If Accent is not overridden, Avalonia uses platform OS accent color if available.
+Also, Accent supports bindings and can be changed in runtime. But not other properties, as they are read once after app started and are statically used for performance reasons.
 
-It is possible to build palettes from the code behind, but same rules apply - only AccentColor can be updated dynamically, and palettes should be 
+It is possible to build palettes from the code behind, but same rules apply - only Accent can be updated dynamically, and palettes should be
 
 :::note
 FluentTheme supports only Dark and Light theme variants, and it's not possible to define palettes for custom variants.
@@ -92,7 +92,8 @@ FluentTheme supports only Dark and Light theme variants, and it's not possible t
 ## Creating custom color palettes with online editor
 
 Microsoft Fluent Theme Editor was ported to Avalonia and now available to be used with our FluentTheme as well.
-It is available on https://theme.xaml.live/ page and supports following features:
+It is available on <https://theme.xaml.live/> page and supports following features:
+
 1. Editing palette colors for both Light and Dark variants.
 2. Previewing of the current palette.
 3. Exporting current palettes as XAML code that can be copy pasted into `App.axaml` file.

--- a/docs/concepts/services/storage-provider/file-picker-options.md
+++ b/docs/concepts/services/storage-provider/file-picker-options.md
@@ -19,6 +19,9 @@ Can be obtained from previously picked folder or using `StorageProvider.TryGetFo
 :::note
 This is a suggestion for the system, that can ignore this parameter, if application doesn't have access to the folder or it doesn't exist.
 :::
+:::note
+On Linux some DBus file picker don't support start location. For using GTK Free Desktop disable `UseDBusFilePicker` in `X11PlatformOptions`
+:::
 
 ## FilePickerOpenOptions
 
@@ -70,6 +73,7 @@ Gets or sets an option indicating whether open picker allows users to select mul
 # Defining custom file types
 
 Avalonia has set of build in file types:
+
 - FilePickerFileTypes.All - all files
 - FilePickerFileTypes.TextPlain - txt files
 - FilePickerFileTypes.ImageAll - all images
@@ -80,6 +84,7 @@ Avalonia has set of build in file types:
 However it is possible to define custom file types that can be used by the picker:
 
 For instance, build-in ImageAll type is defined as
+
 ```cs
 public static FilePickerFileType ImageAll { get; } = new("All Images")
 {
@@ -90,6 +95,7 @@ public static FilePickerFileType ImageAll { get; } = new("All Images")
 ```
 
 Where each file type has following hints that are used by the different platforms:
+
 - `Patterns` are used by most Windows, Linux and Browser platforms, and is a basic GLOB patten that can be matched on types.
 - `AppleUniformTypeIdentifiers` is a standard identifier defined by Apple and is used on macOS and iOS platforms.
 - And `MimeTypes` is a web identfier for the files used on most of platforms, but Windows and iOS.

--- a/docs/concepts/toplevel.md
+++ b/docs/concepts/toplevel.md
@@ -11,12 +11,14 @@ The TopLevel act as the visual root, and is the base class for all top level con
 Here are two common ways to access TopLevel instance.
 
 ### Using TopLevel.GetTopLevel
+
 You can use the static `GetTopLevel` method of the TopLevel class to get the top-level control that contains the current control.
 
 ```cs
 var topLevel = TopLevel.GetTopLevel(control);
 // Here you can reference various services like Clipboard or StorageProvider from topLevel instance.
 ```
+
 This method can be helpful if you're working within a user control or a lower-level component and need access to the TopLevel services.
 
 :::note
@@ -33,10 +35,10 @@ var topLevel = window;
 
 This method is typically used when you're already working within the context of a window, such as in a ViewModel or an event handler within the `Window` class.
 
-
 ## Common Properties
 
 ### ActualTransparencyLevel
+
 Gets the achieved `WindowTransparencyLevel` that the platform was able to provide.
 
 ```cs
@@ -44,6 +46,7 @@ WindowTransparencyLevel ActualTransparencyLevel { get; }
 ```
 
 ### ClientSize
+
 Gets the client size of the window.
 
 ```cs
@@ -51,6 +54,7 @@ Size ClientSize { get; }
 ```
 
 ### Clipboard
+
 Gets the platform's [Clipboard](./services/clipboard) implementation.
 
 ```cs
@@ -58,6 +62,7 @@ IClipboard? Clipboard { get; }
 ```
 
 ### FocusManager
+
 Gets [focus manager](./services/focus-manager) of the root.
 
 ```cs
@@ -65,6 +70,7 @@ IFocusManager? FocusManager { get; }
 ```
 
 ### FrameSize
+
 Gets the total size of the top level including system frame if presented.
 
 ```cs
@@ -72,6 +78,7 @@ Size? FrameSize { get; }
 ```
 
 ### InsetsManager
+
 Gets the platform's [InsetsManager](./services/insets-manager) implementation.
 
 ```cs
@@ -79,6 +86,7 @@ IInsetsManager? InsetsManager { get; }
 ```
 
 ### PlatformSettings
+
 Represents a contract for accessing top-level [platform-specific settings](./services/platform-settings).
 
 ```cs
@@ -86,6 +94,7 @@ IPlatformSettings? PlatformSettings { get; }
 ```
 
 ### RendererDiagnostics
+
 Gets a value indicating whether the renderer should draw specific diagnostics.
 
 ```cs
@@ -93,6 +102,7 @@ RendererDiagnostics RendererDiagnostics { get; }
 ```
 
 ### RenderScaling
+
 Gets the scaling factor to use in rendering.
 
 ```cs
@@ -100,6 +110,7 @@ double RenderScaling { get; }
 ```
 
 ### RequestedThemeVariant
+
 Gets or sets the UI theme variant that is used by the control (and its child elements) for resource determination. The UI theme you specify with ThemeVariant can override the app-level ThemeVariant.
 
 ```cs
@@ -107,6 +118,7 @@ ThemeVariant? RequestedThemeVariant { get; set; }
 ```
 
 ### StorageProvider
+
 [File System storage](./services/storage-provider/) service used for file pickers and bookmarks.
 
 ```cs
@@ -114,6 +126,7 @@ IStorageProvider StorageProvider { get; }
 ```
 
 ### TransparencyBackgroundFallback
+
 Gets or sets the `IBrush` that transparency will blend with when transparency is not supported. By default this is a solid white brush.
 
 ```cs
@@ -121,7 +134,8 @@ IBrush TransparencyBackgroundFallback { get; set; }
 ```
 
 ### TransparencyLevelHint
-Gets or sets the `WindowTransparencyLevel` that the TopLevel should use when possible. Accepts multiple values which are applied in a fallback order. For instance, with "Mica, Blur" Mica will be applied only on platforms where it is possible, and Blur will be used on the rest of them. Default value is an empty array or "None".   
+
+Gets or sets the `WindowTransparencyLevel` that the TopLevel should use when possible. Accepts multiple values which are applied in a fallback order. For instance, with "Mica, Blur" Mica will be applied only on platforms where it is possible, and Blur will be used on the rest of them. Default value is an empty array or "None".
 
 ```cs
 IReadOnlyList<WindowTransparencyLevel> TransparencyLevelHint { get; set; }
@@ -130,6 +144,7 @@ IReadOnlyList<WindowTransparencyLevel> TransparencyLevelHint { get; set; }
 ## Common Events
 
 ### BackRequested
+
 Occurs when physical Back Button is pressed or a back navigation has been requested.
 
 ```cs
@@ -137,6 +152,7 @@ event EventHandler<RoutedEventArgs> BackRequested { add; remove; }
 ```
 
 ### Closed
+
 Fired when the window is closed.
 
 ```cs
@@ -144,6 +160,7 @@ event EventHandler Closed;
 ```
 
 ### Opened
+
 Fired when the window is opened.
 
 ```cs
@@ -151,6 +168,7 @@ event EventHandler Opened;
 ```
 
 ### ScalingChanged
+
 Occurs when the TopLevel's scaling changes.
 
 ```cs
@@ -160,9 +178,12 @@ event EventHandler ScalingChanged;
 ## Common Methods
 
 ### GetTopLevel
+
 Gets the `TopLevel` for which the given `Visual` is hosted in.
+
 #### Parameters
-`control` 
+
+`control`
 The visual to query its TopLevel
 
 ```cs
@@ -170,6 +191,7 @@ static TopLevel? GetTopLevel(Visual? visual)
 ```
 
 ### RequestAnimationFrame
+
 Enqueues a callback to be called on the next animation tick
 
 ```cs
@@ -177,6 +199,7 @@ void RequestAnimationFrame(Action<TimeSpan> action)
 ```
 
 ### RequestPlatformInhibition
+
 Requests a `PlatformInhibitionType` to be inhibited. The behavior remains inhibited until the return value is disposed. The available set of `PlatformInhibitionType`s depends on the platform. If a behavior is inhibited on a platform where this type is not supported the request will have no effect.
 
 ```cs
@@ -184,12 +207,12 @@ async Task<IDisposable> RequestPlatformInhibition(PlatformInhibitionType type, s
 ```
 
 ### TryGetPlatformHandle
+
 Tries to get the platform handle for the TopLevel-derived control.
 
 ```cs
 IPlatformHandle? TryGetPlatformHandle()
 ```
-
 
 ## More Information
 

--- a/docs/stay-up-to-date/upgrade-from-0.10.md
+++ b/docs/stay-up-to-date/upgrade-from-0.10.md
@@ -3,19 +3,20 @@ id: upgrade-from-0.10
 title: Upgrading from 0.10
 ---
 
-Avalonia 11 introduces a number of breaking changes from 0.10. The following guide convers the most commonly-encountered changes and gives solutions for them.
+Avalonia 11 introduces a number of breaking changes from 0.10. The following guide converse the most commonly-encountered changes and gives solutions for them.
 
-## Updating the project.
+## Updating the project
 
 1. Update the Avalonia packages to 11.x
 2. Themes are no longer included in the Avalonia.Desktop package, so you will need to add a package reference to either
-  - `Avalonia.Themes.Fluent`
-  - `Avalonia.Themes.Simple`
+    - `Avalonia.Themes.Fluent`
+    - `Avalonia.Themes.Simple`
 3. Remove the package reference to `XamlNameReferenceGenerator` - Avalonia now includes an inbuilt generator by default
 4. If necessary, update the `<LangVersion>` to at least 9 in order to be able to use init-only properties
 5. If you want the same fonts as in 0.10, also include `Avalonia.Fonts.Inter` package and add `.WithInterFont()` to the app builder. By default, 11.0 doesn't include any custom fonts.
 
 ## Theme Handling
+
 In v0.10, the theme is specified directly inside the `Application.Styles` tag in the `Application.axaml` file. An example of this is shown below:
 
 ```xml
@@ -23,11 +24,13 @@ In v0.10, the theme is specified directly inside the `Application.Styles` tag in
     <FluentTheme Mode="Light"/>
 </Application.Styles>
 ```
+
 In this example, the `Mode` attribute of the `FluentTheme` tag is used to specify the theme mode, which can be either "Light" or "Dark".
 
 Theme management is improved by introducing a new attribute to the `Application` tag: `RequestedThemeVariant`. This new attribute is used to set the theme of your application, overriding the system's current theme if specified. If you want to follow the system's current theme, you can set it to "Default". Other available options are "Dark" and "Light".
 
 An example of how this attribute is used is shown below:
+
 ```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -35,6 +38,7 @@ An example of how this attribute is used is shown below:
              xmlns:local="using:ILoveAvaloniaUI"
              RequestedThemeVariant="Default">
 ```
+
 The `FluentTheme` tag no longer requires the `Mode` attribute and can be left empty.
 
 ```xml
@@ -119,14 +123,14 @@ Views that are in the form of a `.axaml`/`.axaml.cs` (or `.xaml`/`.xaml.cs`) pai
 
 - Make the class in the .cs file `partial`
 - Remove the `private void InitializeComponent()` method
-- Do *NOT* remove the call to `InitializeComponent()` in the constructor: this method is now a generated method and still needs to be called
+- Do **NOT** remove the call to `InitializeComponent()` in the constructor: this method is now a generated method and still needs to be called
 - Remove the `this.AttachDevTools()` call from the constructor - `InitializeComponent` now has a parameter which controls whether DevTools is attached in debug mode whose default is `true`
 
 Previously, to find a named control declared in the XAML file, a call to `this.FindControl<T>(string name)` or `this.GetControl<T>(string name)` was needed. This is now unnecessary - controls in the XAML file with a `Name` or `x:Name` attribute will automatically cause a field to be generated in the class to access the named control (as in WPF/UWP etc).
 
 Note, this source generator is available for C# only. For F# nothing was changed.
 
-# ItemsControl
+## ItemsControl
 
 `ItemsControl` and derived classes such as `ListBox` and `ComboBox` now have both an `Items` property and an `ItemsSource` as in WPF/UWP.
 
@@ -134,13 +138,13 @@ Note, this source generator is available for C# only. For F# nothing was changed
 
 Replace any bindings to `Items` with a binding to `ItemsSource`:
 
-```
+```xml
 <ListBox Items="{Binding Items}">
 ```
 
-Becomes 
+Becomes
 
-```
+```xml
 <ListBox ItemsSource="{Binding Items}">
 ```
 
@@ -206,13 +210,13 @@ var bitmap = new Bitmap(AssetLoader.Open(new Uri(uri)));
 
 ## OnPropertyChanged
 
-The virtual `AvaloniaObject.OnPropertyChanged` method is now non-generic. Replace 
+The virtual `AvaloniaObject.OnPropertyChanged` method is now non-generic. Replace
 
 ```csharp
 protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
 ```
 
-with 
+with
 
 ```csharp
 protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -233,11 +237,11 @@ The following events have been renamed:
 - `PointerEnter` -> `PointerEntered`
 - `PointerLeave` -> `PointerExited`
 - `ContextMenu`
-    - `ContextMenuClosing` -> `Closing`
-    - `ContextMenuOpening` -> `Opening`
+  - `ContextMenuClosing` -> `Closing`
+  - `ContextMenuOpening` -> `Opening`
 - `MenuBase`
-    - `MenuClosed` -> `Closed`
-    - `MenuOpened` -> `Opened`
+  - `MenuClosed` -> `Closed`
+  - `MenuOpened` -> `Opened`
 
 `RoutedEventArgs.Source` has changed from type `IInteractive` to type `object`: cast to a concrete type such as `Control` to use it.
 
@@ -293,7 +297,7 @@ See [#11407](https://github.com/AvaloniaUI/Avalonia/pull/11407) for more informa
 
 `IVisual` was used in 0.10.x to expose the visual parent and visual children of a control. Because `IVisual` is no longer available, these are now exposed as extension methods in the `Avalonia.VisualTree` namespace:
 
-```
+```csharp
 using Avalonia.VisualTree;
 
 var visualParent = control.GetVisualParent();
@@ -311,6 +315,7 @@ See [#10299](https://github.com/AvaloniaUI/Avalonia/pull/10299) for more informa
 ## Locator
 
 The `AvaloniaLocator` is no longer available. Most services that were available via the locator now have alternative methods of access:
+
 1. `AssetLoader` is a static class now with all of the old methods.
 2. `IPlatformSettings` was moved to `TopLevel.PlatformSettings` and `Application.PlatformSettings`. Note, it's always preferred to use settings of the specific top level (window) rather than global ones.
 3. `IClipboard` was moved to the `TopLevel.Clipboard`. Note, that `Application.Clipboard` was removed as well.
@@ -327,3 +332,4 @@ Some applications were using the `AvaloniaLocator` as a general-purpose service 
 - `IRenderRoot.RenderScaling` has been moved to `TopLevel.RenderScaling`
 - `LightweightObservableBase` and `SingleSubscriberObservableBase` have been made internal. These were utility classes designed for a specific purpose in Avalonia and were not intended to be used by clients as they do not handle certain edge cases. Use the mechanisms provided by `System.Reactive` to create observables, such as `Observable.Create`
 - When binding to methods, the method must either have no parameters or a single object parameter.
+- `OpenFileDialog` and `SaveFileDialog` have been removed. For file system storage service use `IStorageProvider` on the Top Level.


### PR DESCRIPTION
* Fix markdown warnings 
* Add note about `SuggestedStartLocation`
* Add to migration guide info about file dialogs
* Fix typos
* Fix in `ColorPaletteResources` `AccentColor` to `Accent`