### PR TITLE
Revert "Switch from HTML to markdown table syntax"

### DIFF
--- a/docs/reference/controls/colorpicker/README.md
+++ b/docs/reference/controls/colorpicker/README.md
@@ -80,11 +80,45 @@ Main improvements learning from WinUI were:
 
 Several pre-defined color palettes implementing the `IColorPalette` interface are provided. Instances of these palettes may be set to the `Palette` property of a `ColorView` or `ColorPicker`.
 
-| Palette | Description |
-|---------|-------------|
-| <img src={ColorPaletteFluent} alt="Fluent Color Palette" width="300" /> | Contains the Fluent color palette found in Windows 10 and later. This is the default color palette. |
-| <img src="{ColorPaletteFlat}" alt="Flat UI Color Palette" width="300" /> | Contains the full [Flat UI color palette](https://github.com/designmodo/Flat-UI). |
-| <img src="{ColorPaletteFlatHalf}" alt="Flat UI Half Color Palette" width="300" /> | Contains half of [Flat UI color palette](https://github.com/designmodo/Flat-UI) for improved usability especially on mobile devices. |
-| <img src="{ColorPaletteMaterial}" alt="Material Color Palette" width="300" /> | Contains most of the [Material design color palette](https://material.io/design/color/the-color-system.html#tools-for-picking-colors). In order to make the palette uniform and rectangular the following alterations were made 1. The A100-A700 shades of each color are excluded. These shades do not exist for all colors (Brown/Gray). 2. Black/White are stand-alone colors and are also excluded. |
-| <img src="{ColorPaletteMaterialHalf}" alt="Material Half Color Palette" width="300" /> | Contains half of the [Material design color palette](https://material.io/design/color/the-color-system.html#tools-for-picking-colors) shown above for improved usability especially on mobile devices. |
-| <img src="{ColorPaletteSixteen}" alt="Sixteen Color Palette" width="300" /> | Contains the standard [sixteen color palette](https://en.wikipedia.org/wiki/Web_colors#HTML_color_names) from the HTML 4.01 specification. |
+<table>
+  <tr>
+    <th>Palette</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>
+      <img src={ColorPaletteFluent} alt="Fluent Color Palette" width="300" />
+    </td>
+    <td>Contains the Fluent color palette found in Windows 10 and later. This is the default color palette.</td>
+  </tr>
+  <tr>
+    <td>
+      <img src="{ColorPaletteFlat}" alt="Flat UI Color Palette" width="300" />
+    </td>
+    <td>Contains the full <a href="https://github.com/designmodo/Flat-UI">Flat UI color palette</a>.</td>
+  </tr>
+  <tr>
+    <td>
+      <img src="{ColorPaletteFlatHalf}" alt="Flat UI Half Color Palette" width="300" />
+    </td>
+    <td>Contains half of <a href="https://github.com/designmodo/Flat-UI">Flat UI color palette</a> for improved usability especially on mobile devices.</td>
+  </tr>
+  <tr>
+    <td>
+      <img src="{ColorPaletteMaterial}" alt="Material Color Palette" width="300" />
+    </td>
+    <td>Contains most of the <a href="https://material.io/design/color/the-color-system.html#tools-for-picking-colors">Material design color palette</a>. In order to make the palette uniform and rectangular the following alterations were made 1. The A100-A700 shades of each color are excluded. These shades do not exist for all colors (Brown/Gray). 2. Black/White are stand-alone colors and are also excluded.</td>
+  </tr>
+  <tr>
+    <td>
+      <img src="{ColorPaletteMaterialHalf}" alt="Material Half Color Palette" width="300" />
+    </td>
+    <td>Contains half of the <a href="https://material.io/design/color/the-color-system.html#tools-for-picking-colors">Material design color palette</a> shown above for improved usability especially on mobile devices.</td>
+  </tr>
+  <tr>
+    <td>
+      <img src="{ColorPaletteSixteen}" alt="Sixteen Color Palette" width="300" />
+    </td>
+    <td>Contains the standard <a href="https://en.wikipedia.org/wiki/Web_colors#HTML_color_names">sixteen color palette</a> from the HTML 4.01 specification.</td>
+  </tr>
+</table>


### PR DESCRIPTION
Follow-up to:
 * https://github.com/AvaloniaUI/avalonia-docs/pull/230

This reverts commit ed3c5407f47fa0dee070a912702e507cffebe40e.

As discussed here: https://github.com/AvaloniaUI/avalonia-docs/pull/230#discussion_r1382671308, Markdown doesn't seem to like images in a table. This reverts back to HTML in an attempt to fix this:

![image](https://github.com/AvaloniaUI/avalonia-docs/assets/17993847/e6910d34-9758-4649-a178-85977326b7f4)
