### PR TITLE
Fix spelling/grammar mistakes in avalonia-ui-and-mvvm.md

### DIFF
--- a/docs/concepts/the-mvvm-pattern/avalonia-ui-and-mvvm.md
+++ b/docs/concepts/the-mvvm-pattern/avalonia-ui-and-mvvm.md
@@ -6,11 +6,11 @@ import MvvmDataBindingDiagram from '/img/gitbook-import/assets/mvvm.png';
 
 # Avalonia UI and MVVM
 
-On this page you will lean how the MVVM pattern is realised when you use it with _Avalonia UI_.
+On this page you will learn how the MVVM pattern is realised when used with _Avalonia UI_.
 
 ## Views and View Models
 
-When you use the MVVM pattern with _Avalonia UI_, you implement a view with an AXAML file that has a code-behind file attached, and a view model with a plain-old code class file. 
+When you use the MVVM pattern with _Avalonia UI_, you implement a view with an AXAML file, attached to a corresponding code-behind file, and a view model with a plain-old code class file. 
 
 In _Avalonia UI_, a view is implemented as a composition of UI elements in a window or a user control (both AXAML files with code-behind). The UI elements in a composition can be a mixture of _Avalonia UI_ built-in controls, user controls and (more advanced) controls of your own design and implementation.
 
@@ -32,7 +32,7 @@ Data binding is the key technology that allows an _Avalonia UI_ MVVM application
 
 <img src={MvvmDataBindingDiagram} alt=""/>
 
-Notice how some of the data bindings are represented by a two way arrow, and others by a single-headed arrow. For example, the name and address inputs are two ways - you want both changes in the view model to be notified to the view, and for inputs to the view to be updated on the view model.
+Notice how some of the data bindings are represented by a two way arrow and others by a single-headed arrow. For example, the name and address inputs are two ways - you want both changes in the view model to be notified to the view, and for inputs to the view to be updated on the view model.
 
 The buttons however have one-direction commands, issued by the view and acted out by the view model. 
 
@@ -42,7 +42,7 @@ When you use the MVVM pattern in practice, you will use a corresponding view mod
 
 ## The MVVM Model
 
-The model is the other part of the MVVM pattern. Models are much less precisely defined in the pattern as they represent 'the rest of the architecture'. This is often data storage, or other services.
+The model is the other part of the MVVM pattern. Models are much less precisely defined in the pattern as they represent 'the rest of the architecture'. This is often data storage or other services.
 
 The important principle for you to maintain is separation. You should implement the relationship between view model and model using some form of the Dependency Injection (DI) pattern.
 
@@ -50,4 +50,4 @@ The important principle for you to maintain is separation. You should implement 
 
 There are a number of frameworks designed to help write applications using the MVVM pattern.
 
-In the pages following, you will lean about the _ReactiveUI_ framework which is one of the most popular and is supported by one of the _Avalonia UI_ packages.
+In the following pages, you will learn about the _ReactiveUI_ framework which is one of the most popular and is supported by one of the _Avalonia UI_ packages.


### PR DESCRIPTION
- The 2 important changes are fixing both instances of "learn" being misspelled as "lean".
- The other changes are just minor improvements to grammar:
   - Improve flow/wording
   - Remove unnecessary commas