### PR TITLE
Remove text related to 0.9.x that's no longer relevant

### DIFF
--- a/docs/basics/user-interface/introduction-to-xaml.md
+++ b/docs/basics/user-interface/introduction-to-xaml.md
@@ -17,10 +17,6 @@ These pages will introduce you to how XAML is used specifically in _Avalonia UI_
 
 The file extension for XAML files used elsewhere is `.xaml` but due to technical issues integrating with Visual Studio, _Avalonia UI_ uses its own `.axaml` extension - 'Avalonia XAML'.
 
-:::info
-From _Avalonia UI_ version 0.9.11 all XAML files created in Visual Studio have the `.axaml` extension; and from version 0.10 all _Avalonia UI_ templates create files using the `.axaml` extension.
-:::
-
 ## File Format
 
 A typical Avalonia XAML file looks like this:

--- a/docs/concepts/input/routed-events.md
+++ b/docs/concepts/input/routed-events.md
@@ -75,8 +75,6 @@ To add a handler for an event using XAML, you declare the event name as an attri
 
 The XAML syntax for adding standard CLR event handlers is the same for adding routed event handlers, because you are really adding handlers to the CLR event wrapper, which has a routed event implementation underneath.
 
-As of Avalonia 0.9.x the Avalonia designer requires event handlers to be declared as `public` methods. We hope to remove this restriction in future.
-
 ## Routing Strategies
 
 Routed events use one of three routing strategies:

--- a/i18n/ru/docusaurus-plugin-content-docs/current/basics/user-interface/introduction-to-xaml.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/basics/user-interface/introduction-to-xaml.md
@@ -17,10 +17,6 @@ These pages will introduce you to how XAML is used specifically in _Avalonia UI_
 
 The file extension for XAML files used elsewhere is `.xaml` but due to technical issues integrating with Visual Studio, _Avalonia UI_ uses its own `.axaml` extension - 'Avalonia XAML'.
 
-:::info
-From _Avalonia UI_ version 0.9.11 all XAML files created in Visual Studio have the `.axaml` extension; and from version 0.10 all _Avalonia UI_ templates create files using the `.axaml` extension.
-:::
-
 ## File Format
 
 A typical Avalonia XAML file looks like this:

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/input/routed-events.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/input/routed-events.md
@@ -75,8 +75,6 @@ To add a handler for an event using XAML, you declare the event name as an attri
 
 The XAML syntax for adding standard CLR event handlers is the same for adding routed event handlers, because you are really adding handlers to the CLR event wrapper, which has a routed event implementation underneath.
 
-As of Avalonia 0.9.x the Avalonia designer requires event handlers to be declared as `public` methods. We hope to remove this restriction in future.
-
 ## Routing Strategies
 
 Routed events use one of three routing strategies:

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/input/routed-events.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/input/routed-events.md
@@ -74,7 +74,6 @@ public class SampleControl: Control
 
 添加标准CLR事件处理程序的XAML语法与添加路由事件处理程序的语法相同，因为您实际上是将处理程序添加到具有路由事件实现的CLR事件包装器上。
 
-从Avalonia 0.9.x开始，Avalonia设计器要求事件处理程序被声明为`public`方法。我们希望在将来能够取消这个限制。
 ## 路由策略
 
 路由事件使用以下三种路由策略：


### PR DESCRIPTION
Removes from localized versions, too, where possible. Doesn't touch any of the 0.10.x docs.

Closes #358 