### PR TITLE
Removed Header from TimePicker Documentation

### DIFF
--- a/docs/reference/controls/detailed-reference/timepicker.md
+++ b/docs/reference/controls/detailed-reference/timepicker.md
@@ -12,7 +12,7 @@ The time picker has two or three 'spinner' controls to allow the user to pick a 
 
 You will probably use these properties most often:
 
-<table><thead><tr><th width="231">Property</th><th>Description</th></tr></thead><tbody><tr><td><code>Header</code></td><td>Displays a title above the date picker.</td></tr><tr><td><code>ClockIdentifier</code></td><td>Choose between 12 and 24 hour formats. The 12 hour format shows a third spinner for AM/PM.</td></tr><tr><td><code>MinuteIncrement</code></td><td>Defines selectable increments for the minutes. The default is 1 (all minutes can be selected).</td></tr><tr><td><code>SelectedTime</code></td><td>(Nullable TimeSpan) the selected time.</td></tr></tbody></table>
+<table><thead><tr><th width="231">Property</th><th>Description</th></tr></thead><tbody><tr><td><code>ClockIdentifier</code></td><td>Choose between 12 and 24 hour formats. The 12 hour format shows a third spinner for AM/PM.</td></tr><tr><td><code>MinuteIncrement</code></td><td>Defines selectable increments for the minutes. The default is 1 (all minutes can be selected).</td></tr><tr><td><code>SelectedTime</code></td><td>(Nullable TimeSpan) the selected time.</td></tr></tbody></table>
 
 ## Example
 
@@ -20,6 +20,7 @@ This example shows how to create a time picker for the 24 hour clock, with 20 mi
 
 ```xml
 <StackPanel Margin="20">
+  <Label Content="Please choose your time:"/>
   <TimePicker Header="Please choose your time:" 
               ClockIdentifier="24HourClock"              
               MinuteIncrement="20"/>

--- a/docs/reference/controls/detailed-reference/timepicker.md
+++ b/docs/reference/controls/detailed-reference/timepicker.md
@@ -19,10 +19,9 @@ You will probably use these properties most often:
 This example shows how to create a time picker for the 24 hour clock, with 20 minute time slots:
 
 ```xml
-<StackPanel Margin="20">
+<StackPanel Margin="20" Spacing="4">
   <Label Content="Please choose your time:"/>
-  <TimePicker Header="Please choose your time:" 
-              ClockIdentifier="24HourClock"              
+  <TimePicker ClockIdentifier="24HourClock"              
               MinuteIncrement="20"/>
 </StackPanel>
 ```


### PR DESCRIPTION
TimePicker does not have Header attribute anymore.
Therefore I propose to remove Header from documentation.