### PR TITLE
Update splitview.md, fixed broken splitview link

### DIFF
--- a/versioned_docs/version-0.10.x/controls/splitview.md
+++ b/versioned_docs/version-0.10.x/controls/splitview.md
@@ -53,4 +53,4 @@ A split view's content area is always visible. The pane can expand and collapse 
 
 ## Source code
 
-[SplitView.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/SplitView.cs)
+[SplitView.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/SplitView/SplitView.cs)


### PR DESCRIPTION
Fixed SplitView.cs source code link, which was broken (pointing "../Avalonia.Controls/SplitView.cs" instead of "../Avalonia.Controls/SplitView/SplitView.cs")