### PR TITLE
Fix 'Test Drive' section

### DIFF
--- a/docs/get-started/test-drive/index.md
+++ b/docs/get-started/test-drive/index.md
@@ -1,0 +1,8 @@
+# Test Drive
+
+```mdx-code-block
+import {DocsCardList} from '../../../src/components/DocsCard';
+import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
+
+<DocsCardList list={useCurrentSidebarCategory().items} />
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -16,9 +16,13 @@ const sidebars = {
         'get-started/install',
         'get-started/set-up-an-editor',
         {
-          type: 'category',
-          label: 'Test Drive',
-          items: [
+          'type': 'category',
+          'label': 'Test Drive',
+          'link' : {
+            'type' : 'doc',
+            'id': 'get-started/test-drive/index'
+          },
+          'items': [
             'get-started/test-drive/introduction',
             'get-started/test-drive/create-a-project',
             'get-started/test-drive/main-window',


### PR DESCRIPTION
Hi, 
I noticed that at "Get Started" page shown below, "Test Drive" card is not clickable:

![Screenshot_20231018_175516-1](https://github.com/AvaloniaUI/avalonia-docs/assets/10996250/4b57948d-c990-45d0-b3bc-bd0dded8aab4)

This PR has a fix.