### PR TITLE
Introduce MinVersion tag

### DIFF
--- a/src/components/MinVersion.js
+++ b/src/components/MinVersion.js
@@ -1,0 +1,37 @@
+﻿import React from 'react';
+
+const newVersion = '11.0';
+const previewVersion = '11.1';
+export default function MinVersion({version}) {
+    let backgroundColor;
+    let description;
+    
+    if (version === newVersion) {
+        backgroundColor = '#ff8d8d';
+        description = ' New!';
+    } else if (version === previewVersion) {
+        backgroundColor = '#d03737';
+        description = ' Preview!';
+    } else {
+        backgroundColor = '#ebedf0';
+        description = '';
+    }
+    
+    return (
+        <span
+            style={{
+                border: '1px solid #fff',
+                display: 'inline-flex',
+                padding: '4px 12px',
+                backgroundColor,
+                borderRadius: '16px',
+                fontSize: '14px',
+                color: '#111',
+                margin: '0 1em 0 1em',
+                verticalAlign: 'middle'
+            }}>
+            v{version}{description}
+        </span>
+    );
+}
+

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -5,6 +5,7 @@ import Highlight from '@site/src/components/Highlight';
 import { CardSection, Card } from '../components/CardComponents'; 
 import HelpNeeded from '../components/HelpNeeded'; 
 import GitHubSampleLink from '../components/GitHubSampleLink';
+import MinVersion from '../components/MinVersion';
 import XpfAd from '../components/XpfAdvert';
 
 export default {
@@ -17,5 +18,6 @@ export default {
   GitHubSampleLink,
   Card,
   HelpNeeded,
+  MinVersion,
   XpfAd,
 };


### PR DESCRIPTION
Will need some future work if this is ever used within a text body instead of only headings. Anybody looking to tighten up the appearance can lookup "Chip" design for reference. Better version management could be done, too. Maybe "Nightly" is a better term than "Preview !".

```md
## Overview <MinVersion version="0.10.18" />
## Overview <MinVersion version="11.0" />
## Overview <MinVersion version="11.1" />
```

![image](https://github.com/AvaloniaUI/avalonia-docs/assets/1782158/a393893e-46a3-4859-b7d7-c3103fb1bc24)

Closes #379 