### PR TITLE
Correct Command name in how-to-create-attached-properties.md code sample

### DIFF
--- a/docs/guides/custom-controls/how-to-create-attached-properties.md
+++ b/docs/guides/custom-controls/how-to-create-attached-properties.md
@@ -155,7 +155,7 @@ public class TestViewModel : ReactiveObject
 
     public TestViewModel()
     {
-        EditCommand = ReactiveCommand.CreateFromTask<object, Unit>(EditProfileExecuted);
+        EditCommand = ReactiveCommand.CreateFromTask<object, Unit>(EditCommandExecuted);
     }
 
     private async Task<Unit> EditCommandExecuted(object p)


### PR DESCRIPTION
The command name in the code example was incorrect, corrected.