### PR TITLE
Update displaying-images.md

### DIFF
--- a/docs/tutorials/music-store-app/displaying-images.md
+++ b/docs/tutorials/music-store-app/displaying-images.md
@@ -201,7 +201,7 @@ Follow this procedure:
 - Add this data binding and converter to the panel element below:
 
 ```
-IsVisible="{Binding Cover, Converter={x:Static ObjectConverters.IsNotNull}}"
+IsVisible="{Binding Cover, Converter={x:Static ObjectConverters.IsNull}}"
 ```
 
 A converter is an extension of a data binding expression that can convert the binding value before it is passed to the bound control. The `IsNull` converter returns a Boolean that is true when the value object is null.


### PR DESCRIPTION
We want the filler image to show up when the Cover is null. But, the sample code makes it show up when it's not null because we it is calling ObjectConverters.IsNotNull instead of calling ObjectConverters.IsNull.