### PR TITLE
Update docusaurus.config.js config to show version as 11.0.x

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -100,7 +100,7 @@ const config = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: "11.0.0",
+              label: "11.0.x",
               banner: "none"
             },
             "0.10.x": {


### PR DESCRIPTION
This will align with the previous version naming of 0.10.x and will help reduce confusion to new users.