### PR TITLE
Add FallBackValues to Binding page

### DIFF
--- a/docs/basics/data/data-binding/data-binding-syntax.md
+++ b/docs/basics/data/data-binding/data-binding-syntax.md
@@ -138,7 +138,7 @@ An example of a custom converter can bind an image file. For guidance on how to 
 You may optionally define fallback values in the XAML in case the binding fails.
 
 ```xml
-<TextBlock Text="{Binding Name, FallBackValue=Bob}"/>
+<TextBlock Text="{Binding Name, FallbackValue=Bob}"/>
 ```
 
 


### PR DESCRIPTION
I don't really know how this works for non string content, so someone may want to add on.

Also not entirely sure if this should go on this page or somewhere under How to guides > Data Binding > ...

Currently there's a note mentioning in passing under one of those pages, which is insufficient and I was unable to find it without help from the community on telegram. I think this is valuable enough to warrant a proper section.