### PR TITLE
fix: Example Style for DataValidationErrors

### DIFF
--- a/docs/guides/development-guides/data-validation.md
+++ b/docs/guides/development-guides/data-validation.md
@@ -97,7 +97,7 @@ To display the validation messages, Avalonia has a control called [`DataValidati
                           Padding="{TemplateBinding Padding}"/>
       </DockPanel>
     </ControlTemplate>
-  </Setter>   
+  </Setter>
   <Setter Property="ErrorTemplate">
     <DataTemplate x:DataType="{x:Type x:Object}">
       <Canvas Width="14" Height="14" Margin="4 0 1 0" 

--- a/docs/guides/development-guides/data-validation.md
+++ b/docs/guides/development-guides/data-validation.md
@@ -97,9 +97,9 @@ To display the validation messages, Avalonia has a control called [`DataValidati
                           Padding="{TemplateBinding Padding}"/>
       </DockPanel>
     </ControlTemplate>
-  </Setter>
+  </Setter>   
   <Setter Property="ErrorTemplate">
-    <DataTemplate>
+    <DataTemplate x:DataType="{x:Type x:Object}">
       <Canvas Width="14" Height="14" Margin="4 0 1 0" 
               Background="Transparent">
         <Canvas.Styles>


### PR DESCRIPTION
When CompiledBinding is enabled XamlC throws `Unable to infer DataContext type for compiled bindings nested within this element.`

To avoid adding `x:DataType="{x:Type x:Object}"` to DataTemplate