### PR TITLE
Add documentation for Selectable Text Block

### DIFF
--- a/docs/basics/user-interface/controls/builtin-controls.md
+++ b/docs/basics/user-interface/controls/builtin-controls.md
@@ -52,6 +52,7 @@ These controls display repeating data, in either a tabular or list format:
 |[Auto Complete Box](../../../reference/controls/autocompletebox.md)|A control that shows a text box for user input and a drop-down that contains possible matches based on what has been typed.|
 |[Text Block](../../../reference/controls/detailed-reference/textblock.md)|A control that displays a block of text. Read-only.|
 |[Text Box](../../../reference/controls/detailed-reference/textbox.md)|Used to display or edit text without formatting restrictions.|
+|[Selectable Text Box](../../../reference/controls/detailed-reference/selectabletextbox.md)|Used to display or edit text without formatting restrictions. Allows selecting and copying.|
 |[Masked Text Box](../../../reference/controls/maskedtextbox.md)|Used to display text in the format contained in a mask; or used to edit text using the format mask to prevent invalid user input.|
 
 ## Value selection

--- a/docs/reference/controls/detailed-reference/SelectableTextBlock.md
+++ b/docs/reference/controls/detailed-reference/SelectableTextBlock.md
@@ -1,0 +1,54 @@
+---
+description: REFERENCE - Built-in Controls
+---
+
+import TextBlockStylePreviewScreenshot from '/img/gitbook-import/assets/image (2) (5).png';
+
+# Selectable Text Block
+
+The selectable text block is a label for the display of text that allows selecting and copying of text. It can display multiple lines, and features full control over the font used.
+
+## Useful Properties
+
+You will probably use these properties most often:
+
+| Property        | Description                                                                                                                                                                                                           |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SelectionStart  | a character index for the start of the current selection.                                                                                                                                                             |
+| SelectionEnd    | a character index for the end of the current selection.                                                                                                                                                               |
+| SelectionBrush  | The brush that highlights selected text.                                                                                                                                                                              |
+| SelectionForeground | Brush that is used for the foreground of selected text.                                                                                                                                                           |
+| FontSize        | The size of the font.                                                                                                                                                                                                 |
+| FontWeight      | The weight of the font. Default is normal, options include `Bold`.                                                                                                                                                    |
+| FontStyle       | A style to apply to the lettering. Default is normal, options include `Italic`.                                                                                                                                       |
+| TextDecorations | A line decoration to apply to the lettering. Default is none, options include `Underline`, `Strikethrough`, `Baseline` and `Overline`. To apply more than one at the same time, list the options with spaces between. |
+| xml:space       | TextBlock itself would respect the line breaks and whitespace of its content as set out in XAML, but it will be filtered out by the parser without `xml:space="preserve"`.                                            |
+
+## Example
+
+This example shows a text block used as a heading, single line and multi-line displays.
+
+```xml
+  <StackPanel Margin="20">
+  <SelectableTextBlock Margin="0 5" FontSize="18" FontWeight="Bold" >Heading</SelectableTextBlock>
+  <SelectableTextBlock Margin="0 5" FontStyle="Italic" xml:space="preserve" SelectionBrush="Red">This is a single line.</SelectableTextBlock>
+  <SelectableTextBlock Margin="0 5" xml:space="preserve" SelectionStart="3" SelectionEnd="13">This is a multi-line display
+    that has returns in it.
+    The text block repects the line breaks
+    as set out in XAML.</SelectableTextBlock>
+</StackPanel>
+```
+
+The styling works in the preview pane:
+
+<img src={TextBlockStylePreviewScreenshot} alt="" />
+
+## More Information
+
+:::info
+For the complete API documentation about this control, see [here](http://reference.avaloniaui.net/api/Avalonia.Controls/SelectableTextBlock/).
+:::
+
+:::info
+View the source code on GitHub [`SelectableTextBlock.cs`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/SelectableTextBlock.cs)
+:::


### PR DESCRIPTION
What does the pull request do?
Adds documentation for Selectable Text Block

There is an issue that I do not know how to address. In the info section linking to the api docs, there is no doc for SelectableTextBlock in the api docs.

For the complete API documentation about this control, see [here](http://reference.avaloniaui.net/api/Avalonia.Controls/SelectableTextBlock/).

What is the current behavior?
N/A

Breaking changes
None

Fixed issues
https://github.com/AvaloniaUI/avalonia-docs/issues/157
https://github.com/AvaloniaUI/avalonia-docs/issues/154
https://github.com/AvaloniaUI/Avalonia/issues/7995