### PR TITLE
Update XAML comparison with x:True & x:False

### DIFF
--- a/docs/get-started/wpf/comparison-of-avalonia-with-wpf-and-uwp.md
+++ b/docs/get-started/wpf/comparison-of-avalonia-with-wpf-and-uwp.md
@@ -25,6 +25,8 @@ Legend:
 | x:Array                |     ✖    |  ✔  |  ✖  | x:Array isn't supported in UWP.                                                                                                                                                                                                                     |
 | x:Static               |     ✔    |  ✔  |  ⚡  | x:Static could be replaced with x:Bind                                                                                                                                                                                                              |
 | x:Type                 |     ✔    |  ✔  |  ✖  |                                                                                                                                                                                                                                                     |
+| x:True                 |     ✔    |  ✖  |  ✖  |                                               |
+| x:False                |     ✔    |  ✖  |  ✖  |                                               |
 | Full Markup Extension  |     ✔    |  ✔  |  ✖  | UWP only implements a subset of the full markup extension support in WPF. This area needs to be expanded upon in the future.                                                                                                                        |
 | Compiled Bindings      |     ✔    |  ✖  |  ✖  |                                                                                                                                                                                                                                                     |
 


### PR DESCRIPTION
This PR adds the `x:True` and `x:False` markup extensions to the XAML comparison table. They probably should be added elsewhere as well. See #139 