### PR TITLE
Fix dead link to point to the application life time page on the docs instead of github

### DIFF
--- a/docs/concepts/reactiveui/data-persistence.md
+++ b/docs/concepts/reactiveui/data-persistence.md
@@ -105,7 +105,7 @@ public class NewtonsoftJsonSuspensionDriver : ISuspensionDriver
 
 ### Wiring The Things Together
 
-On the final step, we initialize the `AutoSuspendHelper`, following the [new Avalonia lifetimes pattern](https://github.com/AvaloniaUI/Avalonia/wiki/Application-lifetimes). In the `App.xaml.cs` file we create an override for the `OnFrameworkInitializationCompleted` method and initialize the variables required for the suspension feature to work fine.
+On the final step, we initialize the `AutoSuspendHelper`, following the [new Avalonia lifetimes pattern](https://docs.avaloniaui.net/docs/concepts/application-lifetimes). In the `App.xaml.cs` file we create an override for the `OnFrameworkInitializationCompleted` method and initialize the variables required for the suspension feature to work fine.
 
 ```csharp
 public class App : Application


### PR DESCRIPTION
Fixes an issue pointed out in https://github.com/AvaloniaUI/Avalonia/issues/14028 with the docs.

I am not clear if this is where the link should lead to or not, but at least it's better than the link going nowhere. The page title certainly matches what the github link had.