### PR TITLE
Bind to a Control with casting of parents DataContext

### DIFF
--- a/docs/guides/data-binding/binding-to-controls.md
+++ b/docs/guides/data-binding/binding-to-controls.md
@@ -86,7 +86,7 @@ If you need to include a XAML namespace in the ancestor type, you separate the n
 </local:MyControl>
 ```
 
-To access a property of a parents `DataContext` it will be necessary to cast it with a casting expression `(vm:MyUserControlViewModel)DataContext` to it's actual type. Otherwise `DataContext` would be considered as of type `object` and accessing a custom property would result in an compile time error.
+To access a property of a parent's `DataContext` it will be necessary to cast it with a casting expression `(vm:MyUserControlViewModel)DataContext` to its actual type. Otherwise `DataContext` would be considered as of type `object` and accessing a custom property would result in an compile-time error.
 
 ```markup
 <local:MyControl Tag="Hello World!">

--- a/docs/guides/data-binding/binding-to-controls.md
+++ b/docs/guides/data-binding/binding-to-controls.md
@@ -86,6 +86,16 @@ If you need to include a XAML namespace in the ancestor type, you separate the n
 </local:MyControl>
 ```
 
+To access a property of a parents `DataContext` it will be necessary to cast it with a casting expression `(vm:MyUserControlViewModel)DataContext` to it's actual type. Otherwise `DataContext` would be considered as of type `object` and accessing a custom property would result in an compile time error.
+
+```markup
+<local:MyControl Tag="Hello World!">
+  <Decorator>
+    <TextBlock Text="{Binding $parent[local:MyControl].((vm:MyUserControlViewModel)DataContext).CustomProperty}"/>
+  </Decorator>
+</local:MyControl>
+```
+
 :::warning
 _Avalonia UI_ also supports WPF/UWP's `RelativeSource` syntax which does something similar, but is _not_ the same. `RelativeSource` works on the _visual_ tree whereas the syntax given here works on the _logical_ tree.
 :::

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/binding-to-controls.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/binding-to-controls.md
@@ -86,7 +86,7 @@ If you need to include a XAML namespace in the ancestor type, you separate the n
 </local:MyControl>
 ```
 
-To access a property of a parents `DataContext` it will be necessary to cast it with a casting expression `(vm:MyUserControlViewModel)DataContext` to it's actual type. Otherwise `DataContext` would be considered as of type `object` and accessing a custom property would result in an compile time error.
+'To access a property of a parent's `DataContext` it will be necessary to cast it with a casting expression `(vm:MyUserControlViewModel)DataContext` to its actual type. Otherwise `DataContext` would be considered as of type `object` and accessing a custom property would result in an compile-time error.
 
 ```markup
 <local:MyControl Tag="Hello World!">

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/binding-to-controls.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/binding-to-controls.md
@@ -86,6 +86,16 @@ If you need to include a XAML namespace in the ancestor type, you separate the n
 </local:MyControl>
 ```
 
+To access a property of a parents `DataContext` it will be necessary to cast it with a casting expression `(vm:MyUserControlViewModel)DataContext` to it's actual type. Otherwise `DataContext` would be considered as of type `object` and accessing a custom property would result in an compile time error.
+
+```markup
+<local:MyControl Tag="Hello World!">
+  <Decorator>
+    <TextBlock Text="{Binding $parent[local:MyControl].((vm:MyUserControlViewModel)DataContext).CustomProperty}"/>
+  </Decorator>
+</local:MyControl>
+```
+
 :::warning
 _Avalonia UI_ also supports WPF/UWP's `RelativeSource` syntax which does something similar, but is _not_ the same. `RelativeSource` works on the _visual_ tree whereas the syntax given here works on the _logical_ tree.
 :::


### PR DESCRIPTION
Adds explanation how to cast the DataContext of a parents Control to access custom properties.