### PR TITLE
Migrate ```markup blocks to ```xml

### DIFF
--- a/docs/basics/data/data-binding/compiled-bindings.md
+++ b/docs/basics/data/data-binding/compiled-bindings.md
@@ -21,7 +21,7 @@ Depending on the template that was used to create the Avalonia project, compiled
 
 If you want your application to use compiled bindings globally by default, you can add
 
-```markup
+```xml
 <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 ```
 
@@ -33,7 +33,7 @@ To enable compiled bindings, you will need to define the `DataType` of the objec
 
 You can now enable or disable compiled bindings by setting `x:CompileBindings="[True|False]"`. All child nodes will inherit this property, so you can enable it in your root node and disable it for a specific child, if needed.
 
-```markup
+```xml
 <!-- Set DataType and enable compiled bindings -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -59,7 +59,7 @@ You can now enable or disable compiled bindings by setting `x:CompileBindings="[
 
 If you don't want to enable compiled bindings for all child nodes, you can also use the `CompiledBinding`-markup. You still need to define the `DataType`, but you can omit `x:CompileBindings="True"`.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -85,7 +85,7 @@ If you don't want to enable compiled bindings for all child nodes, you can also 
 
 If you have compiled bindings enabled in the root node (via `x:CompileBindings="True"`) and you either don't want to use compiled binding at a certain position or you hit one of the [known limitations](#known-limitations), you can use the `ReflectionBinding`-markup.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -111,7 +111,7 @@ If you have compiled bindings enabled in the root node (via `x:CompileBindings="
 
 In some cases the target type of the binding expression cannot be automatically evaluated. In such cases you must provide an explicit type cast in the binding expression.
 
-```markup
+```xml
 <ItemsRepeater ItemsSource="{Binding MyItems}">
 <ItemsRepeater.ItemTemplate>
     <DataTemplate>

--- a/docs/basics/user-interface/building-layouts/alignment-margins-and-padding.md
+++ b/docs/basics/user-interface/building-layouts/alignment-margins-and-padding.md
@@ -20,7 +20,7 @@ At first glance, the `Button` elements in this illustration may appear to be pla
 
 The following example describes how to create the layout in the preceding illustration. A `Border` element encapsulates a parent `StackPanel`, with a `Padding` value of 15 device independent pixels. This accounts for the narrow `LightBlue` band that surrounds the child `StackPanel`. Child elements of the `StackPanel` are used to illustrate each of the various positioning properties that are detailed in this topic. Three `Button` elements are used to demonstrate both the `Margin` and `HorizontalAlignment` properties.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication2.MainWindow"
@@ -69,7 +69,7 @@ The `HorizontalAlignment` property declares the horizontal alignment characteris
 
 The following example shows how to apply the `HorizontalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors.
 
-```markup
+```xml
 <Button HorizontalAlignment="Left">Button 1 (Left)</Button>
 <Button HorizontalAlignment="Right">Button 2 (Right)</Button>
 <Button HorizontalAlignment="Center">Button 3 (Center)</Button>
@@ -93,7 +93,7 @@ The `VerticalAlignment` property describes the vertical alignment characteristic
 
 The following example shows how to apply the `VerticalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors. For purposes of this sample, a `Grid` element with visible gridlines is used as the parent, to better illustrate the layout behavior of each property value.
 
-```markup
+```xml
 <Border Background="LightBlue" BorderBrush="Black" BorderThickness="2" Padding="15">
     <Grid Background="White" ShowGridLines="True">
       <Grid.RowDefinitions>
@@ -128,7 +128,7 @@ A non-zero margin applies space outside the element's `Bounds`.
 
 The following example shows how to apply uniform margins around a group of `Button` elements. The `Button` elements are spaced evenly with a ten-pixel margin buffer in each direction.
 
-```markup
+```xml
 <Button Margin="10">Button 7</Button>
 <Button Margin="10">Button 8</Button>
 <Button Margin="10">Button 9</Button>
@@ -136,7 +136,7 @@ The following example shows how to apply uniform margins around a group of `Butt
 
 In many instances, a uniform margin is not appropriate. In these cases, non-uniform spacing can be applied. The following example shows how to apply non-uniform margin spacing to child elements. Margins are described in this order: left, top, right, bottom.
 
-```markup
+```xml
 <Button Margin="0,10,0,10">Button 1</Button>
 <Button Margin="0,10,0,10">Button 2</Button>
 <Button Margin="0,10,0,10">Button 3</Button>
@@ -148,7 +148,7 @@ Padding is similar to `Margin` in most respects. The Padding property is exposed
 
 The following example shows how to apply `Padding` to a parent `Border` element.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"
@@ -162,7 +162,7 @@ The following example shows how to apply `Padding` to a parent `Border` element.
 
 The following example demonstrates each of the concepts that are detailed in this topic. Building on the infrastructure found in the first sample in this topic, this example adds a`Grid` element as a child of the `Border` in the first sample. `Padding` is applied to the parent `Border` element. The`Grid` is used to partition space between three child `StackPanel` elements. `Button` elements are again used to show the various effects of `Margin` and `HorizontalAlignment`. `TextBlock` elements are added to each `ColumnDefinition` to better define the various properties applied to the `Button` elements in each column.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"

--- a/docs/basics/user-interface/introduction-to-xaml.md
+++ b/docs/basics/user-interface/introduction-to-xaml.md
@@ -21,7 +21,7 @@ The file extension for XAML files used elsewhere is `.xaml` but due to technical
 
 A typical Avalonia XAML file looks like this:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -50,7 +50,7 @@ A UI can be composed of several different types of control. To learn more about 
 
 For example, this XAML adds a button to the content of a window:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button>Hello World!</Button>
@@ -67,7 +67,7 @@ The XML elements that represent controls have attributes corresponding to contro
 
 For example, to specify a blue background for a button control, you add the `Background` attribute set the value to `"Blue"`. Like this:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Background="Blue">Hello World!</Button>
@@ -78,7 +78,7 @@ For example, to specify a blue background for a button control, you add the `Bac
 
 You might have noticed that the button in the above sample has its content (the 'Hello World' string) placed between its opening and closing tags. As an alternative, you can set the content attribute, as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="Hello World!"/>
@@ -91,7 +91,7 @@ This behaviour is specific to the content of an _Avalonia UI_ control.
 
 You will often use the _Avalonia UI_ binding system to link a control property to an underlying object. The link is declared using the `{Binding}` mark-up extension. For example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="{Binding Greeting}"/>

--- a/docs/basics/user-interface/styling/style-classes.md
+++ b/docs/basics/user-interface/styling/style-classes.md
@@ -9,7 +9,7 @@ You can assign an _Avalonia UI_ control one or more style classes, and use these
 
 For example, this button has both the `h1` and `blue` style classes applied:
 
-```markup
+```xml
 <Button Classes="h1 blue"/>
 ```
 
@@ -21,7 +21,7 @@ For example `:pointerover` pseudo class indicates that the pointer input is curr
 
 This is an example of  a `:pointerover` pseudo class selector:
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Border:pointerover">
@@ -36,7 +36,7 @@ This is an example of  a `:pointerover` pseudo class selector:
 
 In this example, the pseudo class selector changes properties inside a control template:
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Button:pressed /template/ ContentPresenter">
@@ -57,7 +57,7 @@ For more detail about pseudo classes, see the reference [here](../../../referenc
 
 If you need to add or remove a class using a bound condition, then you can use following special syntax:
 
-```markup
+```xml
 <Button Classes.accent="{Binding IsSpecial}" />
 ```
 

--- a/docs/concepts/input/hotkeys.md
+++ b/docs/concepts/input/hotkeys.md
@@ -6,7 +6,7 @@ description: CONCEPTS - Input
 
 Various Controls that implement `ICommandSource` have a `HotKey` property that you can set or bind to. Pressing the hotkey will execute the command [bound](../../basics/user-interface/adding-interactivity#commands) to the Control.
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem x:Name="SaveMenuItem" Header="_Save" Command="{Binding SaveCommand}" HotKey="Ctrl+S"/>

--- a/docs/concepts/input/routed-events.md
+++ b/docs/concepts/input/routed-events.md
@@ -69,7 +69,7 @@ public class SampleControl: Control
 
 To add a handler for an event using XAML, you declare the event name as an attribute on the element that is an event listener. The value of the attribute is the name of your implemented handler method, which must exist in the class of the code-behind file.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -104,7 +104,7 @@ Each of the above considerations is discussed in a separate section of this topi
 
 To add an event handler in XAML, you simply add the event name to an element as an attribute and set the attribute value as the name of the event handler that implements an appropriate delegate, as in the following example.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -201,7 +201,7 @@ The Avalonia input system uses attached events extensively. However, nearly all 
 
 Another syntax usage that resembles _typename_._eventname_ attached event syntax but is not strictly speaking an attached event usage is when you attach handlers for routed events that are raised by child elements. You attach the handlers to a common parent, to take advantage of event routing, even though the common parent might not have the relevant routed event as a member. Consider this example again:
 
-```markup
+```xml
 <Border Height="50" Width="300">
   <StackPanel Orientation="Horizontal" Button.Click="CommonClickHandler">
     <Button Name="YesButton">Yes</Button>

--- a/docs/concepts/reactiveui/binding-to-sorted-filtered-list.md
+++ b/docs/concepts/reactiveui/binding-to-sorted-filtered-list.md
@@ -43,14 +43,14 @@ public MainWindowViewModel(){
 
 Now that the `_sourceCache` is created and populated and the `ReadOnlyObservableCollection<T>` is created and bound we can go into our view and bind exactly the way we normally would with an `ObservableCollection<T>`
 
-```markup
-    <Design.DataContext>
-        <vm:MainWindowViewModel/>
-    </Design.DataContext>
+```xml
+<Design.DataContext>
+    <vm:MainWindowViewModel/>
+</Design.DataContext>
 
-    <TreeView ItemsSource="{Binding TestViewModels}">
-        <TreeView.DataTemplates>
-            !-- DataTemplate Definitions -->
-        </TreeView.DataTemplates> 
-    </TreeView>
+<TreeView ItemsSource="{Binding TestViewModels}">
+    <TreeView.DataTemplates>
+        !-- DataTemplate Definitions -->
+    </TreeView.DataTemplates> 
+</TreeView>
 ```

--- a/docs/concepts/reactiveui/data-persistence.md
+++ b/docs/concepts/reactiveui/data-persistence.md
@@ -54,7 +54,7 @@ public class MainWindow : ReactiveWindow<MainViewModel>
 
 The XAML of our `ReactiveWindow` will look like as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="ReactiveUI.Samples.Suspension.MainWindow"

--- a/docs/concepts/reactiveui/routing.md
+++ b/docs/concepts/reactiveui/routing.md
@@ -38,7 +38,7 @@ namespace RoutingExample
 
 **FirstView.xaml**
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="RoutingExample.FirstView">
@@ -110,7 +110,7 @@ namespace RoutingExample
 
 Now we need to place the `RoutedViewHost` XAML control to our main view. It will resolve and embed appropriate views for the view models based on the supplied `IViewLocator` implementation and the passed `Router` instance of type `RoutingState`. Note, that you need to import `rxui` namespace for `RoutedViewHost` to work. Additionally, you can override animations that are played when `RoutedViewHost` changes a view — simply override `RoutedViewHost.PageTransition` property in XAML.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:rxui="http://reactiveui.net"
         xmlns:app="clr-namespace:RoutingExample"
@@ -155,7 +155,7 @@ Now we need to place the `RoutedViewHost` XAML control to our main view. It will
 
 To disable the animations, simply set the `RoutedViewHost.PageTransition` property to `{x:Null}`, like so:
 
-```markup
+```xml
 <rxui:RoutedViewHost Grid.Row="0" Router="{Binding Router}" PageTransition="{x:Null}">
     <rxui:RoutedViewHost.DefaultContent>
         <TextBlock Text="Default content"

--- a/docs/concepts/reactiveui/view-activation.md
+++ b/docs/concepts/reactiveui/view-activation.md
@@ -35,7 +35,7 @@ public class ViewModel : ReactiveObject, IActivatableViewModel
 
 This is the UI for the view model you see above.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         Background="#f0f0f0" FontFamily="Ubuntu"

--- a/docs/concepts/templates/content-template.md
+++ b/docs/concepts/templates/content-template.md
@@ -17,7 +17,7 @@ One way to use a data template is to set the `ContentTemplate` property of a con
 
 You can define a data template (for no particular class) using the `DataTemplate` tag, a composition of built-in controls, and some bindings. For example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/docs/concepts/templates/creating-data-templates-in-code.md
+++ b/docs/concepts/templates/creating-data-templates-in-code.md
@@ -18,7 +18,7 @@ var template = new FuncDataTemplate<Student>((value, namescope) =>
 
 Which is equivalent to the XAML:
 
-```markup
+```xml
 <DataTemplate DataType="{x:Type local:Student}">
     <TextBlock Text="{Binding FirstName}"/>
 </DataTemplate>

--- a/docs/concepts/templates/data-templates-collection.md
+++ b/docs/concepts/templates/data-templates-collection.md
@@ -14,7 +14,7 @@ Data templates are matched by type: a match occurs when the class of the object 
 
 So you can modify the previous sample to use the `DataTemplates` collection, as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/docs/concepts/templates/data-templates.md
+++ b/docs/concepts/templates/data-templates.md
@@ -16,7 +16,7 @@ The concept of the zones of an _Avalonia UI_ control is discussed [here](../layo
 
 For example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -34,7 +34,7 @@ The window displays the button - in this case centred both horizontally (specifi
 
 And if you put a string into the window content zone, for example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -67,7 +67,7 @@ namespace MySample
 
 And the XML namespace `local` defined as the `MySample` namespace (from above), you can define a student object in the content zone of the window; as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="using:MySample"

--- a/docs/concepts/templates/implement-idatatemplate.md
+++ b/docs/concepts/templates/implement-idatatemplate.md
@@ -34,9 +34,9 @@ public class MyDataTemplate : IDataTemplate
 
 You can now use the class `MyDataTemplate` in your view, like this:
 
-```markup
-xmlns:dataTemplates="using:MyApp.DataTemplates" -->
-...
+```xml
+<!-- xmlns:dataTemplates="using:MyApp.DataTemplates" -->
+
 <ContentControl Content="{Binding MyContent}">
 	<ContentControl.ContentTemplate>
 		<dataTemplates:MyDataTemplate />

--- a/docs/concepts/templates/reusing-data-templates.md
+++ b/docs/concepts/templates/reusing-data-templates.md
@@ -31,7 +31,7 @@ namespace MySample
 
 And in the app.axaml file, add a data template for the type `Teacher`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:MySample"

--- a/docs/deployment/macOS.md
+++ b/docs/deployment/macOS.md
@@ -94,7 +94,7 @@ More documentation on possible `Info.plist` keys is available [here](https://dev
 
 If at any point the tooling gives you an error that your assets file doesn't have a target for `osx-64`, add the following [runtime identifiers](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) to the top `<PropertyGroup>` in your `.csproj`:
 
-```markup
+```xml
 <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
 ```
 
@@ -114,7 +114,7 @@ The file that is actually executed by macOS when starting your `.app` bundle wil
 
 * Add the following to your `.csproj` file:
 
-```markup
+```xml
 <PropertyGroup>
   <UseAppHost>true</UseAppHost>
 </PropertyGroup>
@@ -134,7 +134,7 @@ It is recommended that you target `net6-macos`, which will handle package genera
 
 You'll first have to add the project as a `PackageReference` in your project. Add it to your project via NuGet package manager or by adding the following line to your `.csproj` file:
 
-```markup
+```xml
 <PackageReference Include="Dotnet.Bundle" Version="*" />
 ```
 
@@ -159,7 +159,7 @@ dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-x64 -p:CFBundleDisplayName=
 
 Instead of specifying `CFBundleDisplayName`, etc., on the command line, you can also specify them in your project file:
 
-```markup
+```xml
 <PropertyGroup>
     <CFBundleName>AppName</CFBundleName> <!-- Also defines .app file name -->
     <CFBundleDisplayName>MyBestThingEver</CFBundleDisplayName>
@@ -520,7 +520,7 @@ When upload succeeds - you will see your package in App Store Connect.
 
 This means that your application most likely does not specify a menu. On startup, Avalonia creates the default menu items for an application and automatically adds the _About Avalonia_ item when no menu has been configured. This can be resolved by adding one to your `App.xaml`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:RoadCaptain.App.RouteBuilder"

--- a/docs/get-started/wpf/datatemplates.md
+++ b/docs/get-started/wpf/datatemplates.md
@@ -10,7 +10,7 @@ Instead, data templates are placed either inside a `DataTemplates` collection in
 
 For example, this code adds a data template to display the view model class `MyViewModel`:
 
-```markup
+```xml
 <UserControl xmlns:viewmodels="using:MyApp.ViewModels"
              x:DataType="viewmodels:ControlViewModel">
     <UserControl.DataTemplates>

--- a/docs/get-started/wpf/grid.md
+++ b/docs/get-started/wpf/grid.md
@@ -2,7 +2,7 @@
 
 Column and row definitions can be specified in Avalonia using strings, avoiding the clunky syntax in WPF:
 
-```markup
+```xml
 <Grid ColumnDefinitions="Auto,*,32" RowDefinitions="*,Auto">
 ```
 

--- a/docs/get-started/wpf/styling.md
+++ b/docs/get-started/wpf/styling.md
@@ -9,7 +9,7 @@ The most obvious difference from other XAML frameworks is in its styling system.
 
 The following code shows a `UserControl` which defines its own CSS-like style.
 
-```markup
+```xml
 <UserControl>
     <UserControl.Styles>
         <!-- Make TextBlocks with the h1 style class have a font size of 24 points -->

--- a/docs/guides/custom-controls/how-to-create-attached-properties.md
+++ b/docs/guides/custom-controls/how-to-create-attached-properties.md
@@ -121,7 +121,7 @@ In the verify method we utilize the routed event system to attach a new handler.
 
 This example UI shows how to use the attached property. After making the namespace known to the XAML compiler it can be used by qualifying it with a dot. Then bindings can be used.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:MyApp.Behaviors"

--- a/docs/guides/custom-controls/how-to-create-templated-controls.md
+++ b/docs/guides/custom-controls/how-to-create-templated-controls.md
@@ -10,7 +10,7 @@ title: How To Create Templated Controls
 
 When you're creating a control template and you want to bind to the templated parent you can use:
 
-```markup
+```xml
 <TextBlock Name="tb" Text="{TemplateBinding Caption}"/>
 
 <!-- Which is the same as -->
@@ -21,7 +21,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
 
 1.  `TemplateBinding` accepts only a single property rather than a property path, so if you want to bind using a property path you must use the second syntax:
 
-    ```markup
+    ```xml
     <!-- This WON'T work as TemplateBinding only accepts single properties -->
     <TextBlock Name="tb" Text="{TemplateBinding Caption.Length}"/>
 
@@ -35,7 +35,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
     ```
 3. `TemplateBinding` can only be used on `IStyledElement`.
 
-```markup
+```xml
 <!-- This WON'T work as GeometryDrawing is not a IStyledElement. -->
 <GeometryDrawing Brush="{TemplateBinding Foreground}"/>
 

--- a/docs/guides/data-binding/binding-to-controls.md
+++ b/docs/guides/data-binding/binding-to-controls.md
@@ -16,7 +16,7 @@ Note that this technique does not use a data context at all. When you do this, y
 
 If you want to bind to a property on another named control, you can use the control name prefixed by a `#` character.
 
-```markup
+```xml
 <TextBox Name="other">
 
 <!-- Binds to the Text property of the "other" control -->
@@ -25,7 +25,7 @@ If you want to bind to a property on another named control, you can use the cont
 
 This is the equivalent to the long-form binding that will be familiar to WPF and UWP users:
 
-```markup
+```xml
 <TextBox Name="other">
 <TextBlock Text="{Binding Text, ElementName=other}"/>
 ```
@@ -36,7 +36,7 @@ _Avalonia UI_ supports both syntaxes.
 
 You can bind to the (logical control tree) parent of the target using the `$parent` syntax:
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <TextBlock Text="{Binding $parent.Tag}"/>
 </Border>
@@ -44,7 +44,7 @@ You can bind to the (logical control tree) parent of the target using the `$pare
 
 Or to any level of ancestor by using an index with the `$parent` syntax:
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Border>
     <TextBlock Text="{Binding $parent[1].Tag}"/>
@@ -56,7 +56,7 @@ The index is zero based so `$parent[0]` is equivalent to `$parent`.
 
 You can also bind to the closest ancestor of a given type, like this:
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Decorator>
     <TextBlock Text="{Binding $parent[Border].Tag}"/>
@@ -66,7 +66,7 @@ You can also bind to the closest ancestor of a given type, like this:
 
 Finally, you can combine the index and the type:
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Border>
     <Decorator>
@@ -78,7 +78,7 @@ Finally, you can combine the index and the type:
 
 If you need to include a XAML namespace in the ancestor type, you separate the namespace and class using a colon, like this:
 
-```markup
+```xml
 <local:MyControl Tag="Hello World!">
   <Decorator>
     <TextBlock Text="{Binding $parent[local:MyControl].Tag}"/>
@@ -88,7 +88,7 @@ If you need to include a XAML namespace in the ancestor type, you separate the n
 
 To access a property of a parent's `DataContext` it will be necessary to cast it with a casting expression `(vm:MyUserControlViewModel)DataContext` to its actual type. Otherwise `DataContext` would be considered as of type `object` and accessing a custom property would result in an compile-time error.
 
-```markup
+```xml
 <local:MyControl Tag="Hello World!">
   <Decorator>
     <TextBlock Text="{Binding $parent[local:MyControl].((vm:MyUserControlViewModel)DataContext).CustomProperty}"/>

--- a/docs/guides/data-binding/how-to-bind-tabs.md
+++ b/docs/guides/data-binding/how-to-bind-tabs.md
@@ -38,7 +38,7 @@ The `TabStrip` header content is defined by ItemTemplate property, while `TabIte
 
 Finally create a `TabControl` and bind its `ItemsSource` property to the DataContext.
 
-```markup
+```xml
 <TabControl ItemsSource="{Binding}">
     <TabControl.ItemTemplate>
       <DataTemplate>

--- a/docs/guides/data-binding/how-to-bind-to-a-command-with-reactiveui.md
+++ b/docs/guides/data-binding/how-to-bind-to-a-command-with-reactiveui.md
@@ -79,7 +79,7 @@ When the control bound to the reactive command is activated (in this example: wh
 
 You will often need to pass an argument to the reactive command that is bound to a control. You can achieve this using the `CommandParameter` attribute in the XAML. For example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
    ...
    <StackPanel Margin="20">
@@ -114,7 +114,7 @@ Note that no type conversion is carried out on the `CommandParameter` attribute,
 
 For example to pass an integer parameter:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:sys="clr-namespace:System;assembly=mscorlib">
  ...   

--- a/docs/guides/data-binding/how-to-bind-to-a-task-result.md
+++ b/docs/guides/data-binding/how-to-bind-to-a-task-result.md
@@ -26,7 +26,7 @@ private async Task<string> GetTextAsync()
 
 You can bind to the result in the following way:
 
-```markup
+```xml
 <TextBlock Text="{Binding MyAsyncText^, FallbackValue='Wait a second'}" />
 ```
 

--- a/docs/guides/data-binding/how-to-bind-to-an-observable.md
+++ b/docs/guides/data-binding/how-to-bind-to-an-observable.md
@@ -14,6 +14,6 @@ You can subscribe to the result of a task or an observable by using the `^` stre
 
 For example if `DataContext.Name` is an `IObservable<string>` then the following example will bind to the length of each string produced by the observable as each value is produced
 
-```markup
+```xml
 <TextBlock Text="{Binding Name^.Length}"/>
 ```

--- a/docs/guides/data-binding/how-to-create-a-custom-data-binding-converter.md
+++ b/docs/guides/data-binding/how-to-create-a-custom-data-binding-converter.md
@@ -18,7 +18,7 @@ As the `IValueConverter` interface was not available in .NET standard 2.0, Avalo
 
 You must reference a custom converter in some resources before it can be used. This can be at any level in your application. In this example, the custom converter `myConverter` is referenced in the window resources:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:ExampleApp;assembly=ExampleApp">
@@ -35,7 +35,7 @@ You must reference a custom converter in some resources before it can be used. T
 
 This example data binding converter can convert text to specific case from a parameter:
 
-```markup
+```xml
 <TextBlock Text="{Binding TheContent, 
     Converter={StaticResource textCaseConverter},
     ConverterParameter=lower}" />

--- a/docs/guides/graphics-and-animation/graphics-and-animations.md
+++ b/docs/guides/graphics-and-animation/graphics-and-animations.md
@@ -22,7 +22,7 @@ Avalonia introduces an extensive, scalable, and flexible set of graphics feature
 
 Avalonia provides a library of common vector-drawn 2D shapes such as `Ellipse`, `Line`, `Path`, `Polygon` and `Rectangle`.
 
-```markup
+```xml
 <Canvas Background="Yellow" Width="300" Height="400">
     <Rectangle Fill="Blue" Width="63" Height="41" Canvas.Left="40" Canvas.Top="31">
         <Rectangle.OpacityMask>

--- a/docs/guides/graphics-and-animation/keyframe-animations.md
+++ b/docs/guides/graphics-and-animation/keyframe-animations.md
@@ -75,7 +75,7 @@ The animation runs as soon as the rectangle control is loaded and can be selecte
 
 This example shows you how to animate two properties on the same timeline.
 
-```markup
+```xml
 <Window.Styles>
     <Style Selector="Rectangle.red">
       <Setter Property="Fill" Value="Red"/>
@@ -103,7 +103,7 @@ The red rectangle is faded-in and rotated at the same time.
 
 You can add a delay to the start of an animation by setting the delay attribute of the animation element. For example:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"> 
     ...
@@ -170,7 +170,7 @@ An easing function defines how a property is varied over time during an animatio
 
 The default easing function is linear (above left), but you use another pattern by setting the name of the desired function in the easing attribute. For example to use the 'bounce ease in' function (above right):
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"
            Easing="BounceEaseIn"> 
@@ -184,7 +184,7 @@ For a full list of the _Avalonia UI_ easing functions, see the reference [here](
 
 You can also add your own custom easing function class like this:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1">
     <Animation.Easing>

--- a/docs/guides/graphics-and-animation/page-transitions/page-slide-transition.md
+++ b/docs/guides/graphics-and-animation/page-transitions/page-slide-transition.md
@@ -7,7 +7,7 @@ title: Page Slide Transition
 
 The page slide transition moves the old page out of view, and the new page into view, for the given duration. You can specify the slide direction using the orientation property (default horizontal).
 
-```markup title='XAML'
+```xml title='XAML'
 <PageSlide Duration="0:00:00.500" Orientation="Vertical" />
 ```
 

--- a/docs/guides/graphics-and-animation/transitions.md
+++ b/docs/guides/graphics-and-animation/transitions.md
@@ -8,7 +8,7 @@ title: How To Use Transitions
 
 Transitions in Avalonia are also heavily inspired by CSS Animations. They listen to any changes in target property's value and subsequently animates the change according to its parameters. They can be defined on any `Control` via `Transitions` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -37,7 +37,7 @@ The above example will listen to changes in the `Rectangle`'s `Opacity` property
 
 Transitions can also be defined in any style by using a `Setter` with `Transitions` as the target property and encapsulating them in a `Transitions` object, like so:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -90,7 +90,7 @@ The following transition types are available. The correct type must be used depe
 
 Render transforms applied to controls using CSS-like syntax can be transitioned. The following example shows a Border which rotates 45 degrees when the pointer is hovered over it:
 
-```markup title='XAML'
+```xml title='XAML'
 <Border Width="100" Height="100" Background="Red">
     <Border.Styles>
         <Style Selector="Border">

--- a/docs/guides/implementation-guides/code-behind.md
+++ b/docs/guides/implementation-guides/code-behind.md
@@ -40,7 +40,7 @@ namespace AvaloniaApplication1.Views
 
 Notice that this class name is the same as name of the XAML file, and is also referenced in the `x:Class` attribute of the window element.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:AvaloniaApplication1.ViewModels"
@@ -68,11 +68,11 @@ To do this you will first need a reference to a control. Your code will use find
 
 In this example, the button in the XAML has the name attribute defined:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication5.MainWindow">
-  <Button Name=GreetingButton">Hello World</Button>
+  <Button Name="GreetingButton">Hello World</Button>
 </Window>
 ```
 
@@ -94,7 +94,7 @@ Any useful application will require you to implement some action! When you use t
 
 You write event handlers as methods in the code-behind file, and then reference them in the XAML with an event attribute. For example to add a handler for a button click:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">

--- a/docs/guides/implementation-guides/ide-support.md
+++ b/docs/guides/implementation-guides/ide-support.md
@@ -39,7 +39,7 @@ With the namespace added, the following design-time properties become available:
 
 The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to the control being previewed.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -53,7 +53,7 @@ The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to 
 
 The `d:DataContext` property applies a `DataContext` only at design-time. It is recommended that you use this property in conjunction with the `{x:Static}` directive to reference a static property in one of your assemblies:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -81,7 +81,7 @@ namespace My.Namespace
 
 Alternatively you can use `Design.DataContext` attached property. As well as `Design.Width` and `Design.Height`.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/docs/guides/platforms/rpi/running-on-raspbian-lite-via-drm.md
+++ b/docs/guides/platforms/rpi/running-on-raspbian-lite-via-drm.md
@@ -89,7 +89,7 @@ When we work via FrameBuffer there are no windows, so we need a separate view (U
 
 `MainView` will be our app base in which we develop our UI:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -112,7 +112,7 @@ When we work via FrameBuffer there are no windows, so we need a separate view (U
 
 Now create a new UserControl with name `MainSingleView` and host the `MainView`:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -128,7 +128,7 @@ Now create a new UserControl with name `MainSingleView` and host the `MainView`:
 
 Also change the `MainWindow.axaml` to host the `MainView` inside:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/docs/guides/styles-and-resources/how-to-use-included-styles.md
+++ b/docs/guides/styles-and-resources/how-to-use-included-styles.md
@@ -11,7 +11,7 @@ This guide shows you how to share styles from a separate styles file (that is in
 
 To do this, you define styles in a new XAML file. Here, the root element must then be either a `Style` or `Styles` element. For example:
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="TextBlock.h1">
@@ -34,7 +34,7 @@ To use the styles defined in a separate file, you must reference it using a `Sty
 
 For example, to use styles defined in a file `AppStyles.axaml` (saved in the folder `/Styles`), you could write a a `StyleInclude` element in the window like this:
 
-```markup
+```xml
 <Window ... >
     <Window.Styles>
         <StyleInclude Source="/Styles/AppStyles.axaml" />

--- a/docs/guides/styles-and-resources/property-setters.md
+++ b/docs/guides/styles-and-resources/property-setters.md
@@ -13,14 +13,14 @@ The setters in a style define what properties will be changed after _Avalonia UI
 
 For example:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="24"/>
 <Setter Property="Padding" Value="4 2 0 4"/>
 ```
 
 You can also use a long-form syntax to set a control property to an object with several properties set, like this:
 
-```markup
+```xml
 <Setter Property="MyProperty">
    <MyObject Property1="My Value" Property2="999"/>
 </Setter>
@@ -28,7 +28,7 @@ You can also use a long-form syntax to set a control property to an object with 
 
 A style can also set properties using bindings. After the usual selection process, this causes _Avalonia UI_ to use a value from data context of the target control. For example, the setter can be defined like this:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="{Binding SelectedFontSize}"/>
 ```
 
@@ -60,7 +60,7 @@ Note that the `Setter` creates a single instance of `Value` which will be applie
 
 Also note that bindings on an object defined in a setter value will not have access to the target control's data context. This is because there may be multiple target controls. This scenario may arise with a style defined like this:
 
-```markup
+```xml
 <Style Selector="local|MyControl">
   <Setter Property="MyProperty">
      <MyObject Property1="{Binding MyViewModelProperty}"/>
@@ -72,7 +72,7 @@ This means that in the example above, the binding source for the setter will be 
 
 Note: if you are using compiled bindings, you need to explicitly set the data type of the binding source in the `<Style>` element:
 
-```markup
+```xml
 <Style Selector="MyControl" x:DataType="MyViewModelClass">
   <Setter Property="ControlProperty" Value="{Binding MyViewModelProperty}" />
 </Style>
@@ -86,7 +86,7 @@ For more information about compiled bindings, see here. --> TO DO
 
 As previously described here, when you use a setter without a **data template**, a single instance of the setter value is created and shared across all matching controls. To change the value depending on a data template, you place the target control inside a template element, like this:
 
-```markup
+```xml
 <Style Selector="Border.empty">
   <Setter Property="Child">
     <Template>

--- a/docs/guides/styles-and-resources/troubleshooting.md
+++ b/docs/guides/styles-and-resources/troubleshooting.md
@@ -24,20 +24,20 @@ Check whether you have used a child selector where there are no children to matc
 
 Styles are applied in order of declaration. If there are multiple style files included that target the same control property, the last style included will override the previous ones. For example:
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Green" />
 </Style>
 ```
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Blue" />
     <Style Property="FontSize" Value="16" />
 </Style>
 ```
 
-```markup
+```xml
 <StyleInclude Source="Style1.axaml" />
 <StyleInclude Source="Style2.axaml" />
 ```
@@ -48,7 +48,7 @@ Here styles from file **Styles1.axaml** were applied first, so setters in styles
 
 A local value defined directly on a control often has higher priority than any style value. So in this example the text block will have a red foreground:
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Setter Property="Foreground" Value="Green" />
 </Style>
@@ -72,7 +72,7 @@ Some default _Avalonia UI_ styles use local values in their templates instead of
 
 Let's imagine a situation in which you might expect a second style to override previous one, but it doesn't:
 
-```markup
+```xml
 <Style Selector="Border:pointerover">
     <Setter Property="Background" Value="Blue" />
 </Style>
@@ -93,7 +93,7 @@ Visit the Avalonia source code to find the [original templates](https://github.c
 
 The following code example of styles that can be expected to work on top of default styles:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="Red" />
 </Style>
@@ -106,7 +106,7 @@ You might expect the `Button` to be red by default and blue when pointer is over
 
 The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code (old [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) theme and new [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="{DynamicResource ButtonBackground}"/>
     <Setter Property="Template">
@@ -124,7 +124,7 @@ The reason is hidden in the Button's template. You can find the default template
 
 The actual background is rendered by a `ContentPresenter`, which in the default is bound to the Buttons `Background` property. However in the pointer-over state the selector is directly applying the background to the `ContentPresenter (Button:pointerover /template/ ContentPresenter#PART_ContentPresenter`) That's why when our setter was ignored in the previous code example. The corrected code should target content presenter directly as well:
 
-```markup
+```xml
 <!-- Here #PART_ContentPresenter name selector is not necessary, but was added to have more specific style -->
 <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Blue" />

--- a/docs/reference/built-in-data-binding-converters.md
+++ b/docs/reference/built-in-data-binding-converters.md
@@ -20,7 +20,7 @@ _Avalonia UI_ includes a number of built-in data binding converters for common s
 
 This example shows the text block when the bound value is false:
 
-```markup
+```xml
 <StackPanel>
   <TextBox Name="input" IsEnabled="{Binding AllowInput}"/>
   <TextBlock IsVisible="{Binding !AllowInput}">Input is not allowed</TextBlock>
@@ -31,7 +31,7 @@ Negation also works when you bind to a non-Boolean value. This works because the
 
 For example, as the integer zero is converted to false (by the function `Convert.ToBoolean`) and all other integer values are converted to true, you can use the negation operator to show a message when a collection is empty, like this:
 
-```markup
+```xml
 <Panel>
   <ListBox ItemsSource="{Binding Items}"/>
   <TextBlock IsVisible="{Binding !Items.Count}">No results found</TextBlock>
@@ -42,7 +42,7 @@ You can also use the negation operator twice. For example, where you want to per
 
 You can use this to hide a control when a collection is empty (count is zero), like this:
 
-```markup
+```xml
 <Panel>
   <ListBox ItemsSource="{Binding Items}" IsVisible="{Binding !!Items.Count}"/>
 </Panel>
@@ -52,7 +52,7 @@ You can use this to hide a control when a collection is empty (count is zero), l
 
 This example binding will hide the text block if its bound text is null or empty:
 
-```markup
+```xml
 <TextBlock Text="{Binding MyText}"
            IsVisible="{Binding MyText, 
                        Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
@@ -60,7 +60,7 @@ This example binding will hide the text block if its bound text is null or empty
 
 And this example will hide the content control if the bound object is null or empty:
 
-```markup
+```xml
 <ContentControl Content="{Binding MyContent}"
                 IsVisible="{Binding MyContent, 
                             Converter={x:Static ObjectConverters.IsNotNull}}"/>

--- a/docs/reference/controls/checkbox.md
+++ b/docs/reference/controls/checkbox.md
@@ -25,7 +25,7 @@ You will probably use these properties most often:
 
 This is an example of two-state check boxes:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -46,7 +46,7 @@ Looks like this when running on Windows:
 
 This is an example of a three-state checkbox:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/docs/reference/controls/combobox.md
+++ b/docs/reference/controls/combobox.md
@@ -37,7 +37,7 @@ You will probably use these properties most often:
 
 This is basic example with text items has a limit set on the drop-down list height.
 
-```markup
+```xml
 <StackPanel Margin="20">
   <ComboBox SelectedIndex="0" MaxDropDownHeight="100">
     <ComboBoxItem>Text Item 1</ComboBoxItem>
@@ -57,7 +57,7 @@ This is basic example with text items has a limit set on the drop-down list heig
 
 This example uses a composed view for each item:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <ComboBox SelectedIndex="0">
     <ComboBoxItem>

--- a/docs/reference/controls/datagrid/README.md
+++ b/docs/reference/controls/datagrid/README.md
@@ -50,7 +50,7 @@ You must reference the `DataGrid` themes to include the additional styles that t
 
 For example:
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
@@ -129,7 +129,7 @@ These examples use the MVVM pattern with data binding to an `ObservableCollectio
 
 Property names from the item class will generally not make good column names. This example adds custom header names to the grid. It also allows column reordering and resizing and disallows the default column sorting option:
 
-```markup
+```xml
 <DataGrid Margin="20" ItemsSource="{Binding People}"
           IsReadOnly="True"
           CanUserReorderColumns="True"

--- a/docs/reference/controls/detailed-reference/border.md
+++ b/docs/reference/controls/detailed-reference/border.md
@@ -39,7 +39,7 @@ If you use the four value pattern; you must provide all four values, even if one
 
 This example adds some border controls to create a 'pod' look in the layout:
 
-```markup
+```xml
 <StackPanel>
   <Border Background="Gainsboro"
         BorderBrush="Black"
@@ -86,7 +86,7 @@ If both offset values are set to zero, the shadow is placed behind the element, 
 
 This is an example of a drop-shadow:
 
-```markup
+```xml
 <<StackPanel>
   <Border Background="Gainsboro"
         BorderBrush="Black"

--- a/docs/reference/controls/detailed-reference/calendar/README.md
+++ b/docs/reference/controls/detailed-reference/calendar/README.md
@@ -23,7 +23,7 @@ You will probably use these properties most often:
 
 This is a basic calendar allowing a single date selection. The calendar's selected date is shown in the text block below.
 
-```markup
+```xml
 <StackPanel Margin="20">
   <Calendar x:Name="calendar" SelectionMode="MultipleRange"/>
   <TextBlock Margin="20" 
@@ -35,7 +35,7 @@ This is a basic calendar allowing a single date selection. The calendar's select
 
 This example allows multiple range selections:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <Calendar SelectionMode="MultipleRange"/>
 </StackPanel>

--- a/docs/reference/controls/detailed-reference/tabcontrol.md
+++ b/docs/reference/controls/detailed-reference/tabcontrol.md
@@ -24,7 +24,7 @@ If you only need the function of the tab headers part of this control, consider 
 
 This is simple tab example. The tab content is just some text: 
 
-```markup
+```xml
 <TabControl Margin="5">
   <TabItem Header="Tab 1">
     <TextBlock Margin="5">This is tab 1 content</TextBlock>

--- a/docs/reference/controls/detailed-reference/textbox.md
+++ b/docs/reference/controls/detailed-reference/textbox.md
@@ -19,7 +19,7 @@ You will probably use these properties most often:
 
 This example has a basic one line text box, a password box, and a text-wrapping multiline text box:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5" >Name:</TextBlock>
   <TextBox  Watermark="Enter your name"/>

--- a/docs/reference/controls/detailed-reference/timepicker.md
+++ b/docs/reference/controls/detailed-reference/timepicker.md
@@ -33,7 +33,7 @@ This example shows how to create a time picker for the 24 hour clock, with 20 mi
 
 You can set the time value as an attribute in XAML.  Use a string in the form _Hh:Mm_ where _Hh_ is hours and can be between 0 and 23 and _Mm_ is minutes and can be between 0 and 59.
 
-```markup
+```xml
 <TimePicker SelectedTime="09:15"/>
 ```
 

--- a/docs/reference/controls/detailed-reference/tooltip.md
+++ b/docs/reference/controls/detailed-reference/tooltip.md
@@ -20,7 +20,7 @@ You will probably use these properties most often:
 
 This is a simple text-based tooltip, using default values for the placement and delay properties; this rectangle is placed in a window with larger dimensions:
 
-```markup
+```xml
 <Rectangle Fill="Aqua" Height="200" Width="400"
             ToolTip.Tip="This is a rectangle" />
 ```
@@ -29,7 +29,7 @@ This is a simple text-based tooltip, using default values for the placement and 
 
 To provide a richer presentation for a tooltip, use a `<ToolTip.Tip>` element. For example:
 
-```markup
+```xml
 <Rectangle Fill="Aqua" Height="200" Width="400"
     ToolTip.Placement="Bottom">
     <ToolTip.Tip>

--- a/docs/reference/controls/detailed-reference/transitioningcontentcontrol.md
+++ b/docs/reference/controls/detailed-reference/transitioningcontentcontrol.md
@@ -22,7 +22,7 @@ You will probably use these properties most often:
 
 In this example, the view model contains a collection of different images to show them in a slideshow. The following XAML will use the default page transition to change the image (in the data template) whenever the bound `SelectedImage` property changes:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">
@@ -36,7 +36,7 @@ In this example, the view model contains a collection of different images to sho
 
 In this example, a different page transition has been specified to slide the images horizontally:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.PageTransition>
         <PageSlide Orientation="Horizontal" Duration="0:00:00.500" />

--- a/docs/reference/controls/detailed-reference/treedatagrid/README.md
+++ b/docs/reference/controls/detailed-reference/treedatagrid/README.md
@@ -63,7 +63,7 @@ You must reference the data grid themes to include the additional styles that th
 
 For example:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AvaloniaApplication.App">

--- a/docs/reference/controls/detailed-reference/viewbox.md
+++ b/docs/reference/controls/detailed-reference/viewbox.md
@@ -40,7 +40,7 @@ The values for the `StretchDirection` property are as follows:
 
 This simple example shows a `Viewbox` scaling up a circle uniformly (both stretch and direction are default).
 
-```markup
+```xml
 <Viewbox Stretch="Uniform" Width="300" Height="300">
    <Ellipse Width="50" Height="50" Fill="CornflowerBlue" />  
 </Viewbox>

--- a/docs/reference/controls/dockpanel.md
+++ b/docs/reference/controls/dockpanel.md
@@ -38,7 +38,7 @@ You will probably use these properties most often:
 
 Setting the opacity of the orange rectangle to 0.5 demonstrates that there are no overlaps.
 
-```markup
+```xml
 <DockPanel Width="300" Height="300">
     <Rectangle Fill="Red" Height="100" DockPanel.Dock="Top"/>
     <Rectangle Fill="Blue" Width="100" DockPanel.Dock="Left" />

--- a/docs/reference/controls/flyouts.md
+++ b/docs/reference/controls/flyouts.md
@@ -30,7 +30,7 @@ Only the button and split button controls support the `Flyout` property. You can
 
 For controls that do not have the `Flyout` property, use the `AttachedFlyout` property like this:
 
-```markup
+```xml
 <Border Background="Red" PointerPressed="Border_PointerPressed">
     <FlyoutBase.AttachedFlyout>
         <Flyout>
@@ -82,7 +82,7 @@ This setting describes how the flyout shows and hides:
 
 You can share flyouts between two or more elements in your app. For example, to share a flyout from the resources collection of a window:
 
-```markup
+```xml
 <Window.Resources>
     <Flyout x:Key="MySharedFlyout">
         <!-- Flyout content here -->
@@ -98,7 +98,7 @@ You can share flyouts between two or more elements in your app. For example, to 
 
 Although flyouts are not themselves controls, their general appearance can be customized by targeting the presenter the `Flyout` uses to display its content. For a normal `Flyout` this is `FlyoutPresenter` and for `MenuFlyout` this is `MenuFlyoutPresenter`. Because flyout presenters are not exposed, special style classes that should pertain to specific flyouts can be passed using the `FlyoutPresenterClasses` property on `FlyoutBase`
 
-```markup
+```xml
 <Style Selector="FlyoutPresenter.mySpecialClass">
     <Setter Property="Background" Value="Red" />
 </Style>

--- a/docs/reference/controls/grid.md
+++ b/docs/reference/controls/grid.md
@@ -135,7 +135,7 @@ This example shows:
 
 An example of a Grid with 3 equal Rows and 3 Columns with (1 fixed width), (2 grabbing the rest proportionally) would be:
 
-```markup
+```xml
 <Grid ColumnDefinitions="100,1.5*,4*" RowDefinitions="Auto,Auto,Auto"  Margin="4">
   <TextBlock Text="Col0Row0:" Grid.Row="0" Grid.Column="0"/>
   <TextBlock Text="Col0Row1:" Grid.Row="1" Grid.Column="0"/>

--- a/docs/reference/controls/gridsplitter.md
+++ b/docs/reference/controls/gridsplitter.md
@@ -24,7 +24,7 @@ To provide any meaningful movement, the direction of travel of the splitter must
 
 This is a column splitter:
 
-```markup
+```xml
 <Grid ColumnDefinitions="*, 4, *">
     <Rectangle Grid.Column="0" Fill="Blue"/>
     <GridSplitter Grid.Column="1" Background="Black" ResizeDirection="Columns"/>
@@ -36,7 +36,7 @@ This is a column splitter:
 
 This is a row splitter:
 
-```markup
+```xml
 <Grid RowDefinitions="*, 4, *">
     <Rectangle Grid.Row="0" Fill="Blue"/>
     <GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>

--- a/docs/reference/controls/listbox.md
+++ b/docs/reference/controls/listbox.md
@@ -89,7 +89,7 @@ The following selection modes are available for the list box:
 
 These values can be combined, for example:
 
-```markup
+```xml
 <ListBox SelectionMode="Multiple,Toggle">
 ```
 

--- a/docs/reference/controls/maskedtextbox.md
+++ b/docs/reference/controls/maskedtextbox.md
@@ -31,7 +31,7 @@ The escape character (backslash) can be used to include a special character as a
 
 This is a basic example:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">International phone number:</TextBlock>
   <MaskedTextBox Mask="(+09) 000 000 0000" />

--- a/docs/reference/controls/menu.md
+++ b/docs/reference/controls/menu.md
@@ -80,7 +80,7 @@ You will probably use these properties most often:
 
 This example creates a menu docked at the top edge of a window.
 
-```markup
+```xml
 <Window ...>
     <DockPanel>
     <Menu DockPanel.Dock="Top">
@@ -121,7 +121,7 @@ Once keyboard interaction has been initiated with the Alt key, the user can also
 
 To initiate an action, the command property of a menu item can be bound to an `ICommand` object. The command will be executed when the menu item is clicked or selected with the keyboard. For example:
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem Header="_Open..." Command="{Binding OpenCommand}"/>
@@ -137,7 +137,7 @@ For guidance on how to bind to commands, see [here](../../basics/user-interface/
 
 A menu icon can be displayed by placing an image or a path icon in the `<MenuItem.Icon>` attached property. For example:
 
-```markup
+```xml
 <MenuItem Header="_Edit">
   <MenuItem Header="Copy">
      <MenuItem.Icon>

--- a/docs/reference/controls/numericupdown.md
+++ b/docs/reference/controls/numericupdown.md
@@ -29,7 +29,7 @@ You will probably use these properties most often:
 
 This is a basic example of a numeric up-down control. There are no limits to the value here:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">Number of items:</TextBlock>
   <NumericUpDown Value="10" />
@@ -46,7 +46,7 @@ Remember to specify a `FormatString` property when you create a custom decimal i
 
 For example:
 
-```markup
+```xml
 <StackPanel Margin="20">  
   <TextBlock Margin="0 5">Opacity:</TextBlock>
   <NumericUpDown Value="0.5" Increment="0.05" 

--- a/docs/reference/controls/panel.md
+++ b/docs/reference/controls/panel.md
@@ -16,7 +16,7 @@ For a discussion about using other panels, see [here](../../basics/user-interfac
 
 This example uses some 50% opacities to demonstrate that child controls overlap.
 
-```markup
+```xml
 <Panel Height="300" Width="300">
     <Rectangle Fill="Red" Height="100" VerticalAlignment="Top"/>
     <Rectangle Fill="Blue" Opacity="0.5" Width="100" HorizontalAlignment="Right" />

--- a/docs/reference/controls/refreshcontainer.md
+++ b/docs/reference/controls/refreshcontainer.md
@@ -12,7 +12,7 @@ The `RefreshContainer` allows a user to pull down on content or a list of data t
 This example shows hows to use a RefreshContainer with a
 
 _In the axaml file._
-```markup
+```xml
 <RefreshContainer PullDirection="TopToBottom"
                 RefreshRequested="RefreshContainerPage_RefreshRequested">
     <ListBox ItemsSource="{Binding Items}"/>

--- a/docs/reference/controls/relativepanel.md
+++ b/docs/reference/controls/relativepanel.md
@@ -49,7 +49,7 @@ You will probably use these properties most often:
 
 This XAML shows how to arrange some child controls in different ways:
 
-```markup
+```xml
 <Border BorderBrush="DarkGray" BorderThickness="1" Width="300" Height="300">
   <RelativePanel >
     <Rectangle x:Name="RedRect" Fill="Red" Height="50" Width="50"/>

--- a/docs/reference/controls/splitview.md
+++ b/docs/reference/controls/splitview.md
@@ -39,7 +39,7 @@ The display mode property controls how the pane is drawn in its open and closed 
 
 ## Example
 
-```markup
+```xml
 <SplitView IsPaneOpen="True"
            DisplayMode="Inline"
            OpenPaneLength="300">

--- a/docs/reference/controls/stackpanel.md
+++ b/docs/reference/controls/stackpanel.md
@@ -26,7 +26,7 @@ You will probably use these properties most often:
 
 The following XAML shows how to create a vertical stack panel.
 
-```markup
+```xml
 <StackPanel Width="200">
     <Rectangle Fill="Red" Height="50"/>
     <Rectangle Fill="Blue" Height="50"/>

--- a/docs/reference/styles/style-selector-syntax.md
+++ b/docs/reference/styles/style-selector-syntax.md
@@ -10,7 +10,7 @@ This page lists the XAML syntax for style selectors with the C# code methods tha
 
 
 
-```markup
+```xml
 <Style Selector="Button">
 <Style Selector="local|Button">
 ```
@@ -41,7 +41,7 @@ Note the type of an object is actually determined by looking at its `StyleKey` p
 
 
 
-```markup
+```xml
 <Style Selector="#myButton">
 <Style Selector="Button#myButton">
 ```
@@ -60,7 +60,7 @@ Selects a control by its `Name` attribute, with an added `#` (hash) character pr
 
 
 
-```markup
+```xml
 <Style Selector="Button.large">
 <Style Selector="Button.large.red">
 ```
@@ -102,7 +102,7 @@ For more detail about pseudo classes, see the reference [here](pseudo-classes.md
 
 
 
-```markup
+```xml
 <Style Selector=":is(Button)">
 <Style Selector=":is(local|Button)">
 ```
@@ -125,7 +125,7 @@ INterestingly, this allows you to write very general class-based selectors. As c
 
 
 
-```markup
+```xml
 <Style Selector=":is(Control).margin2">
 <Style Selector=":is(local|Control.margin2)">
 ```
@@ -142,7 +142,7 @@ new Style(x => x.Is(typeof(Control)).Class("margin2"));
 
 
 
-```markup
+```xml
 <Style Selector="StackPanel > Button">
 ```
 
@@ -177,7 +177,7 @@ The selector will match the first button, but not the second. This is because th
 
 
 
-```markup
+```xml
 <Style Selector="StackPanel Button">
 ```
 
@@ -196,7 +196,7 @@ Therefore applying the above selector to the previous XAML sample, both buttons 
 
 
 
-```markup
+```xml
 <Style Selector="Button[IsDefault=true]">
 ```
 
@@ -221,7 +221,7 @@ For example, in the XAML above, the first button will be selected, but not the s
 :::info
 Note: when you use an attached property as a property match, the property name must be wrapped in parentheses. Fro example:
 
-```markup
+```xml
 <Style Selector="TextBlock[(Grid.Row)=0]">
 ```
 :::
@@ -234,7 +234,7 @@ Further note: when you use a property match, the property type must support the 
 
 
 
-```markup
+```xml
 <Style Selector="Button /template/ ContentPresenter">
 ```
 
@@ -253,7 +253,7 @@ In the example above, if a button has a template, then the selector matches sele
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:not(.h1)">
 ```
 
@@ -270,7 +270,7 @@ This function negates the selection in the brackets. In the example above all th
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock, Button">
 ```
 
@@ -287,7 +287,7 @@ You can select any element that matches a comma-separated list of selectors. Any
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-child(2n+3)">
 ```
 
@@ -312,7 +312,7 @@ There is a corresponding selector with a formula that counts from the end of the
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-last-child(2n+3)">
 ```
 
@@ -329,7 +329,7 @@ You can omit the **A** and **n** from the formula in XAML to specify a single po
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-child(3)">
 ```
 

--- a/docs/tutorials/music-store-app/add-and-layout-controls.md
+++ b/docs/tutorials/music-store-app/add-and-layout-controls.md
@@ -20,7 +20,7 @@ To display a button in the content zone of the main window, follow this procedur
 - Locate and open the **MainWindow.axaml** file.
 - Inside the panel element, add the following XAML for a button. The panel XAML should look like this:
 
-```markup
+```xml
 <Panel>
     <ExperimentalAcrylicBorder IsHitTestVisible="False">
         <ExperimentalAcrylicBorder.Material>
@@ -49,7 +49,7 @@ Follow this procedure to position the button correctly:
 - Add a margin attribute to the new panel element, with a value of 40. 
 - Add horizontal and vertical alignment attributes to the button element, as shown:
 
-```markup
+```xml
 <Panel Margin="40">
   <Button Content="Buy Music" 
      HorizontalAlignment="Right" VerticalAlignment="Top" />
@@ -69,7 +69,7 @@ To use the Microsoft Store icon, follow this procedure:
 - Navigate to the _Avalonia UI_ _GitHub_ to find the list of Fluent Icons at [https://avaloniaui.github.io/icons.html](https://avaloniaui.github.io/icons.html)
 - Use your browser's text search to locate the name of the icon 'store\_microsoft\_regular'. There should be some code similar to:
 
-```markup
+```xml
 <StreamGeometry x:Key="store_microsoft_regular">M11.5 9.5V13H8V9.5H11.5Z M11.5 17.5V14H8V17.5H11.5Z M16 9.5V13H12.5V9.5H16Z M16 17.5V14H12.5V17.5H16Z M8 6V3.75C8 2.7835 8.7835 2 9.75 2H14.25C15.2165 2 16 2.7835 16 3.75V6H21.25C21.6642 6 22 6.33579 22 6.75V18.25C22 19.7688 20.7688 21 19.25 21H4.75C3.23122 21 2 19.7688 2 18.25V6.75C2 6.33579 2.33579 6 2.75 6H8ZM9.5 3.75V6H14.5V3.75C14.5 3.61193 14.3881 3.5 14.25 3.5H9.75C9.61193 3.5 9.5 3.61193 9.5 3.75ZM3.5 18.25C3.5 18.9404 4.05964 19.5 4.75 19.5H19.25C19.9404 19.5 20.5 18.9404 20.5 18.25V7.5H3.5V18.25Z</StreamGeometry>
 ```
 
@@ -82,7 +82,7 @@ To use the Microsoft Store icon, follow this procedure:
 - Enter the **Name** 'Icons', press enter.
 - Locate and open the new **Icons.axaml** file that is created. The XAML will look like this:
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -101,7 +101,7 @@ To use the Microsoft Store icon, follow this procedure:
 
 The icons file now looks like this:
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -126,7 +126,7 @@ Follow this procedure to include the icons file:
 - Locate and open the **App.axaml** file.
 - Add a `<StyleInclude>` element as shown:
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.MusicStore/Icons.axaml" />
@@ -140,7 +140,7 @@ To change the button from text to icon content, follow this procedure:
 - Locate and open the **MainWindow.axaml** file.
 - Alter the XAML for the button, as shown:
 
-```markup
+```xml
 <Button HorizontalAlignment="Right" VerticalAlignment="Top">       
     <PathIcon Data="{StaticResource store_microsoft_regular}" /> 
 </Button>

--- a/docs/tutorials/music-store-app/album-view.md
+++ b/docs/tutorials/music-store-app/album-view.md
@@ -20,7 +20,7 @@ To add the music note icon resource, follow this procedure:
 - Navigate to the _Avalonia UI_ _GitHub_ to find the list of Fluent Icons at [https://avaloniaui.github.io/icons.html](https://avaloniaui.github.io/icons.html)
 - Use your browser's text search to locate the name of the icon 'music_regular'. There should be some code similar to:
 
-```markup
+```xml
 <StreamGeometry x:Key="music_regular">M11.5,2.75 C11.5,2.22634895 12.0230228,1.86388952 12.5133347,2.04775015 L18.8913911,4.43943933 C20.1598961,4.91511241 21.0002742,6.1277638 21.0002742,7.48252202 L21.0002742,10.7513533 C21.0002742,11.2750044 20.4772513,11.6374638 19.9869395,11.4536032 L13,8.83332147 L13,17.5 C13,17.5545945 12.9941667,17.6078265 12.9830895,17.6591069 C12.9940859,17.7709636 13,17.884807 13,18 C13,20.2596863 10.7242052,22 8,22 C5.27579485,22 3,20.2596863 3,18 C3,15.7403137 5.27579485,14 8,14 C9.3521238,14 10.5937815,14.428727 11.5015337,15.1368931 L11.5,2.75 Z M8,15.5 C6.02978478,15.5 4.5,16.6698354 4.5,18 C4.5,19.3301646 6.02978478,20.5 8,20.5 C9.97021522,20.5 11.5,19.3301646 11.5,18 C11.5,16.6698354 9.97021522,15.5 8,15.5 Z M13,3.83223733 L13,7.23159672 L19.5002742,9.669116 L19.5002742,7.48252202 C19.5002742,6.75303682 19.0477629,6.10007069 18.3647217,5.84393903 L13,3.83223733 Z</StreamGeometry>
 ```
 
@@ -41,7 +41,7 @@ To create the graphical 'tile' view, follow this procedure:
 - Add the attribute `Width="200"` to the `<UserControl>` element.
 - Alter the XAML for the user control's content zone as follows:
 
-```markup
+```xml
 <StackPanel Spacing="5" Width="200">
     <Border CornerRadius="10" ClipToBounds="True">
         <Panel Background="#7FFF22DD">
@@ -123,7 +123,7 @@ To tidy up the list, follow this procedure:
 - Expand the `<ListBox>` element so that it has start and end tags.
 - Add the `<ListBox.ItemsPanel>` XAML shown:
 
-```markup
+```xml
 <ListBox ItemsSource="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}"
     Background="Transparent" Margin="0 20">
     <ListBox.ItemsPanel>

--- a/docs/tutorials/music-store-app/creating-a-modern-looking-window.md
+++ b/docs/tutorials/music-store-app/creating-a-modern-looking-window.md
@@ -18,7 +18,7 @@ Follow this procedure to style the main window in 'dark' mode:
 - Locate and open the file **App.axaml**.
 - In the XAML, change the `RequestedThemeVariant` attribute in the `<Application>` element from "Default" to "Dark"
 
-```markup
+```xml
 <Application ...
     RequestedThemeVariant="Dark">
 ```
@@ -41,7 +41,7 @@ Follow this procedure to style the background of the main window with an acrylic
 - Find the end of the opening tag of the `<Window>` element.
 - After the `Title="Avalonia.MusicStore"` attribute, add two new attributes as follows:
 
-```markup
+```xml
 <Window ...
         Title="Avalonia.MusicStore"
 
@@ -51,7 +51,7 @@ Follow this procedure to style the background of the main window with an acrylic
 
 - To apply the acrylic effect to the whole window, replace the `<TextBlock>` element in the content zone of the main window with the following XAML for a panel:
 
-```markup
+```xml
 <Window ... >
        <Panel>
            <ExperimentalAcrylicBorder IsHitTestVisible="False">
@@ -83,7 +83,7 @@ Follow this procedure to extend the acrylic blur effect onto the title bar:
 - Find the end of the opening tag of the `<Window>` element again.
 - Add the `ExtendClientAreaToDecorationsHint` attribute as shown:
 
-```markup
+```xml
    <Window ...
            TransparencyLevelHint="AcrylicBlur"
            Background="Transparent"

--- a/docs/tutorials/music-store-app/opening-a-dialog.md
+++ b/docs/tutorials/music-store-app/opening-a-dialog.md
@@ -30,7 +30,7 @@ To style the new dialog window so that it matches the main window, follow this p
 - Locate and open the **MusicStoreWindow.axaml** file.
 - Change this code as follows to add the acrylic blur background, extended into the title bar (as before) as shown:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/docs/tutorials/todo-list-app/add-item-buttons.md
+++ b/docs/tutorials/todo-list-app/add-item-buttons.md
@@ -110,7 +110,7 @@ To do this, follow this procedure:
 - Locate the **AddItemView.axaml** file in the **/Views** folder.
 - Edit the XAML as shown.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:ToDoList.ViewModels"

--- a/docs/tutorials/todo-list-app/creating-a-view.md
+++ b/docs/tutorials/todo-list-app/creating-a-view.md
@@ -34,7 +34,7 @@ dotnet new avalonia.usercontrol -o Views -n ToDoListView  --namespace ToDoList.V
 
 You will see the new AXAML file created in the `/Views` folder
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -81,7 +81,7 @@ Repeat the process with the main window.
 
 Edit the contents of `Views/TodoListView.axaml` to contain the following:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/docs/tutorials/todo-list-app/inspect-the-xaml.md
+++ b/docs/tutorials/todo-list-app/inspect-the-xaml.md
@@ -53,7 +53,7 @@ The entry `mc:Ignorable="d"` tells the _Avalonia UI_ XAML engine that entries be
 
 The last line links the XAML file with its code-behind class. Note that the fully-qualified class name has to be used here.
 
-```markup
+```xml
 <UserControl ...
    x:Class="ToDoList.Views.ToDoListView">
 ```
@@ -98,7 +98,7 @@ To more detail about the stack panel, see the reference [here](../../reference/c
 
 The remaining XAML adds the hard-coded to do list items as check boxes:
 
-```markup
+```xml
 <CheckBox Margin="4">Walk the dog</CheckBox>
 <CheckBox Margin="4">Buy some milk</CheckBox>
 ```

--- a/docs/tutorials/todo-list-app/locating-views.md
+++ b/docs/tutorials/todo-list-app/locating-views.md
@@ -50,7 +50,7 @@ The view locator class defines a data template in code which takes a view model 
 
 An instance of `ViewLocator` is present in the **App.axaml** file in the app project (it was added by the solution template). It should look like this:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ToDoList.App"

--- a/docs/tutorials/todo-list-app/main-window-content.md
+++ b/docs/tutorials/todo-list-app/main-window-content.md
@@ -17,7 +17,7 @@ Follow this procedure to change the main window content:
 
 The main window XAML should now look like this:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:ToDoList.ViewModels"
@@ -42,7 +42,7 @@ The main window XAML should now look like this:
 
 This XAML is similar in many ways to the user control XAML you had a lookup on the previous page. Specifically, here you added:
 
-```markup
+```xml
 <Window ... xmlns:views="clr-namespace:ToDoList.Views" ...>
 ```
 
@@ -54,7 +54,7 @@ Any user control that you create will need this kind of mapping, or the Avalonia
 
 The last step sets the content zone of the window to display your new user control view:
 
-```markup
+```xml
 <views:ToDoListView/>
 ```
 

--- a/docs/tutorials/todo-list-app/navigate-views.md
+++ b/docs/tutorials/todo-list-app/navigate-views.md
@@ -71,7 +71,7 @@ Follow this procedure:
 - Locate the **MainWindow.axaml** file in the **/Views** folder.
 - Edit the XAML as shown.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:ToDoList.ViewModels"
@@ -95,7 +95,7 @@ Lastly, to make the add item button call the `AddItem()` method, follow this pro
 * Locate the **ToDoListView.axaml** file in the **/Views** folder.
 * Edit the XAML for the button as shown:
 
-```markup
+```xml
 <Button DockPanel.Dock="Bottom"
         HorizontalAlignment="Stretch"
         HorizontalContentAlignment="Center"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/basics/data/data-binding/compiled-bindings.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/basics/data/data-binding/compiled-bindings.md
@@ -23,7 +23,7 @@ description: CONCEPTS
 
 Для включение компиляции привязок по-умолчанию, в файл проекта необходимо добавить:
 
-```markup
+```xml
 <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 ```
 
@@ -38,7 +38,7 @@ description: CONCEPTS
 Для включение или отключения компиляции привязок, укажите `x:CompileBindings="[True|False]"`. 
 Все вложенные элементы унаследуют данное свойство, однако вы можете переопределить его для них:
 
-```markup
+```xml
 <!-- Set DataType and enable compiled bindings -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -65,7 +65,7 @@ description: CONCEPTS
 Если вы не хотите использовать компилируемые привязки для всех вложенных элементов, то можно использовать `CompiledBinding` вмест `Binding`.
 Вам необходимо указывать `DataType`, но вы можете не указывать `x:CompileBindings="True"`.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -92,7 +92,7 @@ description: CONCEPTS
 Если в основном элементе у вас указана компиляция привязок (через `x:CompileBindings="True"`),
 а вам требуется использовать рефлексиб в силу разных причин, то замените `Binding` на `ReflectionBinding`, как в примере ниже:
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -118,7 +118,7 @@ description: CONCEPTS
 
 Иногда невозможно автоматически определить тип привязки. В этом случае, вам необходимо указать его явно:
 
-```markup
+```xml
 <ItemsRepeater ItemsSource="{Binding MyItems}">
 <ItemsRepeater.ItemTemplate>
     <DataTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/basics/data/data-binding/data-binding-syntax.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/basics/data/data-binding/data-binding-syntax.md
@@ -46,14 +46,14 @@ import DataBindingModeDiagram from '/img/basics/data-binding/data-binding-syntax
 Например, если источником данных указано свойство `Student`, 
 а объект, возвращаемый этим свойством, имеет свойство `Name`, то мы можем привязаться к нему, как указано ниже:
 
-```markup
+```xml
 <TextBlock Text="{Binding Student.Name}"/>
 ```
 
 Если источких данных представлен в виде массика или списка (с индексом), 
 то вы можете указать конкретный индекс, как показана в примере ниже:
 
-```markup
+```xml
 <TextBlock Text="{Binding Students[0].Name}"/>
 ```
 
@@ -76,7 +76,7 @@ import DataBindingModeDiagram from '/img/basics/data-binding/data-binding-syntax
 
 Пример:
 
-```markup
+```xml
 <TextBlock Text="{Binding Name, Mode=OneTime}">
 ```
 
@@ -118,20 +118,20 @@ import DataBindingModeDiagram from '/img/basics/data-binding/data-binding-syntax
 
 Пример с обратной косой чертой:
 
-```markup
+```xml
 <TextBlock Text="{Binding FloatValue, StringFormat=\{0:0.0\}}" />
 ```
 
 Однако, если ваш шаблон начинается с нуля, то вам не требуется экранирование.
 Кроме того, если ваш шаблон надо заключать в одинарные кавычки, если он содержит пробелы.
 
-```markup
+```xml
 <TextBlock Text="{Binding Animals.Count, StringFormat='I have {0} animals.'}" />
 ```
 
 Обратите внимание, что если ваш шаблон начинается с привязанного значения, то вы обязаны его экранировать:
 
-```markup
+```xml
 <TextBlock Text="{Binding Animals.Count, 
                                 StringFormat='{}{0} animals live in the farm.'}" />
 ```

--- a/i18n/ru/docusaurus-plugin-content-docs/current/basics/user-interface/building-layouts/alignment-margins-and-padding.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/basics/user-interface/building-layouts/alignment-margins-and-padding.md
@@ -20,7 +20,7 @@ At first glance, the `Button` elements in this illustration may appear to be pla
 
 The following example describes how to create the layout in the preceding illustration. A `Border` element encapsulates a parent `StackPanel`, with a `Padding` value of 15 device independent pixels. This accounts for the narrow `LightBlue` band that surrounds the child `StackPanel`. Child elements of the `StackPanel` are used to illustrate each of the various positioning properties that are detailed in this topic. Three `Button` elements are used to demonstrate both the `Margin` and `HorizontalAlignment` properties.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication2.MainWindow"
@@ -69,7 +69,7 @@ The `HorizontalAlignment` property declares the horizontal alignment characteris
 
 The following example shows how to apply the `HorizontalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors.
 
-```markup
+```xml
 <Button HorizontalAlignment="Left">Button 1 (Left)</Button>
 <Button HorizontalAlignment="Right">Button 2 (Right)</Button>
 <Button HorizontalAlignment="Center">Button 3 (Center)</Button>
@@ -93,7 +93,7 @@ The `VerticalAlignment` property describes the vertical alignment characteristic
 
 The following example shows how to apply the `VerticalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors. For purposes of this sample, a `Grid` element with visible gridlines is used as the parent, to better illustrate the layout behavior of each property value.
 
-```markup
+```xml
 <Border Background="LightBlue" BorderBrush="Black" BorderThickness="2" Padding="15">
     <Grid Background="White" ShowGridLines="True">
       <Grid.RowDefinitions>
@@ -128,7 +128,7 @@ A non-zero margin applies space outside the element's `Bounds`.
 
 The following example shows how to apply uniform margins around a group of `Button` elements. The `Button` elements are spaced evenly with a ten-pixel margin buffer in each direction.
 
-```markup
+```xml
 <Button Margin="10">Button 7</Button>
 <Button Margin="10">Button 8</Button>
 <Button Margin="10">Button 9</Button>
@@ -136,7 +136,7 @@ The following example shows how to apply uniform margins around a group of `Butt
 
 In many instances, a uniform margin is not appropriate. In these cases, non-uniform spacing can be applied. The following example shows how to apply non-uniform margin spacing to child elements. Margins are described in this order: left, top, right, bottom.
 
-```markup
+```xml
 <Button Margin="0,10,0,10">Button 1</Button>
 <Button Margin="0,10,0,10">Button 2</Button>
 <Button Margin="0,10,0,10">Button 3</Button>
@@ -148,7 +148,7 @@ Padding is similar to `Margin` in most respects. The Padding property is exposed
 
 The following example shows how to apply `Padding` to a parent `Border` element.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"
@@ -162,7 +162,7 @@ The following example shows how to apply `Padding` to a parent `Border` element.
 
 The following example demonstrates each of the concepts that are detailed in this topic. Building on the infrastructure found in the first sample in this topic, this example adds a`Grid` element as a child of the `Border` in the first sample. `Padding` is applied to the parent `Border` element. The`Grid` is used to partition space between three child `StackPanel` elements. `Button` elements are again used to show the various effects of `Margin` and `HorizontalAlignment`. `TextBlock` elements are added to each `ColumnDefinition` to better define the various properties applied to the `Button` elements in each column.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/basics/user-interface/introduction-to-xaml.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/basics/user-interface/introduction-to-xaml.md
@@ -21,7 +21,7 @@ The file extension for XAML files used elsewhere is `.xaml` but due to technical
 
 A typical Avalonia XAML file looks like this:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -50,7 +50,7 @@ A UI can be composed of several different types of control. To learn more about 
 
 For example, this XAML adds a button to the content of a window:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button>Hello World!</Button>
@@ -67,7 +67,7 @@ The XML elements that represent controls have attributes corresponding to contro
 
 For example, to specify a blue background for a button control, you add the `Background` attribute set the value to `"Blue"`. Like this:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Background="Blue">Hello World!</Button>
@@ -78,7 +78,7 @@ For example, to specify a blue background for a button control, you add the `Bac
 
 You might have noticed that the button in the above sample has its content (the 'Hello World' string) placed between its opening and closing tags. As an alternative, you can set the content attribute, as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="Hello World!"/>
@@ -91,7 +91,7 @@ This behaviour is specific to the content of an _Avalonia UI_ control.
 
 You will often use the _Avalonia UI_ binding system to link a control property to an underlying object. The link is declared using the `{Binding}` mark-up extension. For example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="{Binding Greeting}"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/basics/user-interface/styling/style-classes.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/basics/user-interface/styling/style-classes.md
@@ -9,7 +9,7 @@ You can assign an _Avalonia UI_ control one or more style classes, and use these
 
 For example, this button has both the `h1` and `blue` style classes applied:
 
-```markup
+```xml
 <Button Classes="h1 blue"/>
 ```
 
@@ -21,7 +21,7 @@ For example `:pointerover` pseudo class indicates that the pointer input is curr
 
 This is an example of  a `:pointerover` pseudo class selector:
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Border:pointerover">
@@ -36,7 +36,7 @@ This is an example of  a `:pointerover` pseudo class selector:
 
 In this example, the pseudo class selector changes properties inside a control template:
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Button:pressed /template/ ContentPresenter">
@@ -57,7 +57,7 @@ For more detail about pseudo classes, see the reference [here](../../../referenc
 
 If you need to add or remove a class using a bound condition, then you can use following special syntax:
 
-```markup
+```xml
 <Button Classes.accent="{Binding IsSpecial}" />
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/input/hotkeys.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/input/hotkeys.md
@@ -6,7 +6,7 @@ description: CONCEPTS - Input
 
 Various Controls that implement `ICommandSource` have a `HotKey` property that you can set or bind to. Pressing the hotkey will execute the command [bound](../../basics/user-interface/adding-interactivity#commands) to the Control.
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem x:Name="SaveMenuItem" Header="_Save" Command="{Binding SaveCommand}" HotKey="Ctrl+S"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/input/routed-events.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/input/routed-events.md
@@ -69,7 +69,7 @@ public class SampleControl: Control
 
 To add a handler for an event using XAML, you declare the event name as an attribute on the element that is an event listener. The value of the attribute is the name of your implemented handler method, which must exist in the class of the code-behind file.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -104,7 +104,7 @@ Each of the above considerations is discussed in a separate section of this topi
 
 To add an event handler in XAML, you simply add the event name to an element as an attribute and set the attribute value as the name of the event handler that implements an appropriate delegate, as in the following example.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -201,7 +201,7 @@ The Avalonia input system uses attached events extensively. However, nearly all 
 
 Another syntax usage that resembles _typename_._eventname_ attached event syntax but is not strictly speaking an attached event usage is when you attach handlers for routed events that are raised by child elements. You attach the handlers to a common parent, to take advantage of event routing, even though the common parent might not have the relevant routed event as a member. Consider this example again:
 
-```markup
+```xml
 <Border Height="50" Width="300">
   <StackPanel Orientation="Horizontal" Button.Click="CommonClickHandler">
     <Button Name="YesButton">Yes</Button>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/reactiveui/binding-to-sorted-filtered-list.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/reactiveui/binding-to-sorted-filtered-list.md
@@ -43,7 +43,7 @@ public MainWindowViewModel(){
 
 Now that the `_sourceCache` is created and populated and the `ReadOnlyObservableCollection<T>` is created and bound we can go into our view and bind exactly the way we normally would with an `ObservableCollection<T>`
 
-```markup
+```xml
     <Design.DataContext>
         <vm:MainWindowViewModel/>
     </Design.DataContext>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/reactiveui/data-persistence.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/reactiveui/data-persistence.md
@@ -54,7 +54,7 @@ public class MainWindow : ReactiveWindow<MainViewModel>
 
 The XAML of our `ReactiveWindow` will look like as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="ReactiveUI.Samples.Suspension.MainWindow"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/reactiveui/routing.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/reactiveui/routing.md
@@ -38,7 +38,7 @@ namespace RoutingExample
 
 **FirstView.xaml**
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="RoutingExample.FirstView">
@@ -110,7 +110,7 @@ namespace RoutingExample
 
 Now we need to place the `RoutedViewHost` XAML control to our main view. It will resolve and embed appropriate views for the view models based on the supplied `IViewLocator` implementation and the passed `Router` instance of type `RoutingState`. Note, that you need to import `rxui` namespace for `RoutedViewHost` to work. Additionally, you can override animations that are played when `RoutedViewHost` changes a view — simply override `RoutedViewHost.PageTransition` property in XAML.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:rxui="http://reactiveui.net"
         xmlns:app="clr-namespace:RoutingExample"
@@ -155,7 +155,7 @@ Now we need to place the `RoutedViewHost` XAML control to our main view. It will
 
 To disable the animations, simply set the `RoutedViewHost.PageTransition` property to `{x:Null}`, like so:
 
-```markup
+```xml
 <rxui:RoutedViewHost Grid.Row="0" Router="{Binding Router}" PageTransition="{x:Null}">
     <rxui:RoutedViewHost.DefaultContent>
         <TextBlock Text="Default content"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/reactiveui/view-activation.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/reactiveui/view-activation.md
@@ -35,7 +35,7 @@ public class ViewModel : ReactiveObject, IActivatableViewModel
 
 This is the UI for the view model you see above.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         Background="#f0f0f0" FontFamily="Ubuntu"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/content-template.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/content-template.md
@@ -17,7 +17,7 @@ One way to use a data template is to set the `ContentTemplate` property of a con
 
 You can define a data template (for no particular class) using the `DataTemplate` tag, a composition of built-in controls, and some bindings. For example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/creating-data-templates-in-code.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/creating-data-templates-in-code.md
@@ -18,7 +18,7 @@ var template = new FuncDataTemplate<Student>((value, namescope) =>
 
 Which is equivalent to the XAML:
 
-```markup
+```xml
 <DataTemplate DataType="{x:Type local:Student}">
     <TextBlock Text="{Binding FirstName}"/>
 </DataTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/data-templates-collection.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/data-templates-collection.md
@@ -14,7 +14,7 @@ Data templates are matched by type: a match occurs when the class of the object 
 
 So you can modify the previous sample to use the `DataTemplates` collection, as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/data-templates.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/data-templates.md
@@ -16,7 +16,7 @@ The concept of the zones of an _Avalonia UI_ control is discussed [here](../layo
 
 For example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -34,7 +34,7 @@ The window displays the button - in this case centred both horizontally (specifi
 
 And if you put a string into the window content zone, for example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -67,7 +67,7 @@ namespace MySample
 
 And the XML namespace `local` defined as the `MySample` namespace (from above), you can define a student object in the content zone of the window; as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="using:MySample"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/implement-idatatemplate.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/implement-idatatemplate.md
@@ -34,8 +34,8 @@ public class MyDataTemplate : IDataTemplate
 
 You can now use the class `MyDataTemplate` in your view, like this:
 
-```markup
-xmlns:dataTemplates="using:MyApp.DataTemplates" -->
+```xml
+<!-- xmlns:dataTemplates="using:MyApp.DataTemplates" -->
 ...
 <ContentControl Content="{Binding MyContent}">
 	<ContentControl.ContentTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/reusing-data-templates.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/concepts/templates/reusing-data-templates.md
@@ -31,7 +31,7 @@ namespace MySample
 
 And in the app.axaml file, add a data template for the type `Teacher`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:MySample"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/deployment/macOS.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/deployment/macOS.md
@@ -94,7 +94,7 @@ More documentation on possible `Info.plist` keys is available [here](https://dev
 
 If at any point the tooling gives you an error that your assets file doesn't have a target for `osx-64`, add the following [runtime identifiers](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) to the top `<PropertyGroup>` in your `.csproj`:
 
-```markup
+```xml
 <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
 ```
 
@@ -114,7 +114,7 @@ The file that is actually executed by macOS when starting your `.app` bundle wil
 
 * Add the following to your `.csproj` file:
 
-```markup
+```xml
 <PropertyGroup>
   <UseAppHost>true</UseAppHost>
 </PropertyGroup>
@@ -134,7 +134,7 @@ It is recommended that you target `net6-macos`, which will handle package genera
 
 You'll first have to add the project as a `PackageReference` in your project. Add it to your project via NuGet package manager or by adding the following line to your `.csproj` file:
 
-```markup
+```xml
 <PackageReference Include="Dotnet.Bundle" Version="*" />
 ```
 
@@ -159,7 +159,7 @@ dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-x64 -p:CFBundleDisplayName=
 
 Instead of specifying `CFBundleDisplayName`, etc., on the command line, you can also specify them in your project file:
 
-```markup
+```xml
 <PropertyGroup>
     <CFBundleName>AppName</CFBundleName> <!-- Also defines .app file name -->
     <CFBundleDisplayName>MyBestThingEver</CFBundleDisplayName>
@@ -520,7 +520,7 @@ When upload succeeds - you will see your package in App Store Connect.
 
 This means that your application most likely does not specify a menu. On startup, Avalonia creates the default menu items for an application and automatically adds the _About Avalonia_ item when no menu has been configured. This can be resolved by adding one to your `App.xaml`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:RoadCaptain.App.RouteBuilder"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/wpf/datatemplates.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/wpf/datatemplates.md
@@ -11,7 +11,7 @@ description: GUIDES - WPF Conversion
 
 К примеру, указанный ниже код, добавит шаблон данных для отображения данных класса `MyViewModel`:
 
-```markup
+```xml
 <UserControl xmlns:viewmodels="using:MyApp.ViewModels"
              x:DataType="viewmodels:ControlViewModel">
     <UserControl.DataTemplates>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/wpf/grid.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/wpf/grid.md
@@ -2,7 +2,7 @@
 
 В Avalonia, можно указать настройки строк и столбцов через строки, избегая избыточного синтаксиса WPF:
 
-```markup
+```xml
 <Grid ColumnDefinitions="Auto,*,32" RowDefinitions="*,Auto">
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/wpf/styling.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/wpf/styling.md
@@ -11,7 +11,7 @@
 
 Нижеуказанный код показывает, как использовать CSS-подобный стиль в `UserControl`.
 
-```markup
+```xml
 <UserControl>
     <UserControl.Styles>
         <!-- Make TextBlocks with the h1 style class have a font size of 24 points -->

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/custom-controls/how-to-create-attached-properties.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/custom-controls/how-to-create-attached-properties.md
@@ -121,7 +121,7 @@ In the verify method we utilize the routed event system to attach a new handler.
 
 This example UI shows how to use the attached property. After making the namespace known to the XAML compiler it can be used by qualifying it with a dot. Then bindings can be used.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:MyApp.Behaviors"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/custom-controls/how-to-create-templated-controls.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/custom-controls/how-to-create-templated-controls.md
@@ -10,7 +10,7 @@ title: How To Create Templated Controls
 
 When you're creating a control template and you want to bind to the templated parent you can use:
 
-```markup
+```xml
 <TextBlock Name="tb" Text="{TemplateBinding Caption}"/>
 
 <!-- Which is the same as -->
@@ -21,7 +21,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
 
 1.  `TemplateBinding` accepts only a single property rather than a property path, so if you want to bind using a property path you must use the second syntax:
 
-    ```markup
+    ```xml
     <!-- This WON'T work as TemplateBinding only accepts single properties -->
     <TextBlock Name="tb" Text="{TemplateBinding Caption.Length}"/>
 
@@ -35,7 +35,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
     ```
 3. `TemplateBinding` can only be used on `IStyledElement`.
 
-```markup
+```xml
 <!-- This WON'T work as GeometryDrawing is not a IStyledElement. -->
 <GeometryDrawing Brush="{TemplateBinding Foreground}"/>
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/binding-to-controls.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/binding-to-controls.md
@@ -16,7 +16,7 @@ Note that this technique does not use a data context at all. When you do this, y
 
 If you want to bind to a property on another named control, you can use the control name prefixed by a `#` character.
 
-```markup
+```xml
 <TextBox Name="other">
 
 <!-- Binds to the Text property of the "other" control -->
@@ -25,7 +25,7 @@ If you want to bind to a property on another named control, you can use the cont
 
 This is the equivalent to the long-form binding that will be familiar to WPF and UWP users:
 
-```markup
+```xml
 <TextBox Name="other">
 <TextBlock Text="{Binding Text, ElementName=other}"/>
 ```
@@ -36,7 +36,7 @@ _Avalonia UI_ supports both syntaxes.
 
 You can bind to the (logical control tree) parent of the target using the `$parent` syntax:
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <TextBlock Text="{Binding $parent.Tag}"/>
 </Border>
@@ -44,7 +44,7 @@ You can bind to the (logical control tree) parent of the target using the `$pare
 
 Or to any level of ancestor by using an index with the `$parent` syntax:
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Border>
     <TextBlock Text="{Binding $parent[1].Tag}"/>
@@ -56,7 +56,7 @@ The index is zero based so `$parent[0]` is equivalent to `$parent`.
 
 You can also bind to the closest ancestor of a given type, like this:
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Decorator>
     <TextBlock Text="{Binding $parent[Border].Tag}"/>
@@ -66,7 +66,7 @@ You can also bind to the closest ancestor of a given type, like this:
 
 Finally, you can combine the index and the type:
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Border>
     <Decorator>
@@ -78,7 +78,7 @@ Finally, you can combine the index and the type:
 
 If you need to include a XAML namespace in the ancestor type, you separate the namespace and class using a colon, like this:
 
-```markup
+```xml
 <local:MyControl Tag="Hello World!">
   <Decorator>
     <TextBlock Text="{Binding $parent[local:MyControl].Tag}"/>
@@ -88,7 +88,7 @@ If you need to include a XAML namespace in the ancestor type, you separate the n
 
 'To access a property of a parent's `DataContext` it will be necessary to cast it with a casting expression `(vm:MyUserControlViewModel)DataContext` to its actual type. Otherwise `DataContext` would be considered as of type `object` and accessing a custom property would result in an compile-time error.
 
-```markup
+```xml
 <local:MyControl Tag="Hello World!">
   <Decorator>
     <TextBlock Text="{Binding $parent[local:MyControl].((vm:MyUserControlViewModel)DataContext).CustomProperty}"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-tabs.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-tabs.md
@@ -38,7 +38,7 @@ The `TabStrip` header content is defined by ItemTemplate property, while `TabIte
 
 Finally create a `TabControl` and bind its `ItemsSource` property to the DataContext.
 
-```markup
+```xml
 <TabControl ItemsSource="{Binding}">
     <TabControl.ItemTemplate>
       <DataTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-a-command-with-reactiveui.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-a-command-with-reactiveui.md
@@ -79,7 +79,7 @@ When the control bound to the reactive command is activated (in this example: wh
 
 You will often need to pass an argument to the reactive command that is bound to a control. You can achieve this using the `CommandParameter` attribute in the XAML. For example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
    ...
    <StackPanel Margin="20">
@@ -114,7 +114,7 @@ Note that no type conversion is carried out on the `CommandParameter` attribute,
 
 For example to pass an integer parameter:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:sys="clr-namespace:System;assembly=mscorlib">
  ...   

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-a-task-result.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-a-task-result.md
@@ -26,7 +26,7 @@ private async Task<string> GetTextAsync()
 
 You can bind to the result in the following way:
 
-```markup
+```xml
 <TextBlock Text="{Binding MyAsyncText^, FallbackValue='Wait a second'}" />
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-an-observable.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-an-observable.md
@@ -14,6 +14,6 @@ You can subscribe to the result of a task or an observable by using the `^` stre
 
 For example if `DataContext.Name` is an `IObservable<string>` then the following example will bind to the length of each string produced by the observable as each value is produced
 
-```markup
+```xml
 <TextBlock Text="{Binding Name^.Length}"/>
 ```

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-create-a-custom-data-binding-converter.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-create-a-custom-data-binding-converter.md
@@ -18,7 +18,7 @@ As the `IValueConverter` interface was not available in .NET standard 2.0, Avalo
 
 You must reference a custom converter in some resources before it can be used. This can be at any level in your application. In this example, the custom converter `myConverter` is referenced in the window resources:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:ExampleApp;assembly=ExampleApp">
@@ -35,7 +35,7 @@ You must reference a custom converter in some resources before it can be used. T
 
 This example data binding converter can convert text to specific case from a parameter:
 
-```markup
+```xml
 <TextBlock Text="{Binding TheContent, 
     Converter={StaticResource textCaseConverter},
     ConverterParameter=lower}" />

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/graphics-and-animations.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/graphics-and-animations.md
@@ -22,7 +22,7 @@ Avalonia introduces an extensive, scalable, and flexible set of graphics feature
 
 Avalonia provides a library of common vector-drawn 2D shapes such as `Ellipse`, `Line`, `Path`, `Polygon` and `Rectangle`.
 
-```markup
+```xml
 <Canvas Background="Yellow" Width="300" Height="400">
     <Rectangle Fill="Blue" Width="63" Height="41" Canvas.Left="40" Canvas.Top="31">
         <Rectangle.OpacityMask>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/keyframe-animations.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/keyframe-animations.md
@@ -75,7 +75,7 @@ The animation runs as soon as the rectangle control is loaded and can be selecte
 
 This example shows you how to animate two properties on the same timeline.
 
-```markup
+```xml
 <Window.Styles>
     <Style Selector="Rectangle.red">
       <Setter Property="Fill" Value="Red"/>
@@ -103,7 +103,7 @@ The red rectangle is faded-in and rotated at the same time.
 
 You can add a delay to the start of an animation by setting the delay attribute of the animation element. For example:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"> 
     ...
@@ -170,7 +170,7 @@ An easing function defines how a property is varied over time during an animatio
 
 The default easing function is linear (above left), but you use another pattern by setting the name of the desired function in the easing attribute. For example to use the 'bounce ease in' function (above right):
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"
            Easing="BounceEaseIn"> 
@@ -184,7 +184,7 @@ For a full list of the _Avalonia UI_ easing functions, see the reference [here](
 
 You can also add your own custom easing function class like this:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1">
     <Animation.Easing>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/page-transitions/page-slide-transition.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/page-transitions/page-slide-transition.md
@@ -7,7 +7,7 @@ title: Page Slide Transition
 
 The page slide transition moves the old page out of view, and the new page into view, for the given duration. You can specify the slide direction using the orientation property (default horizontal).
 
-```markup title='XAML'
+```xml title='XAML'
 <PageSlide Duration="0:00:00.500" Orientation="Vertical" />
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/transitions.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/transitions.md
@@ -8,7 +8,7 @@ title: How To Use Transitions
 
 Transitions in Avalonia are also heavily inspired by CSS Animations. They listen to any changes in target property's value and subsequently animates the change according to its parameters. They can be defined on any `Control` via `Transitions` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -37,7 +37,7 @@ The above example will listen to changes in the `Rectangle`'s `Opacity` property
 
 Transitions can also be defined in any style by using a `Setter` with `Transitions` as the target property and encapsulating them in a `Transitions` object, like so:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -90,7 +90,7 @@ The following transition types are available. The correct type must be used depe
 
 Render transforms applied to controls using CSS-like syntax can be transitioned. The following example shows a Border which rotates 45 degrees when the pointer is hovered over it:
 
-```markup title='XAML'
+```xml title='XAML'
 <Border Width="100" Height="100" Background="Red">
     <Border.Styles>
         <Style Selector="Border">

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/implementation-guides/code-behind.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/implementation-guides/code-behind.md
@@ -40,7 +40,7 @@ namespace AvaloniaApplication1.Views
 
 Notice that this class name is the same as name of the XAML file, and is also referenced in the `x:Class` attribute of the window element.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:AvaloniaApplication1.ViewModels"
@@ -68,7 +68,7 @@ To do this you will first need a reference to a control. Your code will use find
 
 In this example, the button in the XAML has the name attribute defined:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication5.MainWindow">
@@ -94,7 +94,7 @@ Any useful application will require you to implement some action! When you use t
 
 You write event handlers as methods in the code-behind file, and then reference them in the XAML with an event attribute. For example to add a handler for a button click:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/implementation-guides/ide-support.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/implementation-guides/ide-support.md
@@ -39,7 +39,7 @@ With the namespace added, the following design-time properties become available:
 
 The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to the control being previewed.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -53,7 +53,7 @@ The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to 
 
 The `d:DataContext` property applies a `DataContext` only at design-time. It is recommended that you use this property in conjunction with the `{x:Static}` directive to reference a static property in one of your assemblies:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -81,7 +81,7 @@ namespace My.Namespace
 
 Alternatively you can use `Design.DataContext` attached property. As well as `Design.Width` and `Design.Height`.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/platforms/rpi/running-on-raspbian-lite-via-drm.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/platforms/rpi/running-on-raspbian-lite-via-drm.md
@@ -89,7 +89,7 @@ When we work via FrameBuffer there are no windows, so we need a separate view (U
 
 `MainView` will be our app base in which we develop our UI:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -112,7 +112,7 @@ When we work via FrameBuffer there are no windows, so we need a separate view (U
 
 Now create a new UserControl with name `MainSingleView` and host the `MainView`:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -128,7 +128,7 @@ Now create a new UserControl with name `MainSingleView` and host the `MainView`:
 
 Also change the `MainWindow.axaml` to host the `MainView` inside:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/styles-and-resources/how-to-use-included-styles.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/styles-and-resources/how-to-use-included-styles.md
@@ -11,7 +11,7 @@ This guide shows you how to share styles from a separate styles file (that is in
 
 To do this, you define styles in a new XAML file. Here, the root element must then be either a `Style` or `Styles` element. For example:
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="TextBlock.h1">
@@ -34,7 +34,7 @@ To use the styles defined in a separate file, you must reference it using a `Sty
 
 For example, to use styles defined in a file `AppStyles.axaml` (saved in the folder `/Styles`), you could write a a `StyleInclude` element in the window like this:
 
-```markup
+```xml
 <Window ... >
     <Window.Styles>
         <StyleInclude Source="/Styles/AppStyles.axaml" />

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/styles-and-resources/property-setters.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/styles-and-resources/property-setters.md
@@ -13,14 +13,14 @@ The setters in a style define what properties will be changed after _Avalonia UI
 
 For example:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="24"/>
 <Setter Property="Padding" Value="4 2 0 4"/>
 ```
 
 You can also use a long-form syntax to set a control property to an object with several properties set, like this:
 
-```markup
+```xml
 <Setter Property="MyProperty">
    <MyObject Property1="My Value" Property2="999"/>
 </Setter>
@@ -28,7 +28,7 @@ You can also use a long-form syntax to set a control property to an object with 
 
 A style can also set properties using bindings. After the usual selection process, this causes _Avalonia UI_ to use a value from data context of the target control. For example, the setter can be defined like this:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="{Binding SelectedFontSize}"/>
 ```
 
@@ -60,7 +60,7 @@ Note that the `Setter` creates a single instance of `Value` which will be applie
 
 Also note that bindings on an object defined in a setter value will not have access to the target control's data context. This is because there may be multiple target controls. This scenario may arise with a style defined like this:
 
-```markup
+```xml
 <Style Selector="local|MyControl">
   <Setter Property="MyProperty">
      <MyObject Property1="{Binding MyViewModelProperty}"/>
@@ -72,7 +72,7 @@ This means that in the example above, the binding source for the setter will be 
 
 Note: if you are using compiled bindings, you need to explicitly set the data type of the binding source in the `<Style>` element:
 
-```markup
+```xml
 <Style Selector="MyControl" x:DataType="MyViewModelClass">
   <Setter Property="ControlProperty" Value="{Binding MyViewModelProperty}" />
 </Style>
@@ -86,7 +86,7 @@ For more information about compiled bindings, see here. --> TO DO
 
 As previously described here, when you use a setter without a **data template**, a single instance of the setter value is created and shared across all matching controls. To change the value depending on a data template, you place the target control inside a template element, like this:
 
-```markup
+```xml
 <Style Selector="Border.empty">
   <Setter Property="Child">
     <Template>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/styles-and-resources/troubleshooting.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/styles-and-resources/troubleshooting.md
@@ -24,20 +24,20 @@ Check whether you have used a child selector where there are no children to matc
 
 Styles are applied in order of declaration. If there are multiple style files included that target the same control property, the last style included will override the previous ones. For example:
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Green" />
 </Style>
 ```
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Blue" />
     <Style Property="FontSize" Value="16" />
 </Style>
 ```
 
-```markup
+```xml
 <StyleInclude Source="Style1.axaml" />
 <StyleInclude Source="Style2.axaml" />
 ```
@@ -48,7 +48,7 @@ Here styles from file **Styles1.axaml** were applied first, so setters in styles
 
 A local value defined directly on a control often has higher priority than any style value. So in this example the text block will have a red foreground:
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Setter Property="Foreground" Value="Green" />
 </Style>
@@ -72,7 +72,7 @@ Some default _Avalonia UI_ styles use local values in their templates instead of
 
 Let's imagine a situation in which you might expect a second style to override previous one, but it doesn't:
 
-```markup
+```xml
 <Style Selector="Border:pointerover">
     <Setter Property="Background" Value="Blue" />
 </Style>
@@ -93,7 +93,7 @@ Visit the Avalonia source code to find the [original templates](https://github.c
 
 The following code example of styles that can be expected to work on top of default styles:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="Red" />
 </Style>
@@ -106,7 +106,7 @@ You might expect the `Button` to be red by default and blue when pointer is over
 
 The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code (old [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) theme and new [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="{DynamicResource ButtonBackground}"/>
     <Setter Property="Template">
@@ -124,7 +124,7 @@ The reason is hidden in the Button's template. You can find the default template
 
 The actual background is rendered by a `ContentPresenter`, which in the default is bound to the Buttons `Background` property. However in the pointer-over state the selector is directly applying the background to the `ContentPresenter (Button:pointerover /template/ ContentPresenter#PART_ContentPresenter`) That's why when our setter was ignored in the previous code example. The corrected code should target content presenter directly as well:
 
-```markup
+```xml
 <!-- Here #PART_ContentPresenter name selector is not necessary, but was added to have more specific style -->
 <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Blue" />

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/built-in-data-binding-converters.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/built-in-data-binding-converters.md
@@ -21,7 +21,7 @@ _Avalonia UI_ includes a number of built-in data binding converters for common s
 
 Ниже приведен пример блока текста, когда его привязанное значение равно `false`:
 
-```markup
+```xml
 <StackPanel>
   <TextBox Name="input" IsEnabled="{Binding AllowInput}"/>
   <TextBlock IsVisible="{Binding !AllowInput}">Ввод запрещен</TextBlock>
@@ -32,7 +32,7 @@ _Avalonia UI_ includes a number of built-in data binding converters for common s
 
 Целочисленное `0` преобразуется в `false`, а все остальные целочисленные в `true`. Вы можете использовать оператор отрицания, чтобы вывести сообщение, когда коллекция пуста, к примеру:
 
-```markup
+```xml
 <Panel>
   <ListBox ItemsSource="{Binding Items}"/>
   <TextBlock IsVisible="{Binding !Items.Count}">No results found</TextBlock>
@@ -42,7 +42,7 @@ _Avalonia UI_ includes a number of built-in data binding converters for common s
 
 Вы можете использовать такаой способ, чтобы скрыть элемент, если коллексция пуста (кол-во элементов `0`):
 
-```markup
+```xml
 <Panel>
   <ListBox ItemsSource="{Binding Items}" IsVisible="{Binding !!Items.Count}"/>
 </Panel>
@@ -52,7 +52,7 @@ _Avalonia UI_ includes a number of built-in data binding converters for common s
 
 В примере ниже, элемент `TextBlock` будет скрыт, если значение привязанных данных равно `null` или пустое:
 
-```markup
+```xml
 <TextBlock Text="{Binding MyText}"
            IsVisible="{Binding MyText, 
                        Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
@@ -61,7 +61,7 @@ _Avalonia UI_ includes a number of built-in data binding converters for common s
 А этот пример скроет элемент `ContentControl`, если значение привязанных данных равно `null`:
 And this example will hide the content control if the bound object is null or empty:
 
-```markup
+```xml
 <ContentControl Content="{Binding MyContent}"
                 IsVisible="{Binding MyContent, 
                             Converter={x:Static ObjectConverters.IsNotNull}}"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/checkbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/checkbox.md
@@ -24,7 +24,7 @@ You will probably use these properties most often:
 
 This is an example of two-state check boxes:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -45,7 +45,7 @@ Looks like this when running on Windows:
 
 This is an example of a three-state checkbox:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/combobox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/combobox.md
@@ -34,7 +34,7 @@ You will probably use these properties most often:
 
 This is basic example with text items has a limit set on the drop-down list height.
 
-```markup
+```xml
 <StackPanel Margin="20">
   <ComboBox SelectedIndex="0" MaxDropDownHeight="100">
     <ComboBoxItem>Text Item 1</ComboBoxItem>
@@ -54,7 +54,7 @@ This is basic example with text items has a limit set on the drop-down list heig
 
 This example uses a composed view for each item:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <ComboBox SelectedIndex="0">
     <ComboBoxItem>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/datagrid/README.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/datagrid/README.md
@@ -49,7 +49,7 @@ You must reference the data grid themes to include the additional styles that th
 
 For example:
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
@@ -128,7 +128,7 @@ These examples use the MVVM pattern with data binding to an `ObservableCollectio
 
 Property names from the item class will generally not make good column names. This example adds custom header names to the grid. It also allows column reordering and resizing and disallows the default column sorting option:
 
-```markup
+```xml
 <DataGrid Margin="20" ItemsSource="{Binding People}"
           IsReadOnly="True"
           CanUserReorderColumns="True"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/border.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/border.md
@@ -39,7 +39,7 @@ If you use the four value pattern; you must provide all four values, even if one
 
 This example adds some border controls to create a 'pod' look in the layout:
 
-```markup
+```xml
 <StackPanel>
   <Border Background="Gainsboro"
         BorderBrush="Black"
@@ -86,7 +86,7 @@ If both offset values are set to zero, the shadow is placed behind the element, 
 
 This is an example of a drop-shadow:
 
-```markup
+```xml
 <<StackPanel>
   <Border Background="Gainsboro"
         BorderBrush="Black"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/calendar/README.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/calendar/README.md
@@ -23,7 +23,7 @@ You will probably use these properties most often:
 
 This is a basic calendar allowing a single date selection. The calendar's selected date is shown in the text block below.
 
-```markup
+```xml
 <StackPanel Margin="20">
   <Calendar x:Name="calendar" SelectionMode="MultipleRange"/>
   <TextBlock Margin="20" 
@@ -35,7 +35,7 @@ This is a basic calendar allowing a single date selection. The calendar's select
 
 This example allows multiple range selections:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <Calendar SelectionMode="MultipleRange"/>
 </StackPanel>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/tabcontrol.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/tabcontrol.md
@@ -23,7 +23,7 @@ If you only need the function of the tab headers part of this control, consider 
 
 This is simple tab example. The tab content is just some text: 
 
-```markup
+```xml
 <TabControl Margin="5">
   <TabItem Header="Tab 1">
     <TextBlock Margin="5">This is tab 1 content</TextBlock>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/textbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/textbox.md
@@ -18,7 +18,7 @@ You will probably use these properties most often:
 
 This example has a basic one line text box, a password box, and a text-wrapping multiline text box:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5" >Name:</TextBlock>
   <TextBox  Watermark="Enter your name"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/timepicker.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/timepicker.md
@@ -32,7 +32,7 @@ This example shows how to create a time picker for the 24 hour clock, with 20 mi
 
 You can set the time value as an attribute in XAML.  Use a string in the form _Hh:Mm_ where _Hh_ is hours and can be between 0 and 23 and _Mm_ is minutes and can be between 0 and 59.
 
-```markup
+```xml
 <TimePicker SelectedTime="09:15"/>
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/tooltip.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/tooltip.md
@@ -19,7 +19,7 @@ You will probably use these properties most often:
 
 This is a simple text-based tooltip, using default values for the placement and delay properties; this rectangle is placed in a window with larger dimensions:
 
-```markup
+```xml
 <Rectangle Fill="Aqua" Height="200" Width="400"
             ToolTip.Tip="This is a rectangle" />
 ```
@@ -28,7 +28,7 @@ This is a simple text-based tooltip, using default values for the placement and 
 
 To provide a richer presentation for a tooltip, use a `<ToolTip.Tip>` element. For example:
 
-```markup
+```xml
 <Rectangle Fill="Aqua" Height="200" Width="400"
     ToolTip.Placement="Bottom">
     <ToolTip.Tip>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/transitioningcontentcontrol.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/transitioningcontentcontrol.md
@@ -21,7 +21,7 @@ You will probably use these properties most often:
 
 In this example, the view model contains a collection of different images to show them in a slideshow. The following XAML will use the default page transition to change the image (in the data template) whenever the bound `SelectedImage` property changes:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">
@@ -35,7 +35,7 @@ In this example, the view model contains a collection of different images to sho
 
 In this example, a different page transition has been specified to slide the images horizontally:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.PageTransition>
         <PageSlide Orientation="Horizontal" Duration="0:00:00.500" />

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/treedatagrid/README.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/treedatagrid/README.md
@@ -62,7 +62,7 @@ You must reference the data grid themes to include the additional styles that th
 
 For example:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AvaloniaApplication.App">

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/viewbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/viewbox.md
@@ -39,7 +39,7 @@ The values for the `StretchDirecton` property are as follows:
 
 This simple example shows a `Viewbox` scaling up a circle uniformly (both stretch and direction are default).
 
-```markup
+```xml
 <Viewbox Stretch="Uniform" Width="300" Height="300">
    <Ellipse Width="50" Height="50" Fill="CornflowerBlue" />  
 </Viewbox>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/dockpanel.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/dockpanel.md
@@ -37,7 +37,7 @@ You will probably use these properties most often:
 
 Setting the opacity of the orange rectangle to 0.5 demonstrates that there are no overlaps.
 
-```markup
+```xml
 <DockPanel Width="300" Height="300">
     <Rectangle Fill="Red" Height="100" DockPanel.Dock="Top"/>
     <Rectangle Fill="Blue" Width="100" DockPanel.Dock="Left" />

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/flyouts.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/flyouts.md
@@ -30,7 +30,7 @@ Only the button and split button controls support the `Flyout` property. You can
 
 For controls that do not have the `Flyout` property, use the `AttachedFlyout` property like this:
 
-```markup
+```xml
 <Border Background="Red" PointerPressed="Border_PointerPressed">
     <FlyoutBase.AttachedFlyout>
         <Flyout>
@@ -82,7 +82,7 @@ This setting describes how the flyout shows and hides:
 
 You can share flyouts between two or more elements in your app. For example, to share a flyout from the resources collection of a window:
 
-```markup
+```xml
 <Window.Resources>
     <Flyout x:Key="MySharedFlyout">
         <!-- Flyout content here -->
@@ -98,7 +98,7 @@ You can share flyouts between two or more elements in your app. For example, to 
 
 Although flyouts are not themselves controls, their general appearance can be customized by targeting the presenter the `Flyout` uses to display its content. For a normal `Flyout` this is `FlyoutPresenter` and for `MenuFlyout` this is `MenuFlyoutPresenter`. Because flyout presenters are not exposed, special style classes that should pertain to specific flyouts can be passed using the `FlyoutPresenterClasses` property on `FlyoutBase`
 
-```markup
+```xml
 <Style Selector="FlyoutPresenter.mySpecialClass">
     <Setter Property="Background" Value="Red" />
 </Style>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/grid.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/grid.md
@@ -135,7 +135,7 @@ This example shows:
 
 An example of a Grid with 3 equal Rows and 3 Columns with (1 fixed width), (2 grabbing the rest proportionally) would be:
 
-```markup
+```xml
 <Grid ColumnDefinitions="100,1.5*,4*" RowDefinitions="Auto,Auto,Auto"  Margin="4">
   <TextBlock Text="Col0Row0:" Grid.Row="0" Grid.Column="0"/>
   <TextBlock Text="Col0Row1:" Grid.Row="1" Grid.Column="0"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/gridsplitter.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/gridsplitter.md
@@ -23,7 +23,7 @@ To provide any meaningful movement, the direction of travel of the splitter must
 
 This is a column splitter:
 
-```markup
+```xml
 <Grid ColumnDefinitions="*, 4, *">
     <Rectangle Grid.Column="0" Fill="Blue"/>
     <GridSplitter Grid.Column="1" Background="Black" ResizeDirection="Columns"/>
@@ -35,7 +35,7 @@ This is a column splitter:
 
 This is a row splitter:
 
-```markup
+```xml
 <Grid RowDefinitions="*, 4, *">
     <Rectangle Grid.Row="0" Fill="Blue"/>
     <GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/listbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/listbox.md
@@ -41,7 +41,7 @@ The following selection modes are available for the list box:
 
 These values can be combined, for example:
 
-```markup
+```xml
 <ListBox SelectionMode="Multiple,Toggle">
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/maskedtextbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/maskedtextbox.md
@@ -30,7 +30,7 @@ The escape character (backslash) can be used to include a special character as a
 
 This is a basic example:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">International phone number:</TextBlock>
   <MaskedTextBox Mask="(+09) 000 000 0000" />

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/menu.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/menu.md
@@ -35,7 +35,7 @@ You will probably use these properties most often:
 
 This example creates a menu docked at the top edge of a window.
 
-```markup
+```xml
 <Window ...>
     <DockPanel>
     <Menu DockPanel.Dock="Top">
@@ -76,7 +76,7 @@ Once keyboard interaction has been initiated with the Alt key, the user can also
 
 To initiate an action, the command property of a menu item can be bound to an `ICommand` object. The command will be executed when the menu item is clicked or selected with the keyboard. For example:
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem Header="_Open..." Command="{Binding OpenCommand}"/>
@@ -92,7 +92,7 @@ For guidance on how to bind to commands, see [here](../../basics/user-interface/
 
 A menu icon can be displayed by placing an image or a path icon in the `<MenuItem.Icon>` attached property. For example:
 
-```markup
+```xml
 <MenuItem Header="_Edit">
   <MenuItem Header="Copy">
      <MenuItem.Icon>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/numericupdown.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/numericupdown.md
@@ -28,7 +28,7 @@ You will probably use these properties most often:
 
 This is a basic example of a numeric up-down control. There are no limits to the value here:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">Number of items:</TextBlock>
   <NumericUpDown Value="10" />
@@ -45,7 +45,7 @@ Remember to specify a `FormatString` property when you create a custom decimal i
 
 For example:
 
-```markup
+```xml
 <StackPanel Margin="20">  
   <TextBlock Margin="0 5">Opacity:</TextBlock>
   <NumericUpDown Value="0.5" Increment="0.05" 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/panel.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/panel.md
@@ -16,7 +16,7 @@ For a discussion about using other panels, see [here](../../basics/user-interfac
 
 This example uses some 50% opacities to demonstrate that child controls overlap.
 
-```markup
+```xml
 <Panel Height="300" Width="300">
     <Rectangle Fill="Red" Height="100" VerticalAlignment="Top"/>
     <Rectangle Fill="Blue" Opacity="0.5" Width="100" HorizontalAlignment="Right" />

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/refreshcontainer.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/refreshcontainer.md
@@ -11,7 +11,7 @@ The refresh container allows a user to pull down on content or a list of data to
 This example shows hows to use a RefreshContainer with a
 
 _In the axaml file._
-```markup
+```xml
 <RefreshContainer PullDirection="TopToBottom"
                 RefreshRequested="RefreshContainerPage_RefreshRequested">
     <ListBox ItemsSource="{Binding Items}"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/relativepanel.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/relativepanel.md
@@ -48,7 +48,7 @@ You will probably use these properties most often:
 
 This XAML shows how to arrange some child controls in different ways:
 
-```markup
+```xml
 <Border BorderBrush="DarkGray" BorderThickness="1" Width="300" Height="300">
   <RelativePanel >
     <Rectangle x:Name="RedRect" Fill="Red" Height="50" Width="50"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/splitview.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/splitview.md
@@ -38,7 +38,7 @@ The display mode property controls how the pane is drawn in its open and closed 
 
 ## Example
 
-```markup
+```xml
 <SplitView IsPaneOpen="True"
            DisplayMode="Inline"
            OpenPaneLength="300">

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/stackpanel.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/stackpanel.md
@@ -25,7 +25,7 @@ You will probably use these properties most often:
 
 The following XAML shows how to create a vertical stack panel.
 
-```markup
+```xml
 <StackPanel Width="200">
     <Rectangle Fill="Red" Height="50"/>
     <Rectangle Fill="Blue" Height="50"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/styles/style-selector-syntax.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/styles/style-selector-syntax.md
@@ -10,7 +10,7 @@ description: REFERENCE - Styles
 
 
 
-```markup
+```xml
 <Style Selector="Button">
 <Style Selector="local|Button">
 ```
@@ -40,7 +40,7 @@ Note the type of an object is actually determined by looking at its `StyleKey` p
 
 
 
-```markup
+```xml
 <Style Selector="#myButton">
 <Style Selector="Button#myButton">
 ```
@@ -59,7 +59,7 @@ Selects a control by its `Name` attribute, with an added `#` (hash) character pr
 
 
 
-```markup
+```xml
 <Style Selector="Button.large">
 <Style Selector="Button.large.red">
 ```
@@ -101,7 +101,7 @@ For more detail about pseudo classes, see the reference [here](pseudo-classes.md
 
 
 
-```markup
+```xml
 <Style Selector=":is(Button)">
 <Style Selector=":is(local|Button)">
 ```
@@ -124,7 +124,7 @@ INterestingly, this allows you to write very general class-based selectors. As c
 
 
 
-```markup
+```xml
 <Style Selector=":is(Control).margin2">
 <Style Selector=":is(local|Control.margin2)">
 ```
@@ -141,7 +141,7 @@ new Style(x => x.Is(typeof(Control)).Class("margin2"));
 
 
 
-```markup
+```xml
 <Style Selector="StackPanel > Button">
 ```
 
@@ -176,7 +176,7 @@ The selector will match the first button, but not the second. This is because th
 
 
 
-```markup
+```xml
 <Style Selector="StackPanel Button">
 ```
 
@@ -195,7 +195,7 @@ Therefore applying the above selector to the previous XAML sample, both buttons 
 
 
 
-```markup
+```xml
 <Style Selector="Button[IsDefault=true]">
 ```
 
@@ -220,7 +220,7 @@ For example, in the XAML above, the first button will be selected, but not the s
 :::info
 Note: when you use an attached property as a property match, the property name must be wrapped in parentheses. Fro example:
 
-```markup
+```xml
 <Style Selector="TextBlock[(Grid.Row)=0]">
 ```
 :::
@@ -233,7 +233,7 @@ Further note: when you use a property match, the property type must support the 
 
 
 
-```markup
+```xml
 <Style Selector="Button /template/ ContentPresenter">
 ```
 
@@ -252,7 +252,7 @@ In the example above, if a button has a template, then the selector matches sele
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:not(.h1)">
 ```
 
@@ -269,7 +269,7 @@ This function negates the selection in the brackets. In the example above all th
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock, Button">
 ```
 
@@ -286,7 +286,7 @@ You can select any element that matches a comma-separated list of selectors. Any
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-child(2n+3)">
 ```
 
@@ -311,7 +311,7 @@ There is a corresponding selector with a formula that counts from the end of the
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-last-child(2n+3)">
 ```
 
@@ -328,7 +328,7 @@ You can omit the **A** and **n** from the formula in XAML to specify a single po
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-child(3)">
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/add-and-layout-controls.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/add-and-layout-controls.md
@@ -21,7 +21,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - Найдите и откройте файл **MainWindow.axaml**.
 - Внутри элемента `panel`, добавьте XAML кнопки. Содержимое файла должно выглядеть, как показано ниже:
 
-```markup
+```xml
 <Panel>
     <ExperimentalAcrylicBorder IsHitTestVisible="False">
         <ExperimentalAcrylicBorder.Material>
@@ -49,7 +49,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - В него добавьте атрибут `margin` со значением **40**.
 - Добавьте атрибуты `HorizontalAlignment` и `VerticalAlignment` в элемент `button`, как показано ниже:
 
-```markup
+```xml
 <Panel Margin="40">
   <Button Content="Buy Music" 
      HorizontalAlignment="Right" VerticalAlignment="Top" />
@@ -71,7 +71,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - Используйте поиск по страницу, чтобы найти иконку с именем 'store\_microsoft\_regular'. 
 Там должен быть код, похожий на указанный ниже:
 
-```markup
+```xml
 <StreamGeometry x:Key="store_microsoft_regular">M11.5 9.5V13H8V9.5H11.5Z M11.5 17.5V14H8V17.5H11.5Z M16 9.5V13H12.5V9.5H16Z M16 17.5V14H12.5V17.5H16Z M8 6V3.75C8 2.7835 8.7835 2 9.75 2H14.25C15.2165 2 16 2.7835 16 3.75V6H21.25C21.6642 6 22 6.33579 22 6.75V18.25C22 19.7688 20.7688 21 19.25 21H4.75C3.23122 21 2 19.7688 2 18.25V6.75C2 6.33579 2.33579 6 2.75 6H8ZM9.5 3.75V6H14.5V3.75C14.5 3.61193 14.3881 3.5 14.25 3.5H9.75C9.61193 3.5 9.5 3.61193 9.5 3.75ZM3.5 18.25C3.5 18.9404 4.05964 19.5 4.75 19.5H19.25C19.9404 19.5 20.5 18.9404 20.5 18.25V7.5H3.5V18.25Z</StreamGeometry>
 ```
 
@@ -84,7 +84,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - Введите название 'Icons' и нажмите `enter`.
 - Найдите и откройте созданный файл **Icons.axaml**. Его XAML будет выглядеть, как показано ниже:
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -102,7 +102,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 
 Файл `Icons` должен выглядеть примерно так:
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -127,7 +127,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - Найдите и откройте файл **App.axaml**.
 - Добавьте элемент `<StyleInclude>`, как показано ниже:
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.MusicStore/Icons.axaml" />
@@ -141,7 +141,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - Найдите и откройте файл **MainWindow.axaml**.
 - Измените XAML кнопки, как показано ниже:
 
-```markup
+```xml
 <Button HorizontalAlignment="Right" VerticalAlignment="Top">       
     <PathIcon Data="{StaticResource store_microsoft_regular}" /> 
 </Button>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/album-view.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/album-view.md
@@ -23,7 +23,7 @@ import MusicStoreWrapPanelScreenshot from '/img/tutorials/music-store-app/add-co
 - Используйте встроенный поиск браузера, чтобы найти иконку с именем 'music_regular'.
   Ее описание должно быть похоже на указанное ниже:
 
-```markup
+```xml
 <StreamGeometry x:Key="music_regular">M11.5,2.75 C11.5,2.22634895 12.0230228,1.86388952 12.5133347,2.04775015 L18.8913911,4.43943933 C20.1598961,4.91511241 21.0002742,6.1277638 21.0002742,7.48252202 L21.0002742,10.7513533 C21.0002742,11.2750044 20.4772513,11.6374638 19.9869395,11.4536032 L13,8.83332147 L13,17.5 C13,17.5545945 12.9941667,17.6078265 12.9830895,17.6591069 C12.9940859,17.7709636 13,17.884807 13,18 C13,20.2596863 10.7242052,22 8,22 C5.27579485,22 3,20.2596863 3,18 C3,15.7403137 5.27579485,14 8,14 C9.3521238,14 10.5937815,14.428727 11.5015337,15.1368931 L11.5,2.75 Z M8,15.5 C6.02978478,15.5 4.5,16.6698354 4.5,18 C4.5,19.3301646 6.02978478,20.5 8,20.5 C9.97021522,20.5 11.5,19.3301646 11.5,18 C11.5,16.6698354 9.97021522,15.5 8,15.5 Z M13,3.83223733 L13,7.23159672 L19.5002742,9.669116 L19.5002742,7.48252202 C19.5002742,6.75303682 19.0477629,6.10007069 18.3647217,5.84393903 L13,3.83223733 Z</StreamGeometry>
 ```
 
@@ -45,7 +45,7 @@ import MusicStoreWrapPanelScreenshot from '/img/tutorials/music-store-app/add-co
 - Добавьте атрибут `Width="200"` к элементу `<UserControl>`.
 - Замените зону содержимого в XAML, указанным ниже текстом:
 
-```markup
+```xml
 <StackPanel Spacing="5" Width="200">
     <Border CornerRadius="10" ClipToBounds="True">
         <Panel Background="#7FFF22DD">
@@ -136,7 +136,7 @@ public class AlbumViewModel : ViewModelBase
 - Раскройте элемент `<ListBox>`, чтобы у него был начальный и конечный теги.
 - Добавьте в XAML `<ListBox.ItemsPanel>`, как показано ниже:
 
-```markup
+```xml
 <ListBox ItemsSource="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}"
     Background="Transparent" Margin="0 20">
     <ListBox.ItemsPanel>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/creating-a-modern-looking-window.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/creating-a-modern-looking-window.md
@@ -22,7 +22,7 @@ import MusicStoreFullAcrylicWindowScreenshot from '/img/tutorials/music-store-ap
 - В нем, у элемента `<Application>`,
 поменяйте атрибут `RequestedThemeVariant` со значения "Default" на "Dark".
 
-```markup
+```xml
 <Application ...
     RequestedThemeVariant="Dark">
 ```
@@ -46,7 +46,7 @@ import MusicStoreFullAcrylicWindowScreenshot from '/img/tutorials/music-store-ap
 - Найдите окончания открывающего тега `<Window>`.
 - После атрибута `Title="Avalonia.MusicStore"`, добавьте два новых, как показано ниже:
 
-```markup
+```xml
 <Window ...
         Title="Avalonia.MusicStore"
 
@@ -57,7 +57,7 @@ import MusicStoreFullAcrylicWindowScreenshot from '/img/tutorials/music-store-ap
 - Для применения акрилового эффекта на все окно, замените элемент `<TextBlock>` в зоне содержимого
 основного окна, как показано ниже:
 
-```markup
+```xml
 <Window ... >
        <Panel>
            <ExperimentalAcrylicBorder IsHitTestVisible="False">
@@ -91,7 +91,7 @@ import MusicStoreFullAcrylicWindowScreenshot from '/img/tutorials/music-store-ap
 - Найдите окончания открывающего тега `<Window>`.
 - Добавьте атрибут `ExtendClientAreaToDecorationsHint`, как показано ниже
 
-```markup
+```xml
    <Window ...
            TransparencyLevelHint="AcrylicBlur"
            Background="Transparent"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
@@ -33,7 +33,7 @@ import MusicStoreDialogOpenedScreenshot from '/img/tutorials/music-store-app/ope
 - Найдите и откройте файл **MusicStoreWindow.axaml**.
 - Для добавления акрилового размытия фона и строки заголовка, измените код, как показано ниже:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/add-item-buttons.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/add-item-buttons.md
@@ -121,7 +121,7 @@ CancelCommand = ReactiveCommand.Create(() => { });
 - В папке **/Views** найдите файл **AddItemView.axaml**.
 - Измените XAML как показано ниже:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:ToDoList.ViewModels"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/creating-a-view.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/creating-a-view.md
@@ -36,7 +36,7 @@ dotnet new avalonia.usercontrol -o Views -n ToDoListView  --namespace ToDoList.V
 
 В папке `/Views`, вы увидите новый AXAML-файл
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -86,7 +86,7 @@ namespace ToDoList.Views
 
 Замените содержимое `Views/TodoListView.axaml` на следующее:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/inspect-the-xaml.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/inspect-the-xaml.md
@@ -57,7 +57,7 @@ description: TUTORIALS - To Do List App
 Последняя строка, связывает XAML-файл с его `code-behind` классом.
 Обратите внимание, что здесь используется полное имя класса.
 
-```markup
+```xml
 <UserControl ...
    x:Class="ToDoList.Views.ToDoListView">
 ```
@@ -112,7 +112,7 @@ description: TUTORIALS - To Do List App
 
 Оставшийся XAML добавит захардкоженные элементы списка дел в виде флажков:
 
-```markup
+```xml
 <CheckBox Margin="4">Walk the dog</CheckBox>
 <CheckBox Margin="4">Buy some milk</CheckBox>
 ```

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/locating-views.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/locating-views.md
@@ -56,7 +56,7 @@ namespace ToDoList
 Экземпляр `ViewLocator` находит внутри файла проекта **App.xaml** (он был добавлен шаблоном решения).
 Он выглядит примерно так:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ToDoList.App"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/main-window-content.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/main-window-content.md
@@ -18,7 +18,7 @@ import ToDoMainWindowContentScreenshot from '/img/gitbook-import/assets/image (4
 
 XAML основного окна должен выглядеть примерно так:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:ToDoList.ViewModels"
@@ -44,7 +44,7 @@ XAML основного окна должен выглядеть примерн�
 Данный XAML во многом похож на XAML `user control`, с которым вы ознакомились на предыдущей страницу.
 В частности, здесь вы добавили:
 
-```markup
+```xml
 <Window ... xmlns:views="clr-namespace:ToDoList.Views" ...>
 ```
 
@@ -57,7 +57,7 @@ XAML основного окна должен выглядеть примерн�
 
 Последним шагом, меняем содержимое окна для отображения вышего нового `user control`:
 
-```markup
+```xml
 <views:ToDoListView/>
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/navigate-views.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/navigate-views.md
@@ -81,7 +81,7 @@ namespace ToDoList.ViewModels
 - В папке **/Views** найдите файл **MainWindow.axaml**.
 - Измините XAML как показано ниже.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:ToDoList.ViewModels"
@@ -105,7 +105,7 @@ namespace ToDoList.ViewModels
 * В папке **/Views** найдите файл **ToDoListView.axaml**.
 * Измините XAML у кнопки, как показано ниже:
 
-```markup
+```xml
 <Button DockPanel.Dock="Bottom"
         HorizontalAlignment="Stretch"
         HorizontalContentAlignment="Center"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/animations/keyframe-animations.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/animations/keyframe-animations.md
@@ -9,7 +9,7 @@ Keyframe animations in Avalonia are heavily inspired by CSS Animations. They can
 
 Keyframe animations are applied using styles. They can be defined on any style by adding an `Animation` object to the `Style.Animation` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -51,7 +51,7 @@ All `Animation` objects should contain at least one `KeyFrame`, with a `Setter` 
 
 Multiple properties can be also animated in a single Animation by adding additional `Setter` objects on the desired `KeyFrame`:
 
-```markup
+```xml
 <Animation Duration="0:0:1"> 
     <KeyFrame Cue="0%">
         <Setter Property="Opacity" Value="0.0"/>
@@ -68,7 +68,7 @@ Multiple properties can be also animated in a single Animation by adding additio
 
 You can add a delay in a `Animation` by defining the desired delay time on its `Delay` property:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"> 
     ...
@@ -114,7 +114,7 @@ The following table describes the possible behaviors:
 
 Easing functions can be set by setting the name of the desired function to the `Animation`'s `Easing` property:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"
            Easing="BounceEaseIn"> 
@@ -124,7 +124,7 @@ Easing functions can be set by setting the name of the desired function to the `
 
 You can also add your custom easing function class like this:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1">
     <Animation.Easing>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/animations/transitions.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/animations/transitions.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 Transitions in Avalonia are also heavily inspired by CSS Animations. They listen to any changes in target property's value and subsequently animates the change according to its parameters. They can be defined on any `Control` via `Transitions` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -38,7 +38,7 @@ The above example will listen to changes in the `Rectangle`'s `Opacity` property
 
 Transitions can also be defined in any style by using a `Setter` with `Transitions` as the target property and encapsulating them in a `Transitions` object, like so:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/border.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/border.md
@@ -10,7 +10,7 @@ The `Border` control decorates a child with a border and background. It can also
 
 An example of a border with a red background, 2 pixel black border, 3 pixel corner radius and a 4 pixel padding around its content:
 
-```markup
+```xml
 <Border Background="Red"
         BorderBrush="Black"
         BorderThickness="2"
@@ -48,7 +48,7 @@ To specify multiple shadows, provide a comma-separated list of shadows.
 * `spread-radius`: Positive values will cause the shadow to expand and grow bigger, negative values will cause the shadow to shrink. If not specified, it will be 0 \(the shadow will be the same size as the element\).
 * `color`: The color of the shadow using a color name \(such as `red`\) or a `#` hexadecimal color value
 
-```markup
+```xml
 <Border Background="Red"
         BorderBrush="Black"
         BorderThickness="2"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/button.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/button.md
@@ -49,7 +49,7 @@ The Button control's full documentation can be found [here](http://reference.ava
 
 ### Basic button
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -69,7 +69,7 @@ produces following output with **Windows 10**
 
 ### Colored button
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -91,7 +91,7 @@ produces following output with **Windows 10**
 
 Toggles between a "Play" icon and a "Pause" icon on click.
 
-```markup
+```xml
 <UserControl.Resources>
     <Bitmap x:Key="Play">
         <x:Arguments>
@@ -106,7 +106,7 @@ Toggles between a "Play" icon and a "Pause" icon on click.
 </UserControl.Resources>
 ```
 
-```markup
+```xml
 <Button Name="PlayButton" HorizontalAlignment="Center" Width="36" Command="{Binding PlayCommand}">
     <Panel>
         <Image Source="{DynamicResource Play}" IsVisible="{Binding !IsPlaying}" Width="20"
@@ -121,7 +121,7 @@ Toggles between a "Play" icon and a "Pause" icon on click.
 
 It is possible to bind a view model command to a simple method or with a ReactiveCommand. There are lots of advantages to the ReactiveCommand binding for all but the simplest user interfaces such as being able to pass an `IObservable<bool>` object in to have it dynamically calculate state. Both methods are displayed below. First the "simple" method binding:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -157,7 +157,7 @@ public ReactiveCommand OnClickCommand { get; }
 
 ### Binding to Events
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/radiobutton.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/radiobutton.md
@@ -5,7 +5,7 @@ title: RadioButton
 
 The `RadioButton` control allows users to select one or more things from a collection of presented things.
 
-```markup
+```xml
 <!-- First Group -->
 <RadioButton IsChecked="{Binding Option1Enabled }"
              GroupName="First Group"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/togglebutton.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/togglebutton.md
@@ -15,7 +15,7 @@ The `ToggleButton` control is a subclass of the `Button` control that has a buil
 
 This button will show a muted speaker icon or an un-muted speaker icon based on whether the button is checked or unchecked, which the `ToggleButton` control toggles between when users click on the button.
 
-```markup
+```xml
 <Style Selector="ToggleButton DrawingPresenter.tbchecked">
     <Setter Property="IsVisible" Value="False"/>
 </Style>
@@ -32,7 +32,7 @@ This button will show a muted speaker icon or an un-muted speaker icon based on 
 
 The style code above reacts to `ToggleButton`'s `:checked` pseudoclass, so that if the `ToggleButton` is checked, any `DrawingPresenter` with the class `.tbchecked` will be visible, and any `DrawingPresenter` with the class `.tbunchecked` will not be visible.
 
-```markup
+```xml
 <ToggleButton Classes="vtrx" IsChecked="{Binding Path=vtrx.muted}" ToolTip.Tip="stop audio">
     <Panel>
         <DrawingPresenter Drawing="{DynamicResource Icon.Speaker}" Classes="tbunchecked"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/calendar.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/calendar.md
@@ -30,7 +30,7 @@ The `Calendar` control is a standard Calendar control for users to select date\(
 
 ### Basic Calendar
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -46,7 +46,7 @@ The `Calendar` control is a standard Calendar control for users to select date\(
 
 ### Range selection Calendar
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -64,7 +64,7 @@ After selecting the start date, a single range can be selected by holding the sh
 
 ### Calendar with custom start and end dates
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/calendardatepicker.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/calendardatepicker.md
@@ -11,7 +11,7 @@ The `CalendarDatePicker` control allows the user to pick a date value using a ca
 
 The placeholder (the text that appears when the input is empty) can be changed using the `Watermark` property.
 
-```markup
+```xml
 <CalendarDatePicker
 	Watermark="01/01/1970" />
 ```
@@ -20,7 +20,7 @@ The placeholder (the text that appears when the input is empty) can be changed u
 
 The format of the date displayed can be customised by setting the `SelectedDateFormat` to `Custom` and providing a custom format in `CustomDateFormatString` in the same way `DateTime.ToString(string format)` accepts.
 
-```markup
+```xml
 <CalendarDatePicker 
 	SelectedDateFormat="Custom"
 	CustomDateFormatString="yyyy-MM-dd" />

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/canvas.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/canvas.md
@@ -15,7 +15,7 @@ The Canvas does not do any sizing of its children. Each element must specify its
 
 Here's an example of a Canvas in XAML.
 
-```markup
+```xml
 <Canvas Width="120" Height="120">
     <Rectangle Fill="Red" Height="44" Width="44"/>
     <Rectangle Fill="Blue" Height="44" Width="44" Canvas.Left="20" Canvas.Top="20"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/checkbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/checkbox.md
@@ -27,7 +27,7 @@ The `CheckBox` control is a [`ContentControl`](../controls/contentcontrol) which
 
 ### Basic checkbox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -48,7 +48,7 @@ produces following output with **Windows 10**
 
 ### Three state checkbox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/combobox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/combobox.md
@@ -27,7 +27,7 @@ title: ComboBox
 
 ### Basic ComboBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -48,7 +48,7 @@ title: ComboBox
 
 ### ComboBox with custom item templates
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -79,7 +79,7 @@ title: ComboBox
 
 This example binds the fonts installed to a ComboBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/contentcontrol.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/contentcontrol.md
@@ -25,19 +25,19 @@ At its simplest, a `ContentControl` displays the data assigned to its [`Content`
 
 For example:
 
-```markup
+```xml
 <ContentControl Content="Hello World!"/>
 ```
 
 Will display the string "Hello World!". The `Content` property is the control's default property and so the above example can also be written as:
 
-```markup
+```xml
 <ContentControl>Hello World!</ContentControl>
 ```
 
 If you assign a control to a `ContentControl` then it will display the control, for example:
 
-```markup
+```xml
 <ContentControl>
   <Button>Click Me!</Button>
 </ContentControl>
@@ -79,7 +79,7 @@ namespace Example
 
 We can display the student's first and last name in a `ContentControl` using the `ContentTemplate` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
   <ContentControl Content="{Binding Content}">
     <ContentControl.ContentTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/datagrid/datagridcolumns.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/datagrid/datagridcolumns.md
@@ -27,7 +27,7 @@ This column is used to display text data, normally represented by a `string`. In
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid" Items="{Binding People}" AutoGenerateColumns="False" >
     <DataGrid.Columns>
         <DataGridTextColumn Header="Forename" Binding="{Binding FirstName}"/>
@@ -50,7 +50,7 @@ This column is used to represent a `bool` value. The  value is represented by a 
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid" Items="{Binding ToDoListItems}" AutoGenerateColumns="False" >
     <DataGrid.Columns>
         <DataGridCheckBoxColumn Header="✔" Binding="{Binding IsChecked}"/>
@@ -77,7 +77,7 @@ The DataGridTemplateColumn is editable from Avalonia version 0.10.12 onward. If 
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid"
           xmlns:model="using:MyApp.Models"  >
   <DataGrid.Columns>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/datagrid/index.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/datagrid/index.md
@@ -28,7 +28,7 @@ Note, that version should match Avalonia version you are using.
 
 The Themes can be changed to light or dark to fit your application theme.
 
-```markup
+```xml
 <Application.Styles>
     <StyleInclude Source="avares://Avalonia.Themes.Default/DefaultTheme.xaml"/>
     <StyleInclude Source="avares://Avalonia.Themes.Default/Accents/BaseLight.xaml"/>
@@ -38,7 +38,7 @@ The Themes can be changed to light or dark to fit your application theme.
 
 Or if you are using new Fluent theme, you will need to include styles created specifically for that:
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme Mode="Light" />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
@@ -51,7 +51,7 @@ Or if you are using new Fluent theme, you will need to include styles created sp
 
 This will generate a DataGrid with column header names. FirstName and LastName.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -78,7 +78,7 @@ public class Person
 
 The DataGrid uses the same class Person as before, but now with custom column header name. Forename and Surname.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/dockpanel.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/dockpanel.md
@@ -9,7 +9,7 @@ import DockPanelFillNoOverlapScreenshot from '/img/controls/dockpanel/dockpanel.
 
 The `DockPanel` control is a `Panel` which lays out its children by "docking" them to the sides or floating in the center.
 
-```markup
+```xml
 <DockPanel Width="300" Height="300">
     <Rectangle Fill="Red" Height="100" DockPanel.Dock="Top"/>
     <Rectangle Fill="Blue" Width="100" DockPanel.Dock="Left"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/flyouts.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/flyouts.md
@@ -69,7 +69,7 @@ There are two built-in types of Flyouts: `Flyout` and `MenuFlyout`. A regular `F
 
 In order to be shown Flyouts have to be attached to a specific control, though this is not a static assignment and can be changed at runtime. `Button` has a `Flyout` property that can be used to open a Flyout upon click.
 
-```markup
+```xml
 <Button Content="Click me">
     <Button.Flyout>
         <Flyout>
@@ -83,7 +83,7 @@ In order to be shown Flyouts have to be attached to a specific control, though t
 
 For other controls that don't have built-in support for flyouts, one can be assigned using attached flyouts
 
-```markup
+```xml
 <Border Background="Red" PointerPressed="Border_PointerPressed">
     <FlyoutBase.AttachedFlyout>
         <Flyout>
@@ -112,7 +112,7 @@ ContextFlyouts are invoked automatically like normal `ContextMenu`s. Although cu
 
 As previously mentioned, Flyouts can be shared between various elements within your app.
 
-```markup
+```xml
 <Window.Resources>
     <Flyout x:Key="MySharedFlyout">
         <!-- Flyout content here -->
@@ -128,7 +128,7 @@ As previously mentioned, Flyouts can be shared between various elements within y
 
 Although `Flyout`s are not controls themselves, their general appearance can still be customized by targeting the presenter the `Flyout` uses to display its content. For a normal `Flyout` this is `FlyoutPresenter` and for `MenuFlyout` this is `MenuFlyoutPresenter`. Because flyout presenters are not exposed, special style classes that should pertain to specific flyouts can be passed using the `FlyoutPresenterClasses` property on `FlyoutBase`
 
-```markup
+```xml
 <Style Selector="FlyoutPresenter.mySpecialClass">
     <Setter Property="Background" Value="Red" />
 </Style>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/grid.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/grid.md
@@ -31,7 +31,7 @@ Below is an example that shows:
 
 An example of a Grid with 3 equal Rows and 3 Columns with \(1 fixed width\), \(2 grabbing the rest proportionally\) would be:
 
-```markup
+```xml
 <Grid ColumnDefinitions="100,1.5*,4*" RowDefinitions="Auto,Auto,Auto"  Margin="4">
   <TextBlock Text="Col0Row0:" Grid.Row="0" Grid.Column="0"/>
   <TextBlock Text="Col0Row1:" Grid.Row="1" Grid.Column="0"/>
@@ -54,7 +54,7 @@ Here is another example showing the difference between those two.
 
 First let's create sample 2x2 grid in our View, we can achieve this simply by writing code looking like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
@@ -77,7 +77,7 @@ Now let's fill our grid with some elements, I will fill every field with button,
 
 Now our View code look's like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
@@ -103,7 +103,7 @@ As you can see our grid become sticky to its content, it is very useful when we 
 
 This new View code looks like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -125,7 +125,7 @@ This new View code looks like this:
 
 For more complex row and column definitions it's possible to explicitly use `Grid.ColumnDefinitions` and `Grid.RowDefinitions` XAML fields to provide access to these additional settings. The below code produces is exactly the same except for the fact we set the minimum width on the second column to be 300.
 
-```markup
+```xml
 <Grid Margin="4">
   <Grid.ColumnDefinitions>
     <ColumnDefinition Width="100" />

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/gridsplitter.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/gridsplitter.md
@@ -8,7 +8,7 @@ import GridSplitterRowsScreenshot from '/img/controls/gridsplitter/gridsplitter-
 
 The `GridSplitter` control is a control that allows a user to resize the space between `Grid` rows or columns.
 
-```markup
+```xml
 <Grid ColumnDefinitions="*, 4, *">
     <Rectangle Grid.Column="0" Fill="Blue"/>
     <GridSplitter Grid.Column="1" Background="Black" ResizeDirection="Columns"/>
@@ -18,7 +18,7 @@ The `GridSplitter` control is a control that allows a user to resize the space b
 
 <img className="center" src={GridSplitterColumnsScreenshot} alt="GridSplitter in Action for Columns" />
 
-```markup
+```xml
 <Grid RowDefinitions="*, 4, *">
     <Rectangle Grid.Row="0" Fill="Blue"/>
     <GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/image.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/image.md
@@ -21,13 +21,13 @@ The declarative approaches keep images in memory and won't have to load them in 
 
 **Binding Converter Approach**
 
-```markup
+```xml
 <UserControl.Resources>
     <ext:BitmapAssetValueConverter x:Key="variableImage"/>
 </UserControl.Resources>
 ```
 
-```markup
+```xml
 <Image Width="75"
        Height="73"
        Source="{Binding PlaySource, Converter={StaticResource variableImage}}">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/listbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/listbox.md
@@ -7,7 +7,7 @@ The `ListBox` is an `ItemsControl` which displays items in a multi-line list box
 
 The items to display in the `ListBox` are specified using the `Items` property. This property will often be bound to a collection on the control's `DataContext`:
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}"/>
 ```
 
@@ -15,7 +15,7 @@ The items to display in the `ListBox` are specified using the `Items` property. 
 
 You can customize how an item is displayed by specifying an `ItemTemplate`. For example to display each item inside a red border with rounded corners:
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}">
     <ListBox.ItemTemplate>
         <DataTemplate>
@@ -33,7 +33,7 @@ Each item displayed in a `ListBox` will be wrapped in a `ListBoxItem` - this is 
 
 Sometimes you will want to customize the container itself. You can do this by including a style targeting `ListBoxItem` in the `ListBox`:
 
-```markup
+```xml
 <ListBox Items="{Binding Items}">
     <ListBox.Styles>
         <!-- Give the ListBoxItems a fixed with of 100 and right-align them -->
@@ -66,7 +66,7 @@ Controls the type of selection that can be made on the `ListBox`:
 
 These values can be combined, e.g.:
 
-```markup
+```xml
 <ListBox SelectionMode="Multiple,Toggle"/>
 ```
 
@@ -74,7 +74,7 @@ These values can be combined, e.g.:
 
 Exposes the index of the selected item, or in the case of multiple selection the first selected item. You will often want to bind this to a view model if your list `SelectionMode` is set to `Single`.
 
-```markup
+```xml
 <ListBox SelectedIndex="{Binding SelectedIndex}"/>
 ```
 
@@ -97,7 +97,7 @@ By default bindings to this property are two-way.
 
 Exposes the selected item in the `Items` collection, or in the case of multiple selection the first selected item. You will often want to bind this to a view model if your list `SelectionMode` is set to `Single`.
 
-```markup
+```xml
 <ListBox SelectedItem="{Binding SelectedItem}"/>
 ```
 
@@ -128,7 +128,7 @@ Once `Selection` is bound to a `SelectionModel`, `SelectedItems` will no longer 
 
 `SelectionModel` also exposes batching functionality through its `Update()` method and a `SelectionChanged` event which details exactly which items have been selected and deselected.
 
-```markup
+```xml
 <ListBox Items="{Binding Items}" Selection="{Binding Selection}"/>
 ```
 
@@ -172,7 +172,7 @@ This property holds the selected items in an `IList`. It can be bound to any lis
 
 For various reasons the performance of `SelectedItems` can be very poor, particularly on large collections. It is recommended that you use the `Selection` property instead.
 
-```markup
+```xml
 <ListBox SelectedItems="{Binding SelectedItems}"/>
 ```
 
@@ -187,7 +187,7 @@ public MyViewModel : ReactiveObject
 
 By default if an item is too wide to display in the `ListBox`, a horizontal scrollbar will be displayed. If instead you want items to be constrained to the width of the `ListBox` \(for example if you want wrapping text in the items\) you can disable the horizontal scrollbar by setting `ScrollViewer.HorizontalScrollBarVisibility="Disabled"`.
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}" Width="250" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
     <ListBox.ItemTemplate>
         <DataTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/maskedtextbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/maskedtextbox.md
@@ -14,7 +14,7 @@ The `MaskedTextBox` control is an editable text field where a user can input tex
 
 ### Basic example line TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/menu.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/menu.md
@@ -5,7 +5,7 @@ title: Menu
 
 The `Menu` control adds a top-level menu to an application. A `Menu` is usually placed in a `DockPanel` in a `Window`, docked to the top of the window:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <DockPanel>
@@ -40,7 +40,7 @@ If you will press Alt with the example above you will see that some letters are 
 
 Like `Button`, commands can be [bound](../data-binding/binding-to-commands) to `MenuItem`s. The command will be executed when the menu item is clicked or selected with the keyboard:
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem Header="_Open..." Command="{Binding OpenCommand}"/>
@@ -54,7 +54,7 @@ Like `Button`, commands can be [bound](../data-binding/binding-to-commands) to `
 
 A menu icon can be displayed by placing an `Image` in the `Icon` property:
 
-```markup
+```xml
     <MenuItem Header="_Open...">
         <MenuItem.Icon>
             <Image Source="resm:MyApp.Assets.Open.png"/>
@@ -66,7 +66,7 @@ A menu icon can be displayed by placing an `Image` in the `Icon` property:
 
 Similarly, a `CheckBox` can be displayed in the `Icon` property to make the `MenuItem` checkable:
 
-```markup
+```xml
     <MenuItem Header="_Open...">
         <MenuItem.Icon>
             <CheckBox BorderThickness="0"
@@ -192,7 +192,7 @@ public MainWindow()
 
 Finally assign the bindings to the view model in a `Style` within the menu:
 
-```markup
+```xml
 <Menu Items="{Binding MenuItems}">
     <Menu.Styles>
         <Style Selector="MenuItem">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/numericupdown.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/numericupdown.md
@@ -23,7 +23,7 @@ The control has a up and down button spinner attached, used to increment and dec
 
 The value stored in the `NumericUpDown` is a double.
 
-```markup
+```xml
 <NumericUpDown Value="10" Width="100"/>
 ```
 
@@ -35,13 +35,13 @@ produces the following output on **Linux**
 
 A custom increment/decrement value can be set for the button spinner. The default increment value is set to 1.
 
-```markup
+```xml
 <NumericUpDown Value="0.5" Increment="0.01" Minimum="0" Maximum="1"/>
 ```
 
 ### NumericUpDown without a button spinner
 
-```markup
+```xml
 <NumericUpDown Value="42" AllowSpin="False" ShowButtonSpinner="False"/>
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/panel.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/panel.md
@@ -9,7 +9,7 @@ The `Panel` is the base class for controls that can contain multiple children li
 
 The `Panel` class can be useful on its own for very basic layouts, or simply to allow multiple controls to be to be contained.
 
-```markup
+```xml
 <Panel Height="300" Width="300">
     <Rectangle Fill="Red" Height="100" VerticalAlignment="Top"/>
     <Rectangle Fill="Blue" Width="100" HorizontalAlignment="Right" />

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/relativepanel.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/relativepanel.md
@@ -22,7 +22,7 @@ Attached properties are used to control the layout of elements. This table shows
 
 This XAML shows how to arrange elements in a RelativePanel.
 
-```markup
+```xml
 <RelativePanel BorderBrush="Gray" BorderThickness="1">
     <Rectangle x:Name="RedRect" Fill="Red" Height="44" Width="44"/>
     <Rectangle x:Name="BlueRect" Fill="Blue"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/splitview.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/splitview.md
@@ -7,7 +7,7 @@ import SplitViewScreenshot from '/img/controls/splitview/image (9).png';
 
 Represents a container with two views; one view for the main content and another view that is typically used for navigation commands.
 
-```markup
+```xml
 <SplitView IsPaneOpen="True"
            DisplayMode="Inline"
            OpenPaneLength="296">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/stackpanel.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/stackpanel.md
@@ -12,7 +12,7 @@ You can use the [**Orientation**](https://docs.microsoft.com/en-us/uwp/api/windo
 
 The following XAML shows how to create a vertical StackPanel of items.
 
-```markup
+```xml
 <StackPanel>
     <Rectangle Fill="Red" Height="44"/>
     <Rectangle Fill="Blue" Height="44"/>
@@ -29,7 +29,7 @@ In a StackPanel, if a child element's size is not set explicitly, it stretches t
 
 StackPanel has a `Spacing` property to allow an even spacing between items.
 
-```markup
+```xml
 <StackPanel Spacing="5">
     <Rectangle Fill="Red" Height="44"/>
     <Rectangle Fill="Blue" Height="44"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/tabcontrol.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/tabcontrol.md
@@ -14,7 +14,7 @@ Here is an animation of what you can achieve :
 
 To create this, we'll describe the entire control \(TabControl\) and each individual tab+page \(TabItem\). Here is an example :
 
-```markup
+```xml
 <TabControl>
   <TabItem Header="Circle" VerticalContentAlignment="Center">
     <TextBlock Text="I am in the circle page !" HorizontalAlignment="Left" VerticalAlignment="Center"/>
@@ -48,7 +48,7 @@ Let's have a look at a customized `TabControl` :
 
 The grey part is the `TabItem`... Yes, the `TabItem` includes the tab **AND** the page associated to the tab. The tab is called the `header`of the `TabItem`. Moreover, given the way `TabControl` has been implemented, tabs are in a `WrapPanel`. Thus, if you want to color in blue \(like this is done above\) the empty bar of the tabbed bar, you must change the background color of the `WrapPanel` of the `TabControl`. Here is the code used to obtain the result above \(_Note the workaround used to color some tabs : this is due to the way the control is implemented. It might change in the future._\)
 
-```markup
+```xml
 <Window.Styles>
 
   <Style Selector="TabControl">
@@ -123,7 +123,7 @@ DataContext = new TabItemModel[] {
 
 Finally create a `TabControl` and bind its Items property to the DataContext.
 
-```markup
+```xml
 <TabControl Items="{Binding}">
     <TabControl.ItemTemplate>
       <DataTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/textbox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/textbox.md
@@ -22,7 +22,7 @@ The `TextBox` control is an editable text field where a user can input text.
 
 ### Basic one line TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -42,7 +42,7 @@ produces the following output in **Windows 10**
 
 ### Password input TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -62,7 +62,7 @@ produces the following output in **Windows 10** when text is input
 
 When using the Fluent theme, you can apply the style class, `revealPasswordButton`, and the TextBox will provide an eye 👁 glyph for the user to show the plane text temporally. Please note, the `TextBox` may be written to but not copied from.
 
-```markup
+```xml
 <TextBox Classes="revealPasswordButton" PasswordChar="•" />
 ```
 
@@ -70,7 +70,7 @@ When using the Fluent theme, you can apply the style class, `revealPasswordButto
 
 Avalonia can show a "watermark" in a `TextBox`, which is a piece of text that is displayed when the `TextBox` is empty \(in HTML5 this is called a _placeholder_\)
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -90,7 +90,7 @@ produces the following output in **Windows 10**
 
 ### Multiline TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/timepicker.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/timepicker.md
@@ -50,7 +50,7 @@ Use a `TimePicker` to let a user enter a single time value. You can customize th
 
 By default, the time picker shows a 12-hour clock with an AM/PM selector. You can set the [ClockIdentifier](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker.clockidentifier?view=winrt-19041#Windows\_UI\_Xaml\_Controls\_TimePicker\_ClockIdentifier) property to "24HourClock" to show a 24-hour clock instead.
 
-```markup
+```xml
 <TimePicker Header="12HourClock" SelectedTime="14:30"/>
 <TimePicker Header="24HourClock" SelectedTime="14:30" ClockIdentifier="24HourClock"/>
 ```
@@ -61,7 +61,7 @@ By default, the time picker shows a 12-hour clock with an AM/PM selector. You ca
 
 You can set the [MinuteIncrement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker.minuteincrement?view=winrt-19041#Windows\_UI\_Xaml\_Controls\_TimePicker\_MinuteIncrement) property to indicate the time increments shown in the minute picker. For example, 15 specifies that the `TimePicker` minute control displays only the choices 00, 15, 30, 45.
 
-```markup
+```xml
 <TimePicker MinuteIncrement="15"/>
 ```
 
@@ -88,7 +88,7 @@ TimePicker timePicker = new TimePicker
 
 You can set the time value as an attribute in XAML. This is probably easiest if you're already declaring the `TimePicker` object in XAML and aren't using bindings for the time value. Use a string in the form _Hh:Mm_ where _Hh_ is hours and can be between 0 and 23 and _Mm_ is minutes and can be between 0 and 59.
 
-```markup
+```xml
 <TimePicker SelectedTime="14:15"/>
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/tooltip.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/tooltip.md
@@ -28,7 +28,7 @@ The `ToolTip` is a control that pops up with hint text when hovered over the app
 
 ### Text ToolTip
 
-```markup
+```xml
 <Border Margin="5"
         Padding="10"
         Background="{DynamicResource ThemeAccentBrush}"
@@ -39,7 +39,7 @@ The `ToolTip` is a control that pops up with hint text when hovered over the app
 
 ### Rich Tooltip
 
-```markup
+```xml
 <Border Margin="5"
         Padding="10"
         Background="{DynamicResource ThemeAccentBrush}"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/transitioningcontentcontrol.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/transitioningcontentcontrol.md
@@ -26,7 +26,7 @@ import TransitioningContentControlSlideScreenshot from '/img/controls/transition
 
 Let's assume we have a collection of different images and we want to show them in a slideshow like view. In order to do this we can setup our `TransitioningContentControl` like this:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">
@@ -44,7 +44,7 @@ If you don't like the `PageTransition` which is provided by the applied theme, y
 
 In the sample below we will change the [PageTransition](../animations/page-transitions.md) to slide the images horizontally.
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.PageTransition>
         <PageSlide Orientation="Horizontal" Duration="0:00:00.500" />
@@ -63,7 +63,7 @@ In the sample below we will change the [PageTransition](../animations/page-trans
 
 If you want to disable the transition, set the `PageTransition` to `null`.
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" PageTransition="{x:Null}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/creating-a-flat-treedatagrid.md.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/creating-a-flat-treedatagrid.md.md
@@ -88,7 +88,7 @@ The columns above are defined as `TextColumn`s - again, `TextColumn` is a generi
 
 It's now time to add the `TreeDataGrid` control to a window and bind it to the source.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication.MainWindow">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/creating-a-hierarchical-treedatagrid.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/creating-a-hierarchical-treedatagrid.md
@@ -119,7 +119,7 @@ The remaining columns are also defined as `TextColumn`s - again, `TextColumn` is
 
 It's now time to add the `TreeDataGrid` control to a window and bind it to the source.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication.MainWindow">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/index.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/index.md
@@ -36,7 +36,7 @@ We accept issues and pull requests but we answer and review only pull requests a
 * Add the `Avalonia.Controls.TreeDataGrid` NuGet package to your project
 * Add the `TreeDataGrid` theme to your `App.xaml` file (the `StyleInclude` in the following markup):
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AvaloniaApplication.App">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/treeview.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/controls/treeview.md
@@ -7,7 +7,7 @@ The `TreeView` is a control that presents hierarchical tree data and allows sele
 
 One example for populating a `TreeView` can be from a directory on the computer. You can create a `TreeView` in the `MainWindow.axaml` file in an Avalonia MVVM project.
 
-```markup
+```xml
 <TreeView Items="{Binding Items}" 
 	  Width="400" Height="480" 
 	  HorizontalAlignment="Left">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-classes.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-classes.md
@@ -4,7 +4,7 @@ title: Binding Classes
 ---
 In Avalonia, you also can bind classes. Sometimes it could be useful to switch classes depending on some logic, and for those purposes, you can use Binding Classes API. There is the sample usage of Binding Classes. We have two different styles and we want to switch between them depending on `MyProperty` state.
 
-```markup
+```xml
  <ListBox Items="{Binding MyItems}">
     <ListBox.Styles>
         <Style Selector="TextBlock.myClass">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-in-a-control-template.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-in-a-control-template.md
@@ -5,7 +5,7 @@ title: Binding in a Control Template
 
 When you're creating a control template and you want to bind to the templated parent you can use:
 
-```markup
+```xml
 <TextBlock Name="tb" Text="{TemplateBinding Caption}"/>
 
 <!-- Which is the same as -->
@@ -16,7 +16,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
 
  1. `TemplateBinding` accepts only a single property rather than a property path, so if you want to bind using a property path you must use the second syntax:
 
-    ```markup
+    ```xml
     <!-- This WON'T work as TemplateBinding only accepts single properties -->
     <TextBlock Name="tb" Text="{TemplateBinding Caption.Length}"/>
 
@@ -32,7 +32,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
 
  3. `TemplateBinding` can only be used on `IStyledElement`.
 
-   ```markup
+   ```xml
    <!-- This WON'T work as GeometryDrawing is not a IStyledElement. -->
    <GeometryDrawing Brush="{TemplateBinding Foreground}"/>
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-to-commands.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-to-commands.md
@@ -29,7 +29,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Button Command="{Binding DoTheThing}">Do the thing!</Button>
 </Window>
@@ -59,7 +59,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Button Command="{Binding DoTheThing}" CommandParameter="Hello World">Do the thing!</Button>
 </Window>
@@ -67,7 +67,7 @@ namespace Example
 
 Note that no type conversion is carried out on `CommandParameter`, so if you need your type parameter to be something other than `string` you must supply an object of that type in XAML. For example to pass an `int` parameter you could use:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <Button Command="{Binding DoTheThing}">
@@ -100,7 +100,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
   <Button Command="{Binding RunTheThing}" CommandParameter="Hello World">Do the thing!</Button>
 </Window>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-to-tasks-and-observables.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-to-tasks-and-observables.md
@@ -9,7 +9,7 @@ You can subscribe to the result of a task or an observable by using the `^` stre
 
 For example if `DataContext.Name` is an `IObservable<string>` then the following example will bind to the length of each string produced by the observable as each value is produced
 
-```markup
+```xml
 <TextBlock Text="{Binding Name^.Length}"/>
 ```
 
@@ -30,7 +30,7 @@ private async Task<string> GetTextAsync()
 ```
 
 You can bind to the result in the following way: 
-```markup
+```xml
 <TextBlock Text="{Binding MyAsyncText^, FallbackValue='Wait a second'}" />
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/bindings.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/bindings.md
@@ -7,7 +7,7 @@ You bind in XAML using the `{Binding}` markup extension. By using bindings \(ass
 
 By default a binding binds to a property on the [`DataContext`](the-datacontext), e.g.:
 
-```markup
+```xml
 <!-- Binds to the TextBlock's DataContext.Name property -->
 <TextBlock Text="{Binding Name}"/>
 
@@ -17,7 +17,7 @@ By default a binding binds to a property on the [`DataContext`](the-datacontext)
 
 An empty binding binds to DataContext itself
 
-```markup
+```xml
 <!-- Binds to the TextBlock's DataContext property -->
 <TextBlock Text="{Binding}"/>
 
@@ -31,13 +31,13 @@ We call the property on the control the binding _target_ and the property on the
 
 The binding path above can be a single property, or it can be a chain of properties. For example if the object assigned to the `DataContext` has a `Student` property, and the value of this property has a `Name`, you can bind to the student name using:
 
-```markup
+```xml
 <TextBlock Text="{Binding Student.Name}"/>
 ```
 
 You can also include array/list indexers in binding paths:
 
-```markup
+```xml
 <TextBlock Text="{Binding Students[0].Name}"/>
 ```
 
@@ -45,7 +45,7 @@ You can also include array/list indexers in binding paths:
 
 You can change the behavior of a `{Binding}` by specifying a binding `Mode`:
 
-```markup
+```xml
 <TextBlock Text="{Binding Name, Mode=OneTime}">
 ```
 
@@ -65,7 +65,7 @@ The `Default` mode is assumed if one is not specified. This mode is generally `O
 
 You can apply a format string to the binding to influence how the value is represented in the UI:
 
-```markup
+```xml
 <!-- Option 1: Use string format without curly braces -->
 <TextBlock Text="{Binding FloatValue, StringFormat=0.0}" />
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/compiled-bindings.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/compiled-bindings.md
@@ -13,7 +13,7 @@ Compiled bindings are not enabled by default. To enable compiled bindings, you w
 
 You can now enable or disable compiled bindings by setting `x:CompileBindings="[True|False]"`. All child nodes will inherit this property, so you can enable it in your root node and disable it for a specific child, if needed.
 
-```markup
+```xml
 <!-- Set DataType and enable compiled bindings -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -48,7 +48,7 @@ Starting from Avalonia `11.0-preview5` you can also enable or disable it in whol
 
 If you don't want to enable compiled bindings for all child nodes, you can also use the `CompiledBinding`-markup. You still need to define the `DataType`, but you can omit `x:CompileBindings="True"`.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -73,7 +73,7 @@ If you don't want to enable compiled bindings for all child nodes, you can also 
 ## ReflectionBinding-Markup
 If you have compiled bindings enabled in the root node (via `x:CompileBindings="True"`) and you either don't want to use compiled binding at a certain position or you hit one of the [known limitations](#known-limitations), you can use the `ReflectionBinding`-markup.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/converting-binding-values.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/converting-binding-values.md
@@ -27,7 +27,7 @@ Negation also works when binding to non-boolean values. First of all, the value 
 
 A "double-bang" can be used to convert a non-boolean value to a boolean value. For example to hide a control when a collection is empty:
 
-```markup
+```xml
 <Panel>
   <ListBox Items="{Binding Items}" IsVisible="{Binding !!Items.Count}"/>
 </Panel>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/creating-and-binding-attached-properties.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/creating-and-binding-attached-properties.md
@@ -122,7 +122,7 @@ In the verify method we utilize the routed event system to attach a new handler.
 
 This example UI shows how to use the attached property. After making the namespace known to the XAML compiler it can be used by qualifying it with a dot. Then bindings can be used.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:MyApp.Behaviors"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/the-datacontext.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/data-binding/the-datacontext.md
@@ -23,7 +23,7 @@ private static void AppMain(Application app, string[] args)
 
 This means that when the `MainWindow` is created, a new instance of `MainWindowViewModel` will be created and assigned to the window's `DataContext` property. From here all bindings will by default bind to properties on this object:
 
-```markup
+```xml
 <Window>
     <Button Content="{Binding ButtonCaption}"/>
 </Window>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/distribution-publishing/macos.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/distribution-publishing/macos.md
@@ -94,7 +94,7 @@ More documentation on possible `Info.plist` keys is available [here](https://dev
 
 If at any point the tooling gives you an error that your assets file doesn't have a target for `osx-64`, add the following [runtime identifiers](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) to the top `<PropertyGroup>` in your `.csproj`:
 
-```markup
+```xml
 <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
 ```
 
@@ -114,7 +114,7 @@ The file that is actually executed by macOS when starting your `.app` bundle wil
 
 * Add the following to your `.csproj` file:
 
-```markup
+```xml
 <PropertyGroup>
   <UseAppHost>true</UseAppHost>
 </PropertyGroup>
@@ -128,7 +128,7 @@ The file that is actually executed by macOS when starting your `.app` bundle wil
 
 You'll first have to add the project as a `PackageReference` in your project. Add it to your project via NuGet package manager or by adding the following line to your `.csproj` file:
 
-```markup
+```xml
 <PackageReference Include="Dotnet.Bundle" Version="*" />
 ```
 
@@ -153,7 +153,7 @@ dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-x64 -p:CFBundleDisplayName=
 
 Instead of specifying `CFBundleDisplayName`, etc., on the command line, you can also specify them in your project file:
 
-```markup
+```xml
 <PropertyGroup>
     <CFBundleName>AppName</CFBundleName> <!-- Also defines .app file name -->
     <CFBundleDisplayName>MyBestThingEver</CFBundleDisplayName>
@@ -514,7 +514,7 @@ When upload succeeds - you will see your package in App Store Connect.
 
 This means that your application most likely does not specify a menu. On startup, Avalonia creates the default menu items for an application and automatically adds the _About Avalonia_ item when no menu has been configured. This can be resolved by adding one to your `App.xaml`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:RoadCaptain.App.RouteBuilder"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/assets.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/assets.md
@@ -9,7 +9,7 @@ Many applications need to include assets such as bitmaps and [resource dictionar
 
 Assets can be included in an application by using the `<AvaloniaResource>` item in your project file. The MVVM Application template by default includes all files in the `Assets` directory as an `<AvaloniaResource>`:
 
-```markup
+```xml
 <ItemGroup>
   <AvaloniaResource Include="Assets\**"/>
 </ItemGroup>
@@ -23,7 +23,7 @@ You will notice that we're referring to _assets_ here whereas the MSBuild item i
 
 Assets can be referenced in XAML by specifying their relative path:
 
-```markup
+```xml
 <Image Source="icon.png"/>
 <Image Source="images/icon.png"/>
 <Image Source="../icon.png"/>
@@ -31,19 +31,19 @@ Assets can be referenced in XAML by specifying their relative path:
 
 Or their rooted path:
 
-```markup
+```xml
 <Image Source="/Assets/icon.png"/>
 ```
 
 If the asset is located in a different assembly from the XAML file, then use the `avares:` URI scheme. For example, if the asset is contained in an assembly called `MyAssembly.dll`, then you would use:
 
-```markup
+```xml
 <Image Source="avares://MyAssembly/Assets/icon.png"/>
 ```
 
 In case of fonts, you can provide a font name after a '#' sign:
 
-```markup
+```xml
 <TextBlock FontFamily="avares://MyAssembly/Assets/font.ttf#FontName">test</TextBlock>
 ```
 
@@ -55,13 +55,13 @@ Assets can also be included in .NET applications by using the `<EmbeddedResource
 
 You can reference manifest resources using the `resm:` URL scheme:
 
-```markup
+```xml
 <Image Source="resm:MyApp.Assets.icon.png"/>
 ```
 
 Or if the resource is embedded in a different assembly to the XAML file:
 
-```markup
+```xml
 <Image Source="resm:MyApp.Assets.icon.png?assembly=MyAssembly"/>
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/ide-support.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/ide-support.md
@@ -50,7 +50,7 @@ With the namespace added, the following design-time properties become available:
 
 The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to the control being previewed.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -64,7 +64,7 @@ The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to 
 
 The `d:DataContext` property applies a `DataContext` only at design-time. It is recommended that you use this property in conjunction with the `{x:Static}` directive to reference a static property in one of your assemblies:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -91,7 +91,7 @@ namespace My.Namespace
 ### Design.DataContext
 
 Alternatively you can use `Design.DataContext` attached property. As well as Design.Width and Design.Height.
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/data-binding.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/data-binding.md
@@ -13,7 +13,7 @@ Avalonia includes comprehensive support for [binding](../../data-binding/binding
 
 The following example shows a `TextBlock` when an associated `TextBox` is disabled, by using a binding:
 
-```markup
+```xml
 <StackPanel>
     <TextBox Name="input" IsEnabled="False"/>
     <TextBlock IsVisible="{Binding !#input.IsEnabled}">Sorry, no can do!</TextBlock>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/graphics-and-animations.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/graphics-and-animations.md
@@ -16,7 +16,7 @@ Avalonia introduces an extensive, scalable, and flexible set of graphics feature
 
 Avalonia provides a library of common vector-drawn 2D shapes such as `Ellipse`, `Line`, `Path`, `Polygon` and `Rectangle`.
 
-```markup
+```xml
 <Canvas Background="Yellow" Width="300" Height="400">
     <Rectangle Fill="Blue" Width="63" Height="41" Canvas.Left="40" Canvas.Top="31">
         <Rectangle.OpacityMask>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/index.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/index.md
@@ -11,7 +11,7 @@ XAML is an XML-based markup language that implements an application's appearance
 
 The following example uses XAML to implement the appearance of a window that contains a single button:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/accessing-the-ui-thread.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/accessing-the-ui-thread.md
@@ -19,7 +19,7 @@ In the below example we have a `TextBlock` which shows the result and a `Button`
 
 Our view looks like this: 
 
-```markup
+```xml
 <StackPanel>
   <TextBlock x:Name="TextBlock_Result" />
   <Button Content="Run long running process" Click="Button_OnClick" />

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/code-behind.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/code-behind.md
@@ -39,7 +39,7 @@ namespace AvaloniaApplication1
 
 Note that this class definition corresponds closely to the XAML file:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -60,7 +60,7 @@ In addition, the class contains two more things of interest:
 
 One of the main uses of the code-behind file is to manipulate controls using C\# code. To do this you'll usually first want to get a reference to a named control. This can be done using the `FindControl<T>` method:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">
@@ -154,7 +154,7 @@ For the rest of the documentation, we'll assume you're either using Avalonia tem
 
 Another common use for the code-behind file is to define _event handlers_. Event handlers are defined as methods in the code-behind and referenced from XAML. For example to add a handler for a button click:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/introduction-to-xaml.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/introduction-to-xaml.md
@@ -19,7 +19,7 @@ Both `.xaml` and `.axaml` will be supported going forward, so feel free to use t
 
 A basic Avalonia XAML file looks like this:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -97,7 +97,7 @@ using Avalonia.Metadata;
 
 Controls are added to the XAML by adding an XML element with the control's class name. For example to add a button as the child of the window you would write:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button>Hello World!</Button>
@@ -110,7 +110,7 @@ See the [controls documentation](../../controls) for a list of the controls incl
 
 You can set a property of a control by adding an XML attribute to an element. For example to create a button with a blue background you could write:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Background="Blue">Hello World!</Button>
@@ -123,7 +123,7 @@ You can also use _property element syntax_ for setting properties. For more info
 
 You may notice that the button above has its "Hello World!" content placed directly inside the XML element. This could also be written as a property using:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="Hello World"/>
@@ -136,7 +136,7 @@ This is because [`Button.Content`](http://reference.avaloniaui.net/api/Avalonia.
 
 You can bind a property using the `{Binding}` markup extension:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="{Binding Greeting}"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/data-persistence.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/data-persistence.md
@@ -57,7 +57,7 @@ public class MainWindow : ReactiveWindow<MainViewModel>
 
 The XAML of our `ReactiveWindow` will look like as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="ReactiveUI.Samples.Suspension.MainWindow"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/routing.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/routing.md
@@ -41,7 +41,7 @@ namespace RoutingExample
 
 **FirstView.xaml**
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="RoutingExample.FirstView">
@@ -113,7 +113,7 @@ namespace RoutingExample
 
 Now we need to place the `RoutedViewHost` XAML control to our main view. It will resolve and embed appropriate views for the view models based on the supplied `IViewLocator` implementation and the passed `Router` instance of type `RoutingState`. Note, that you need to import `rxui` namespace for `RoutedViewHost` to work. Additionally, you can override animations that are played when `RoutedViewHost` changes a view — simply override `RoutedViewHost.PageTransition` property in XAML. For latest builds from MyGet use `xmlns:rxui="http://reactiveui.net"`, for 0.8.0 release on NuGet use `xmlns:rxui="clr-namespace:Avalonia;assembly=Avalonia.ReactiveUI"` as in the example below.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:rxui="clr-namespace:Avalonia.ReactiveUI;assembly=Avalonia.ReactiveUI"
         xmlns:app="clr-namespace:RoutingExample"
@@ -158,7 +158,7 @@ Now we need to place the `RoutedViewHost` XAML control to our main view. It will
 
 To disable the animations, simply set the `RoutedViewHost.PageTransition` property to `{x:Null}`, like so:
 
-```markup
+```xml
 <rxui:RoutedViewHost Grid.Row="0" Router="{Binding Router}" PageTransition="{x:Null}">
     <rxui:RoutedViewHost.DefaultContent>
         <TextBlock Text="Default content"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/view-activation.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/view-activation.md
@@ -34,7 +34,7 @@ public class ViewModel : ReactiveObject, IActivatableViewModel
 
 This is the UI for the view model you see above.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         Background="#f0f0f0" FontFamily="Ubuntu"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/running-on-raspbian-lite-via-drm.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/running-on-raspbian-lite-via-drm.md
@@ -91,7 +91,7 @@ When we work via FrameBuffer there are no windows, so we need a separate view (U
 counterpart to the normal window.
 
 `MainView` will be our app base in which we develop our UI:
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -113,7 +113,7 @@ counterpart to the normal window.
 ```
 
 Now create a new UserControl with name `MainSingleView` and host the `MainView`:
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -128,7 +128,7 @@ Now create a new UserControl with name `MainSingleView` and host the `MainView`:
 ```
 
 Also change the `MainWindow.axaml` to host the `MainView` inside:
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/input/hotkeys.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/input/hotkeys.md
@@ -5,7 +5,7 @@ title: Hotkeys
 
 Various Controls that implement `ICommandSource` have a `HotKey` property that you can set or bind to. Pressing the hotkey will execute the command [bound](../data-binding/binding-to-commands) to the Control.
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem x:Name="SaveMenuItem" Header="_Save" Command="{Binding SaveCommand}" HotKey="Ctrl+S"/>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/input/routed-events.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/input/routed-events.md
@@ -68,7 +68,7 @@ public class SampleControl: Control
 
 To add a handler for an event using XAML, you declare the event name as an attribute on the element that is an event listener. The value of the attribute is the name of your implemented handler method, which must exist in the class of the code-behind file.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -105,7 +105,7 @@ Each of the above considerations is discussed in a separate section of this topi
 
 To add an event handler in XAML, you simply add the event name to an element as an attribute and set the attribute value as the name of the event handler that implements an appropriate delegate, as in the following example.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -202,7 +202,7 @@ The Avalonia input system uses attached events extensively. However, nearly all 
 
 Another syntax usage that resembles _typename_._eventname_ attached event syntax but is not strictly speaking an attached event usage is when you attach handlers for routed events that are raised by child elements. You attach the handlers to a common parent, to take advantage of event routing, even though the common parent might not have the relevant routed event as a member. Consider this example again:
 
-```markup
+```xml
 <Border Height="50" Width="300">
   <StackPanel Orientation="Horizontal" Button.Click="CommonClickHandler">
     <Button Name="YesButton">Yes</Button>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/layout/alignment-margins-and-padding.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/layout/alignment-margins-and-padding.md
@@ -23,7 +23,7 @@ At first glance, the `Button` elements in this illustration may appear to be pla
 
 The following example describes how to create the layout in the preceding illustration. A `Border` element encapsulates a parent `StackPanel`, with a `Padding` value of 15 device independent pixels. This accounts for the narrow `LightBlue` band that surrounds the child `StackPanel`. Child elements of the `StackPanel` are used to illustrate each of the various positioning properties that are detailed in this topic. Three `Button` elements are used to demonstrate both the `Margin` and `HorizontalAlignment` properties.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication2.MainWindow"
@@ -72,7 +72,7 @@ The `HorizontalAlignment` property declares the horizontal alignment characteris
 
 The following example shows how to apply the `HorizontalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors.
 
-```markup
+```xml
 <Button HorizontalAlignment="Left">Button 1 (Left)</Button>
 <Button HorizontalAlignment="Right">Button 2 (Right)</Button>
 <Button HorizontalAlignment="Center">Button 3 (Center)</Button>
@@ -96,7 +96,7 @@ The `VerticalAlignment` property describes the vertical alignment characteristic
 
 The following example shows how to apply the `VerticalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors. For purposes of this sample, a `Grid` element with visible gridlines is used as the parent, to better illustrate the layout behavior of each property value.
 
-```markup
+```xml
 <Border Background="LightBlue" BorderBrush="Black" BorderThickness="2" Padding="15">
     <Grid Background="White" ShowGridLines="True">
       <Grid.RowDefinitions>
@@ -131,7 +131,7 @@ A non-zero margin applies space outside the element's `Bounds`.
 
 The following example shows how to apply uniform margins around a group of `Button` elements. The `Button` elements are spaced evenly with a ten-pixel margin buffer in each direction.
 
-```markup
+```xml
 <Button Margin="10">Button 7</Button>
 <Button Margin="10">Button 8</Button>
 <Button Margin="10">Button 9</Button>
@@ -139,7 +139,7 @@ The following example shows how to apply uniform margins around a group of `Butt
 
 In many instances, a uniform margin is not appropriate. In these cases, non-uniform spacing can be applied. The following example shows how to apply non-uniform margin spacing to child elements. Margins are described in this order: left, top, right, bottom.
 
-```markup
+```xml
 <Button Margin="0,10,0,10">Button 1</Button>
 <Button Margin="0,10,0,10">Button 2</Button>
 <Button Margin="0,10,0,10">Button 3</Button>
@@ -151,7 +151,7 @@ Padding is similar to `Margin` in most respects. The Padding property is exposed
 
 The following example shows how to apply `Padding` to a parent `Border` element.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"
@@ -165,7 +165,7 @@ The following example shows how to apply `Padding` to a parent `Border` element.
 
 The following example demonstrates each of the concepts that are detailed in this topic. Building on the infrastructure found in the first sample in this topic, this example adds a`Grid` element as a child of the `Border` in the first sample. `Padding` is applied to the parent `Border` element. The`Grid` is used to partition space between three child `StackPanel` elements. `Button` elements are again used to show the various effects of `Margin` and `HorizontalAlignment`. `TextBlock` elements are added to each `ColumnDefinition` to better define the various properties applied to the `Button` elements in each column.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/layout/panels-overview.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/layout/panels-overview.md
@@ -79,7 +79,7 @@ myParentCanvas.Children.Add(myCanvas3);
 
 XAML
 
-```markup
+```xml
 <Canvas Height="400" Width="400">
   <Canvas Height="100" Width="100" Top="0" Left="0" Background="Red"/>
   <Canvas Height="100" Width="100" Top="100" Left="100" Background="Green"/>
@@ -176,7 +176,7 @@ myDockPanel.Children.Add(myBorder5);
 
 XAML
 
-```markup
+```xml
 <DockPanel LastChildFill="True">
   <Border Height="25" Background="SkyBlue" BorderBrush="Black" BorderThickness="1" DockPanel.Dock="Top">
     <TextBlock Foreground="Black">Dock = "Top"</TextBlock>
@@ -378,7 +378,7 @@ myWrapPanel.Children.Add(btn4);
 
 XAML
 
-```markup
+```xml
 <Border HorizontalAlignment="Left" VerticalAlignment="Top" BorderBrush="Black" BorderThickness="2">
   <WrapPanel Background="LightBlue" Width="200" Height="100">
     <Button Width="200">Button 1</Button>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/index.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/index.md
@@ -4,7 +4,7 @@
 
 The following style selects any `TextBlock` in the `Window` with a `h1` _style class_ and sets its font size to 24 point and font weight to bold:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/resources.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/resources.md
@@ -9,7 +9,7 @@ Often, styles and controls will need to share resources such as \(but not limite
 
 If a resource is to be available to your entire application, you can define it in `App.xaml`/`App.axaml`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.App">
@@ -21,7 +21,7 @@ If a resource is to be available to your entire application, you can define it i
 
 Alternatively you can declare resources on a `Window` or `UserControl`: the resource will be available to the `Window`/`UserControl` and its children:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MyUserControl">
@@ -33,7 +33,7 @@ Alternatively you can declare resources on a `Window` or `UserControl`: the reso
 
 Or in fact any control at all:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MainWindow">
@@ -47,7 +47,7 @@ Or in fact any control at all:
 
 You can also declare resources on styles:
 
-```markup
+```xml
 <Style Selector="TextBlock.warn">
   <Style.Resources>
     <SolidColorBrush x:Key="Warning">Yellow</SolidColorBrush>
@@ -59,7 +59,7 @@ You can also declare resources on styles:
 
 You can references resources from controls using the `{DynamicResource}` markup extensions, e.g.:
 
-```markup
+```xml
 <Border Background="{DynamicResource Warning}">
   Look out!
 </Border>
@@ -76,7 +76,7 @@ In return, `StaticResource` doesn't need to add an event handler to listen for c
 
 Resources are resolved by walking up the logical tree from the point of the `DynamicResource` or `StaticResource` until a resource with the requested key is found. This means that resources can be "overridden" in sub-trees of the application, for example:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MyUserControl">
@@ -102,7 +102,7 @@ Here's the `Border`'s background will be `Orange` because its parent `StackPanel
 
 The `Resources` property on each control and style is of type `ResourceDictionary`. Resource dictionaries can also include other resource dictionaries by making use of the `MergedDictionaries` property. To include a resource dictionary in another you can use the `ResourceInclude` class, e.g.:
 
-```markup
+```xml
 <Window.Resources>
   <ResourceDictionary>
     <ResourceDictionary.MergedDictionaries>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/selectors.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/selectors.md
@@ -227,7 +227,7 @@ Matches any control which has the specified property set to the specified value.
 :::info
 **Note:** When using a `AttachedProperty` in selectors inside XAML, it has to be wrapped in parenthesis.
 
-```markup
+```xml
 <Style Selector="TextBlock[(Grid.Row)=0]">
 ```
 :::

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/styles.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/styles.md
@@ -9,7 +9,7 @@ A style applies to the control that it is defined on and all descendent controls
 
 The following style selects any `TextBlock` with a `h1` _style class_ and sets its font size to 24 point and font weight to bold:
 
-```markup
+```xml
 <Style Selector="TextBlock.h1">
     <Setter Property="FontSize" Value="24"/>
     <Setter Property="FontWeight" Value="Bold"/>
@@ -18,7 +18,7 @@ The following style selects any `TextBlock` with a `h1` _style class_ and sets i
 
 Styles can be defined on any control or on the `Application` object by adding them to the [`Control.Styles`](http://reference.avaloniaui.net/api/Avalonia/StyledElement/0A46A84A) or [`Application.Styles`](http://reference.avaloniaui.net/api/Avalonia/Application/04017CAF) collections.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>
@@ -34,7 +34,7 @@ Styles can be defined on any control or on the `Application` object by adding th
 
 Styles can also be included from other files using the `StyleInclude` class, e.g.:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>
@@ -49,7 +49,7 @@ Where `CustomStyles.xaml` is a XAML file with a root of either `Style` or `Style
 
 CustomStyles.xaml
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="TextBlock.h1">
@@ -64,12 +64,12 @@ Note that unlike WPF/UWP, styles will have no effect if they're added to a contr
 
 As in CSS, controls can be given _style classes_ which can be used in selectors. Style classes can be assigned in XAML by setting the `Classes` property to a space-separated list of strings. The following example applies the `h1` and `blue` style classes to a `Button`:
 
-```markup
+```xml
 <Button Classes="h1 blue"/>
 ```
 
 If you need to add or remove class by condition, you can use the following special syntax:
-```markup
+```xml
 <Button Classes.blue="{Binding IsSpecial}" />
 ```
 
@@ -88,7 +88,7 @@ One example of a pseudoclass is the `:pointerover` \(similar to `:hover` in CSS\
 
 Pseudoclasses provide the functionality of `Triggers` in WPF and `VisualStateManager` in UWP:
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Border:pointerover">
@@ -103,7 +103,7 @@ Pseudoclasses provide the functionality of `Triggers` in WPF and `VisualStateMan
 
 Another example that involves changing properties inside of control [template](selectors.md#template):
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Button:pressed /template/ ContentPresenter">
@@ -147,14 +147,14 @@ For more information see the [selectors documentation](selectors.md).
 
 A style's setters describe what will happen when the selector matches a control. They are simple property/value pairs written in the format:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="24"/>
 <Setter Property="Padding" Value="4 2 0 4"/>
 ```
 
 You can also use long-form syntax to declare more complex object values:
 
-```markup
+```xml
 <Setter Property="MyProperty">
    <MyObject Property1="My Value"/>
 </Setter>
@@ -162,7 +162,7 @@ You can also use long-form syntax to declare more complex object values:
 
 Bindings can also be applied using setters and can bind to the target control's `DataContext`:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="{Binding SelectedFontSize}"/>
 ```
 
@@ -170,7 +170,7 @@ Whenever a style is matched with a control, all of the setters will be applied t
 
 Note that the `Setter` creates a single instance of `Value` which will be applied to all controls that the style matches: if the object is mutable then changes will be reflected on all controls. Following on from this, any bindings on an _object within the setter `Value`_ will not have access to the target control's `DataContext` as there may be multiple target controls:
 
-```markup
+```xml
 <Style Selector="local|MyControl">
   <Setter Property="MyProperty">
      <MyObject Property1="{Binding MyViewModelProperty}"/>
@@ -182,7 +182,7 @@ In the above example, the binding source will be `MyObject.DataContext`, not `My
 
 Note: at present, if you are using compiled bindings, you need to explicitly set the data type of the binding source in the `<Style>` element:
 
-```markup
+```xml
 <Style Selector="MyControl" x:DataType="MyViewModelClass">
   <Setter Property="ControlProperty" Value="{Binding MyViewModelProperty}" />
 </Style>
@@ -192,7 +192,7 @@ Note: at present, if you are using compiled bindings, you need to explicitly set
 
 As mentioned above, usually a single instance of a setter's `Value` is created and shared across all matching controls. Due to this, to use a control as a setter value, the control must be wrapped in a `<Template>`:
 
-```markup
+```xml
 <Style Selector="Border.empty">
   <Setter Property="Child">
     <Template>
@@ -206,7 +206,7 @@ As mentioned above, usually a single instance of a setter's `Value` is created a
 
 If multiple styles match a control, and they both attempt to set the same property then the style _closest to the control_ will win. Consider the following example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/troubleshooting.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/styling/troubleshooting.md
@@ -14,7 +14,7 @@ Avalonia selectors, like CSS selectors, do not raise any errors or warnings, whe
 
 Styles are applied in order of declaration. If there are **multiple** style files that target the same control property, one style can override the other:
 
-```markup title="Styles1.axaml"
+```xml title="Styles1.axaml"
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Blue" />
     <Style Property="FontSize" Value="16" />
@@ -22,13 +22,13 @@ Styles are applied in order of declaration. If there are **multiple** style file
 ```
 
 
-```markup title="Styles2.axaml"
+```xml title="Styles2.axaml"
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Green" />
 </Style>
 ```
 
-```markup title="App.axaml"
+```xml title="App.axaml"
 <StyleInclude Source="Style1.axaml" />
 <StyleInclude Source="Style2.axaml" />
 ```
@@ -42,7 +42,7 @@ Similarly, to WPF, Avalonia properties can have multiple values, often of differ
 
 In this example you can see that local value (defined directly on the control) has higher priority than style value, so text block will have red foreground:
 
-```markup
+```xml
 <TextBlock Classes="header" Foreground="Red" />
 ...
 <Style Selector="TextBlock.header">
@@ -60,7 +60,7 @@ Some default Avalonia styles use local values in their templates instead of temp
 
 Let's imagine a situation in which you might expect a second style to override previous one, but it doesn't:
 
-```markup
+```xml
 <Style Selector="Border:pointerover">
     <Setter Property="Background" Value="Blue" />
 </Style>
@@ -81,7 +81,7 @@ Visit the Avalonia source code to find the [original templates](https://github.c
 
 The following code example of styles that can be expected to work on top of default styles:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="Red" />
 </Style>
@@ -94,7 +94,7 @@ You might expect the `Button` to be red by default and blue when pointer is over
 
 The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code (old [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) theme and new [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="{DynamicResource ButtonBackground}"/>
     <Setter Property="Template">
@@ -112,7 +112,7 @@ The reason is hidden in the Button's template. You can find the default template
 
 The actual background is rendered by a `ContentPresenter`, which in the default is bound to the Buttons `Background` property. However in the pointer-over state the selector is directly applying the background to the `ContentPresenter (Button:pointerover /template/ ContentPresenter#PART_ContentPresenter`) That's why when our setter was ignored in the previous code example. The corrected code should target content presenter directly as well:
 
-```markup
+```xml
 <!-- Here #PART_ContentPresenter name selector is not necessary, but was added to have more specific style -->
 <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Blue" />

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/templates/creating-data-templates-in-code.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/templates/creating-data-templates-in-code.md
@@ -17,7 +17,7 @@ var template = new FuncDataTemplate<Student>((value, namescope) =>
 
 Is equivalent to:
 
-```markup
+```xml
 <DataTemplate DataType="{x:Type local:Student}">
     <TextBlock Text="{Binding FirstName}"/>
 </DataTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/templates/data-templates.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/templates/data-templates.md
@@ -10,7 +10,7 @@ import ControlContentStudentScreenshot from '/img/templates/data-templates/stude
 
 Many controls have a `Content` property, such as [`ContentControl.Content`](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756). `Window` inherits from [`ContentControl`](../controls/contentcontrol), so lets use that as an example. You're probably familiar with what happens when you put a control in the `Window.Content` property - the window displays the control:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Button HorizontalAlignment="Center"
@@ -24,7 +24,7 @@ Many controls have a `Content` property, such as [`ContentControl.Content`](http
 
 Similarly if you put a string as the window content, the window will display the string:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   Hello World!
@@ -52,7 +52,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -66,7 +66,7 @@ Not very helpful. That's because Avalonia doesn't know _how_ to display an objec
 
 The easiest way to do this on `Window` (and any control that inherits from `ContentControl`) is to set the [`ContentTemplate`](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/7AA9343E) property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -97,7 +97,7 @@ The data template for the window content doesn't only come from the `ContentTemp
 
 Using the `DataTemplates` collection the previous example could be written as:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -139,7 +139,7 @@ namespace Example
 
 Now we can add a separate data template for the `Teacher` type and depending on the type of object in the `MainWindowViewModel.Content` property, the appropriate view will be displayed:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/templates/implement-idatatemplates.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/templates/implement-idatatemplates.md
@@ -37,7 +37,7 @@ public class MyDataTemplate : IDataTemplate
 
 You can now use the class `MyDataTemplate` in your view like this:
 
-```markup
+```xml
 <!-- remember to add the needed prefix in your view -->
 <!-- xmlns:dataTemplates="using:MyApp.DataTemplates" -->
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-and-layout-controls.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-and-layout-controls.md
@@ -13,7 +13,7 @@ Let's start by adding a `Button` to the `MainWindow`. The button will allow the 
 
 In `MainWindow.axaml` change the code as follows, adding a Button inside the Panel.
 
-```markup
+```xml
 <Panel>
     <ExperimentalAcrylicBorder IsHitTestVisible="False">
         <ExperimentalAcrylicBorder.Material>
@@ -72,7 +72,7 @@ Place the `<Button>` element inside a simple `<Panel>` element.
 
 The simplest way to control the layout of a control is with the `HorizontalAlignment`and `VerticalAlignment` properties.
 
-```markup
+```xml
 <Panel>
   <Button Content="Buy Music" Margin="40" Command="{Binding BuyMusicCommand}" HorizontalAlignment="Right" VerticalAlignment="Top" />
 </Panel>
@@ -88,7 +88,7 @@ Find the name, in this case `store_microsoft_regular`.
 
 There should be some code similar to:
 
-```markup
+```xml
 <StreamGeometry x:Key="store_microsoft_regular">M11.5 9.5V13H8V9.5H11.5Z M11.5 17.5V14H8V17.5H11.5Z M16 9.5V13H12.5V9.5H16Z M16 17.5V14H12.5V17.5H16Z M8 6V3.75C8 2.7835 8.7835 2 9.75 2H14.25C15.2165 2 16 2.7835 16 3.75V6H21.25C21.6642 6 22 6.33579 22 6.75V18.25C22 19.7688 20.7688 21 19.25 21H4.75C3.23122 21 2 19.7688 2 18.25V6.75C2 6.33579 2.33579 6 2.75 6H8ZM9.5 3.75V6H14.5V3.75C14.5 3.61193 14.3881 3.5 14.25 3.5H9.75C9.61193 3.5 9.5 3.61193 9.5 3.75ZM3.5 18.25C3.5 18.9404 4.05964 19.5 4.75 19.5H19.25C19.9404 19.5 20.5 18.9404 20.5 18.25V7.5H3.5V18.25Z</StreamGeometry>
 ```
 
@@ -102,7 +102,7 @@ Enter the name `Icons` when prompted and press `Enter`.
 
 A new `xaml` file will be created that we can put styles or icons inside.
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -117,7 +117,7 @@ A new `xaml` file will be created that we can put styles or icons inside.
 
 Add your Icon code inside wrapped in a `Style` element as a resource like so.
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -137,7 +137,7 @@ Add your Icon code inside wrapped in a `Style` element as a resource like so.
 
 Open `App.axaml` and add a `StyleInclude` so that the `Icons.axaml`can be loaded.
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme Mode="Dark"/>
     <StyleInclude Source="avares://Avalonia.MusicStore/Icons.axaml" />
@@ -148,7 +148,7 @@ Now build the application so that the Icons are available in the previewer.
 
 Return to `MainWindow.axaml`, we can add the Icon to the Button like so...
 
-```markup
+```xml
 <Button Margin="40" HorizontalAlignment="Right" VerticalAlignment="Top" Command="{Binding BuyMusicCommand}">
     <PathIcon Data="{StaticResource store_microsoft_regular}" />
 </Button>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-content-to-dialog.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-content-to-dialog.md
@@ -34,7 +34,7 @@ Build the project so that the previewer will work.
 
 Declare a `<DockPanel>`.
 
-```markup
+```xml
 <DockPanel>
 
 </DockPanel>
@@ -42,7 +42,7 @@ Declare a `<DockPanel>`.
 
 Inside the `DockPanel` add a `<StackPanel>`. Set `DockPanel.Dock="Top"` on the `StackPanel` so that it will be positioned at the top.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
 
@@ -52,7 +52,7 @@ Inside the `DockPanel` add a `<StackPanel>`. Set `DockPanel.Dock="Top"` on the `
 
 Inside the `StackPanel` add a `TextBox` and a `ProgressBar`.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
         <TextBox Text="{Binding SearchText}" Watermark="Search for Albums...." />
@@ -124,7 +124,7 @@ Back inside our DockPanel, add a `Button` and set it to Dock at the bottom. Set 
 
 Then bind its `Command` to `BuyMusicCommand` which we will create in the next chapter.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
         <TextBox Text="{Binding SearchText}" Watermark="Search for Albums...." />
@@ -138,7 +138,7 @@ Add a `ListBox` to the `DockPanel`. Since this is the last item in the Panel it 
 
 Bind the `Items` and `SelectedItem` properties as shown, set the `Background` to `Transparent`. Add a `Margin` of `0 20`. This means left and right sides have 0 and top and bottom have 20. This creates some space between the other controls.
 
-```markup
+```xml
 <ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" Background="Transparent" Margin="0 20" />
 ```
 
@@ -209,7 +209,7 @@ namespace Avalonia.MusicStore
 
 And then add that to `App.axaml`:
 
- ```markup
+ ```xml
 <Application.DataTemplates>
     <local:ViewLocator />
 </Application.DataTemplates>
@@ -240,13 +240,13 @@ xmlns:local="using:Avalonia.MusicStore.Views"
 
 Then inside the `<Panel>` add.
 
-```markup
+```xml
 <local:MusicStoreView />
 ```
 
 Your `MusicStoreWindow.axaml` should look like this.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -297,7 +297,7 @@ public class AlbumViewModel : ViewModelBase
 
 In your newly created `AlbumView` add the following code:
 
-```markup
+```xml
 <StackPanel Spacing="5" Width="200">
     <Border CornerRadius="10" ClipToBounds="True">
         <Panel Background="#7FFF22DD">
@@ -320,7 +320,7 @@ The border contains a `Panel` with a `Background` set, using a hexadecimal colou
 
 This `Panel` contains an `Image` and a `PathIcon` in front of it. Add the source for the Icon to `Icons.axaml`:
 
-```markup
+```xml
 <StreamGeometry x:Key="music_regular">M11.5,2.75 C11.5,2.22634895 12.0230228,1.86388952 12.5133347,2.04775015 L18.8913911,4.43943933 C20.1598961,4.91511241 21.0002742,6.1277638 21.0002742,7.48252202 L21.0002742,10.7513533 C21.0002742,11.2750044 20.4772513,11.6374638 19.9869395,11.4536032 L13,8.83332147 L13,17.5 C13,17.5545945 12.9941667,17.6078265 12.9830895,17.6591069 C12.9940859,17.7709636 13,17.884807 13,18 C13,20.2596863 10.7242052,22 8,22 C5.27579485,22 3,20.2596863 3,18 C3,15.7403137 5.27579485,14 8,14 C9.3521238,14 10.5937815,14.428727 11.5015337,15.1368931 L11.5,2.75 Z M8,15.5 C6.02978478,15.5 4.5,16.6698354 4.5,18 C4.5,19.3301646 6.02978478,20.5 8,20.5 C9.97021522,20.5 11.5,19.3301646 11.5,18 C11.5,16.6698354 9.97021522,15.5 8,15.5 Z M13,3.83223733 L13,7.23159672 L19.5002742,9.669116 L19.5002742,7.48252202 C19.5002742,6.75303682 19.0477629,6.10007069 18.3647217,5.84393903 L13,3.83223733 Z</StreamGeometry>
 ```
 
@@ -338,7 +338,7 @@ As can be seen the albums are displayed vertically. However it would be nice to 
 
 Luckily `ListBox` provides a solution to this with something called `ItemsPanelTemplate`. By default the `ListBox` has its `ItemPanel` property set to an `ItemsPanelTemplate` which contains a `StackPanel`, we can change this to a `WrapPanel` like so.
 
-```markup
+```xml
 <ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" Background="Transparent" Margin="0 20">
     <ListBox.ItemsPanel>
         <ItemsPanelTemplate>

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-items-to-users-collection.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-items-to-users-collection.md
@@ -13,7 +13,7 @@ Modify the `MainWindow.axaml` so that it places the existing `Button` inside a p
 
 We can then use an `ItemsControl` instead of a `ListBox` as we did before. An `ItemsControl` is the exact same as a `ListBox` except it doesn't allow the user to select anything.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Avalonia.MusicStore.ViewModels"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/creating-a-modern-looking-window.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/creating-a-modern-looking-window.md
@@ -15,7 +15,7 @@ Let's try and make this look a little more modern by applying `Dark` mode and so
 
    Change the FluentTheme Mode from Default to Dark.
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Avolonia.MusicStore.App"
@@ -38,7 +38,7 @@ Let's try and make this look a little more modern by applying `Dark` mode and so
 
 1. After where it says `Title="Avalonia.MusicStore"` add the following code:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -57,7 +57,7 @@ This will make the Window Transparent and apply a Blur.
 
 To apply acrylic to the window, that we can tint and customize for a modern look, replace the `<TextBlock>` with the following code:
 
-```markup
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -102,7 +102,7 @@ Notice we have a nice acrylic window effect. Shame about the titlebar, though. L
 
    To enable this mode on the `Window` element set the `ExtendClientAreaToDecorationsHint` property to `True`.
 
-```markup
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/opening-a-dialog.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/opening-a-dialog.md
@@ -20,7 +20,7 @@ When prompted name this MusicStoreWindow and press the `Enter` key.
 
 This will add the following code:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -34,7 +34,7 @@ This will add the following code:
 
 Change this code as follows to enable the Acrylic and extended client area so the Window will look like our `MainWindow`.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/adding-new-items.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/adding-new-items.md
@@ -15,7 +15,7 @@ We start by creating the view \(see [here](../todo-list-app/creating-a-view#crea
 
 Views/AddItemView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -104,7 +104,7 @@ We now want to bind our `Window.Content` property to this new `Content` property
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -119,7 +119,7 @@ And finally we need to make the "Add an item" button call `MainWindowViewModel.A
 
 Views/TodoListView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -146,7 +146,7 @@ Views/TodoListView.axaml
 
 The binding we've added to `<Button>` is:
 
-```markup
+```xml
 Command="{Binding $parent[Window].DataContext.AddItem}"
 ```
 
@@ -254,7 +254,7 @@ We can now bind the OK and Cancel buttons in the view to the `Ok` and `Cancel` c
 
 Views/AddItemView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/creating-a-view.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/creating-a-view.md
@@ -37,7 +37,7 @@ dotnet new avalonia.usercontrol -o Views -n TodoListView  --namespace Todo.Views
 
 The template should create a XAML file with the following contents in the `Views` directory, alongside `MainWindow.axaml`
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -74,7 +74,7 @@ We're not going to touch the code-behind file for a little while, but notice tha
 
 Edit the contents of `Views/TodoListView.axaml` to contain the following:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -102,7 +102,7 @@ If you're using the Visual Studio extension you should see the contents of the c
 
 Lets take a look at the code we just entered line-by-line.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -131,7 +131,7 @@ This line tells the XAML engine where the class that accompanies the XAML can be
 
 Ok, that's the boilerplate out of the way! Now onto the meat of the code:
 
-```markup
+```xml
 <DockPanel>
 ```
 
@@ -139,13 +139,13 @@ First we add a `DockPanel` as the child of the `UserControl`. A `UserControl` ca
 
 `DockPanel` is a type of panel which lays out its controls at the top, bottom, left and right sides, with a single control filling the remaining space in the middle.
 
-```markup
+```xml
 <Button DockPanel.Dock="Bottom" HorizontalAlignment="Center">Add an item</Button>
 ```
 
 Now we declare the `Button` that appears at the bottom of the view. The `DockPanel.Dock` attribute tells the containing `DockPanel` that we want the button to appear at the bottom. `HorizontalAlignment` centers button in the middle of the parent. As the element content we set the button text: `"Add an item"`.
 
-```markup
+```xml
 <StackPanel>
 ```
 
@@ -153,7 +153,7 @@ Next we add another panel: a `StackPanel`. `StackPanel` lays out its child contr
 
 Because this is the last child in the `DockPanel` it will fill the remaining space in the center of the control.
 
-```markup
+```xml
 <CheckBox Margin="4">Walk the dog</CheckBox>
 <CheckBox Margin="4">Buy some milk</CheckBox>
 ```
@@ -166,7 +166,7 @@ To see the view we've just created, we need to add it to the application's main 
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Todo.Views"
@@ -186,7 +186,7 @@ xmlns:views="clr-namespace:Todo.Views"
 
 We want to display the `TodoListView` control we just created, which is in the `Todo.Views` C# namespace. Here we're mapping the `Todo.Views` namespace to the `views` XML namespace. Any control that is not a core Avalonia control will generally need this type of mapping in order for the XAML engine to find the control.
 
-```markup
+```xml
 <views:TodoListView/>
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/locating-views.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/locating-views.md
@@ -7,7 +7,7 @@ Hold on, rewind a second. An observant reader will have noticed something strang
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -66,7 +66,7 @@ namespace Todo
 
 An instance of `ViewLocator` is present in `Application.DataTemplates`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Todo"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/wiring-up-the-views.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/wiring-up-the-views.md
@@ -13,7 +13,7 @@ We're exposing the list in `MainWindowViewModel.List` so let's use that property
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -34,13 +34,13 @@ Content="{Binding List}"
 
 The `Window.Content` property can either be set by placing a control as a child of the `Window` \([as we were doing previously](creating-a-view#display-the-view-in-the-window)\), or by assigning a value to the `Content` property. Both of these syntaxes are equivalent, meaning that writing:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">Hello World!</Window>
 ```
 
 Is _exactly_ the same as writing:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui" Content="Hello World!"/>
 ```
 
@@ -50,7 +50,7 @@ Now we need to make `TodoListView` get the list of TODO items from the view mode
 
 Views/TodoListView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -77,7 +77,7 @@ Views/TodoListView.axaml
 
 The first thing to notice here is that we've changed the `<StackPanel>` control to an `ItemsControl`:
 
-```markup
+```xml
 <ItemsControl Items="{Binding Items}">
 ```
 
@@ -85,7 +85,7 @@ The `ItemsControl` is a very simple control which displays each item in the coll
 
 How each item is displayed is controlled by the `ItemTemplate`. The `ItemTemplate` takes a [`DataTemplate`](https://avaloniaui.net/docs/templates/datatemplate) whose content is repeated for each item. In this case we display each item as a `CheckBox`, with the check state bound to the `IsChecked` property of the `TodoItemViewModel` and the content bound to the `Description`. We also set a `Margin` as before to space the items out a little:
 
-```markup
+```xml
 <ItemsControl.ItemTemplate>
   <DataTemplate>
     <CheckBox Margin="4"

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/datatemplates.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/datatemplates.md
@@ -5,7 +5,7 @@ title: DataTemplates
 
 As styles aren't stored in `Resources`, neither are `DataTemplates`. Instead, `DataTemplates` are placed in a `DataTemplates` collection on each control \(and on `Application`\):
 
-```markup
+```xml
 <UserControl xmlns:viewmodels="clr-namespace:MyApp.ViewModels;assembly=MyApp">
     <UserControl.DataTemplates>
         <DataTemplate DataType="viewmodels:FooViewModel">

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/grid.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/grid.md
@@ -5,7 +5,7 @@ title: Grid
 
 Column and row definitions can be specified in Avalonia using strings, avoiding the clunky syntax in WPF:
 
-```markup
+```xml
 <Grid ColumnDefinitions="Auto,*,32" RowDefinitions="*,Auto">
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/styling.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/styling.md
@@ -5,7 +5,7 @@ title: Styling
 
 The most obvious difference from other XAML frameworks is that Avalonia uses a [CSS-like styling system](../styling/styles). Styles aren't stored in a `Resources` collection as in WPF, they are stored in a separate `Styles` collection:
 
-```markup
+```xml
 <UserControl>
     <UserControl.Styles>
         <!-- Make TextBlocks with the h1 style class have a font size of 24 points -->

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/data/data-binding/compiled-bindings.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/data/data-binding/compiled-bindings.md
@@ -21,7 +21,7 @@ description: CONCEPTS
 
 如果您希望应用程序默认情况下全局使用编译绑定，可以将以下内容添加到您的项目文件中：
 
-```markup
+```xml
 <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 ```
 
@@ -33,7 +33,7 @@ description: CONCEPTS
 
 现在，您可以通过设置`x:CompileBindings="[True|False]"`来启用或禁用编译绑定。所有子节点都将继承此属性，因此您可以在根节点中启用它，并在需要时禁用特定子节点。
 
-```markup
+```xml
 <!-- 设置DataType并启用编译绑定 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -59,7 +59,7 @@ description: CONCEPTS
 
 如果您不希望为所有子节点启用编译绑定，还可以使用`CompiledBinding`标记。您仍然需要定义`DataType`，但可以省略`x:CompileBindings="True"`。
 
-```markup
+```xml
 <!-- 设置DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -85,7 +85,7 @@ description: CONCEPTS
 
 如果您已在根节点启用了编译绑定（通过`x:CompileBindings="True"`），并且您要么不想在某个位置使用编译绑定，要么遇到了[已知的限制](#known-limitations)，则可以使用`ReflectionBinding`标记。
 
-```markup
+```xml
 <!-- 设置DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -111,7 +111,7 @@ description: CONCEPTS
 
 在某些情况下，绑定表达式的目标类型无法自动计算。在这种情况下，您必须在绑定表达式中提供一个明确的类型转换。
 
-```markup
+```xml
 <ItemsRepeater ItemsSource="{Binding MyItems}">
 <ItemsRepeater.ItemTemplate>
     <DataTemplate>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/data/data-binding/data-binding-syntax.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/data/data-binding/data-binding-syntax.md
@@ -33,13 +33,13 @@ import DataBindingModeDiagram from '/img/basics/data-binding/data-binding-syntax
 
 绑定路径可以是单个属性，也可以是属性链。例如，如果数据源有一个`Student`属性，该属性返回的对象具有一个`Name`属性，您可以使用以下语法绑定到学生姓名：
 
-```markup
+```xml
 <TextBlock Text="{Binding Student.Name}"/>
 ```
 
 如果数据源有一个数组或列表（带有索引器），则可以将索引添加到绑定路径中，如下所示：
 
-```markup
+```xml
 <TextBlock Text="{Binding Students[0].Name}"/>
 ```
 
@@ -60,7 +60,7 @@ import DataBindingModeDiagram from '/img/basics/data-binding/data-binding-syntax
 
 例如：
 
-```markup
+```xml
 <TextBlock Text="{Binding Name, Mode=OneTime}">
 ```
 
@@ -90,19 +90,19 @@ import DataBindingModeDiagram from '/img/basics/data-binding/data-binding-syntax
 
 或者，您可以使用反斜杠转义模式所需的花括号。例如：
 
-```markup
+```xml
 <TextBlock Text="{Binding FloatValue, StringFormat=\{0:0.0\}}" />
 ```
 
 但是，如果您的模式不以零开头，则不需要转义。此外，如果模式中有空格，则必须用单引号括起来。例如：
 
-```markup
+```xml
 <TextBlock Text="{Binding Animals.Count, StringFormat='I have {0} animals.'}" />
 ```
 
 请注意，这意味着如果模式以您绑定的值开头，则需要转义。例如：
 
-```markup
+```xml
 <TextBlock Text="{Binding Animals.Count, 
                                 StringFormat='{}{0} animals live in the farm.'}" />
 ```

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/user-interface/building-layouts/alignment-margins-and-padding.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/user-interface/building-layouts/alignment-margins-and-padding.md
@@ -20,7 +20,7 @@ Avalonia定位元素有许多使用方式。然而，实现理想的布局不仅
 
 以下示例描述了如何创建上图中的布局。一个`Border`元素封装了一个父元素`StackPanel`，`Padding`值为15个设备独立像素。这就说明了围绕子`StackPanel`的狭窄的`LightBlue`部分。`StackPanel`的子元素用于说明本章节中详细介绍的每个不同的定位属性。三个`Button`元素用于演示`Margin`和`HorizontalAlignment`属性。
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication2.MainWindow"
@@ -69,7 +69,7 @@ Avalonia定位元素有许多使用方式。然而，实现理想的布局不仅
 
 下面的示例展示了如何将`HorizontalAlignment`属性应用于`Button`元素。为了更好地说明各种渲染行为，每种特性值的效果都被展示了出来。
 
-```markup
+```xml
 <Button HorizontalAlignment="Left">Button 1 (Left)</Button>
 <Button HorizontalAlignment="Right">Button 2 (Right)</Button>
 <Button HorizontalAlignment="Center">Button 3 (Center)</Button>
@@ -93,7 +93,7 @@ Avalonia定位元素有许多使用方式。然而，实现理想的布局不仅
 
 下面的示例展示了如何将`VerticalAlignment`属性应用于`Button`元素。为了更好地说明各种渲染行为，每种特性值的效果都被展示了出来。在本示例中，使用具有可见网格线的`Grid`元素作为父元素，以更好地说明每种属性值的布局行为。
 
-```markup
+```xml
 <Border Background="LightBlue" BorderBrush="Black" BorderThickness="2" Padding="15">
     <Grid Background="White" ShowGridLines="True">
       <Grid.RowDefinitions>
@@ -128,7 +128,7 @@ Avalonia定位元素有许多使用方式。然而，实现理想的布局不仅
 
 下面的示例展示了如何在一组`Button`元素周围应用相同的边距。这些`Button`元素的间距是均匀的，每个方向都有10像素的边距缓冲。
 
-```markup
+```xml
 <Button Margin="10">Button 7</Button>
 <Button Margin="10">Button 8</Button>
 <Button Margin="10">Button 9</Button>
@@ -136,7 +136,7 @@ Avalonia定位元素有许多使用方式。然而，实现理想的布局不仅
 
 在许多情况下，统一的边距是不合适的。在这些情况下，可以应用非统一间距。以下示例展示了如何将非统一边距应用于子元素。边距按该顺序描述：左、上、右、下。
 
-```markup
+```xml
 <Button Margin="0,10,0,10">Button 1</Button>
 <Button Margin="0,10,0,10">Button 2</Button>
 <Button Margin="0,10,0,10">Button 3</Button>
@@ -148,7 +148,7 @@ Avalonia定位元素有许多使用方式。然而，实现理想的布局不仅
 
 以下示例展示了如何将`Padding`应用于父`Border`元素。
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"
@@ -162,7 +162,7 @@ Avalonia定位元素有许多使用方式。然而，实现理想的布局不仅
 
 下面的示例演示了本章节中详细介绍的每个概念。在本章节第一个示例的基础上，这个示例添加了一个`Grid`元素作为第一个示例中`Border`的子元素。`Padding`应用于父`Border`元素。`Grid`用于三个子`StackPanel`元素之间划分空间。`Button`元素再次被用来展示`Margin`和`HorizontalAlignment`的各种效果。`TextBlock`元素被添加到每个`ColumnDefinition`中，以更好地定义应用于每一列中`Button`元素的各种属性。
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/user-interface/introduction-to-xaml.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/user-interface/introduction-to-xaml.md
@@ -25,7 +25,7 @@ _Avalonia UI_ 使用XAML来定义用户界面。XAML是一种基于XML的标记�
 
 一个典型的Avalonia XAML文件如下所示：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -54,7 +54,7 @@ _Avalonia UI_ 使用XAML来定义用户界面。XAML是一种基于XML的标记�
 
 例如，下面的XAML将按钮添加到窗口的内容中：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button>Hello World!</Button>
@@ -71,7 +71,7 @@ _Avalonia UI_ 使用XAML来定义用户界面。XAML是一种基于XML的标记�
 
 例如，要为按钮控件指定蓝色背景，您可以添加`Background`属性并将值设置为`"Blue"`。如下所示：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Background="Blue">Hello World!</Button>
@@ -82,7 +82,7 @@ _Avalonia UI_ 使用XAML来定义用户界面。XAML是一种基于XML的标记�
 
 您可能已经注意到上面示例中的按钮的内容（"Hello World"字符串）放置在其打开和关闭标签之间。或者，您可以使用Content属性来设置内容。
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="Hello World!"/>
@@ -95,7 +95,7 @@ _Avalonia UI_ 使用XAML来定义用户界面。XAML是一种基于XML的标记�
 
 您经常会使用 _Avalonia UI_ 绑定系统将控件属性链接到底层对象。链接是通过`{Binding}`标记扩展来声明的。例如：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="{Binding Greeting}"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/user-interface/styling/style-classes.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/basics/user-interface/styling/style-classes.md
@@ -9,7 +9,7 @@ title: 样式类
 
 例如，这个按钮同时应用了 `h1` 和 `blue` 样式类：
 
-```markup
+```xml
 <Button Classes="h1 blue"/>
 ```
 
@@ -21,7 +21,7 @@ title: 样式类
 
 这是一个使用 `:pointerover` 伪类选择器的示例：
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Border:pointerover">
@@ -36,7 +36,7 @@ title: 样式类
 
 在此示例中，伪类选择器更改了控件模板内的属性：
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Button:pressed /template/ ContentPresenter">
@@ -57,7 +57,7 @@ title: 样式类
 
 如果你需要使用绑定条件添加或删除类，则可以使用以下特殊语法：
 
-```markup
+```xml
 <Button Classes.accent="{Binding IsSpecial}" />
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/input/hotkeys.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/input/hotkeys.md
@@ -6,7 +6,7 @@ description: CONCEPTS - Input
 
 实现了`ICommandSource`接口的各种控件都有一个`HotKey`属性，您可以设置或绑定它。按下快捷键将执行与控件绑定的命令。
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem x:Name="SaveMenuItem" Header="_Save" Command="{Binding SaveCommand}" HotKey="Ctrl+S"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/input/routed-events.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/input/routed-events.md
@@ -68,7 +68,7 @@ public class SampleControl: Control
 
 要使用XAML添加事件处理程序，您需要将事件名称声明为元素的属性，该元素是事件的监听器。属性的值是您实现的处理程序方法的名称，该方法必须存在于代码后台文件的类中。
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -103,7 +103,7 @@ public class SampleControl: Control
 
 要在XAML中添加事件处理程序，只需将事件名称作为属性添加到元素中，并将属性值设置为实现适当委托的事件处理程序的名称，如下例所示。
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -200,7 +200,7 @@ Avalonia输入系统广泛使用附加事件。然而，几乎所有这些附加
 
 另一种类似于_typename_._eventname_附加事件语法的语法用法，严格来说不是附加事件用法，是当您为由子元素引发的路由事件附加处理程序时使用的。您将处理程序附加到一个共同的父元素上，以利用事件路由，即使该共同的父元素可能没有相关的路由事件作为成员。再次考虑以下示例：
 
-```markup
+```xml
 <Border Height="50" Width="300">
   <StackPanel Orientation="Horizontal" Button.Click="CommonClickHandler">
     <Button Name="YesButton">Yes</Button>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/reactiveui/binding-to-sorted-filtered-list.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/reactiveui/binding-to-sorted-filtered-list.md
@@ -42,7 +42,7 @@ public MainWindowViewModel(){
 
 现在，`_sourceCache`已创建并填充，`ReadOnlyObservableCollection<T>`已创建并绑定，我们可以像通常使用`ObservableCollection<T>`一样在视图中进行绑定。
 
-```markup
+```xml
     <Design.DataContext>
         <vm:MainWindowViewModel/>
     </Design.DataContext>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/reactiveui/data-persistence.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/reactiveui/data-persistence.md
@@ -54,7 +54,7 @@ public class MainWindow : ReactiveWindow<MainViewModel>
 
 我们的`ReactiveWindow`的XAML如下所示：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="ReactiveUI.Samples.Suspension.MainWindow"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/reactiveui/routing.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/reactiveui/routing.md
@@ -38,7 +38,7 @@ namespace RoutingExample
 
 **FirstView.xaml**
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="RoutingExample.FirstView">
@@ -107,7 +107,7 @@ namespace RoutingExample
 
 现在我们需要将`RoutedViewHost` XAML控件放置在我们的主视图中。它将根据提供的`IViewLocator`实现和传递的`Router`实例（类型为`RoutingState`）解析和嵌入适当的视图模型。请注意，您需要导入`rxui`命名空间以使`RoutedViewHost`正常工作。此外，您可以在XAML中重写`RoutedViewHost.PageTransition`属性，以覆盖`RoutedViewHost`更改视图时播放的动画。
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:rxui="http://reactiveui.net"
         xmlns:app="clr-namespace:RoutingExample"
@@ -152,7 +152,7 @@ namespace RoutingExample
 
 要禁用动画，只需将`RoutedViewHost.PageTransition`属性设置为`{x:Null}`，如下所示：
 
-```markup
+```xml
 <rxui:RoutedViewHost Grid.Row="0" Router="{Binding Router}" PageTransition="{x:Null}">
     <rxui:RoutedViewHost.DefaultContent>
         <TextBlock Text="Default content"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/reactiveui/view-activation.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/reactiveui/view-activation.md
@@ -35,7 +35,7 @@ public class ViewModel : ReactiveObject, IActivatableViewModel
 
 这是上面所示视图模型的用户界面。
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         Background="#f0f0f0" FontFamily="Ubuntu"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/content-template.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/content-template.md
@@ -17,7 +17,7 @@ import ContentTemplateStudentScreenshot from '/img/concepts/templates/contenttem
 
 您可以使用 `DataTemplate` 标签定义数据模板（针对任何特定的类），它是内置控件和一些绑定的组合。例如：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/creating-data-templates-in-code.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/creating-data-templates-in-code.md
@@ -18,7 +18,7 @@ var template = new FuncDataTemplate<Student>((value, namescope) =>
 
 这等同于以下 XAML：
 
-```markup
+```xml
 <DataTemplate DataType="{x:Type local:Student}">
     <TextBlock Text="{Binding FirstName}"/>
 </DataTemplate>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/data-templates-collection.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/data-templates-collection.md
@@ -14,7 +14,7 @@ _Avalonia UI_中的每个控件都有一个`DataTemplates`（数据模板）集�
 
 因此，您可以修改前面的示例以使用`DataTemplates`集合，如下所示：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/data-templates.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/data-templates.md
@@ -16,7 +16,7 @@ import ControlContentTypeScreenshot from '/img/concepts/templates/content-type.p
 
 例如：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -34,7 +34,7 @@ import ControlContentTypeScreenshot from '/img/concepts/templates/content-type.p
 
 如果您将一个字符串放入窗口的内容区域，例如：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -67,7 +67,7 @@ namespace MySample
 
 并且将XML命名空间`local`定义为`MySample`命名空间（来自上面的代码），您可以在窗口的内容区域中定义一个学生对象，如下所示：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="using:MySample"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/implement-idatatemplate.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/implement-idatatemplate.md
@@ -34,7 +34,7 @@ public class MyDataTemplate : IDataTemplate
 
 现在您可以在视图中使用`MyDataTemplate`类，如下所示：
 
-```markup
+```xml
 xmlns:dataTemplates="using:MyApp.DataTemplates" -->
 ...
 <ContentControl Content="{Binding MyContent}">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/reusing-data-templates.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/templates/reusing-data-templates.md
@@ -31,7 +31,7 @@ namespace MySample
 
 然后在`app.axaml`文件中添加一个`Teacher`类型的数据模板：
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:MySample"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/macOS.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/macOS.md
@@ -94,7 +94,7 @@ MyProgram.app
 
 如果在任何时候工具给出错误，表示您的资产文件没有 `osx-64` 的目标，那么请在 `.csproj` 的顶层 `<PropertyGroup>` 中添加以下[运行时标识符](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog)：
 
-```markup
+```xml
 <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
 ```
 
@@ -115,7 +115,7 @@ MyProgram.app
 
 * 将以下内容添加到您的 `.csproj` 文件中：
 
-```markup
+```xml
 <PropertyGroup>
   <UseAppHost>true</UseAppHost>
 </PropertyGroup>
@@ -135,7 +135,7 @@ MyProgram.app
 
 首先，您需要将该项目作为 `PackageReference` 添加到您的项目中。可以通过 NuGet 包管理器添加它，或者通过将以下行添加到您的 `.csproj` 文件中：
 
-```markup
+```xml
 <PackageReference Include="Dotnet.Bundle" Version="*" />
 ```
 
@@ -160,7 +160,7 @@ dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-x64 -p:CFBundleDisplayName=
 
 您还可以在命令行中指定 `CFBundleDisplayName` 等，也可以在项目文件中指定它们：
 
-```markup
+```xml
 <PropertyGroup>
     <CFBundleName>AppName</CFBundleName> <!-- 同时定义 .app 文件名 -->
     <CFBundleDisplayName>MyBestThingEver</CFBundleDisplayName>
@@ -523,7 +523,7 @@ productbuild --component App/AppName.app /Applications --sign "$INSTALLER_SIGNIN
 
 这意味着您的应用程序很可能没有指定菜单。在启动时，Avalonia 会为应用程序创建默认的菜单项，并在未配置菜单时自动添加 _关于Avalonia_ 项。您可以通过将以下内容添加到 `App.xaml` 来解决这个问题：
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:RoadCaptain.App.RouteBuilder"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/get-started/wpf/datatemplates.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/get-started/wpf/datatemplates.md
@@ -10,7 +10,7 @@ description: GUIDES - WPF Conversion
 
 例如，以下代码添加了一个数据模板来显示视图模型类`MyViewModel`：
 
-```markup
+```xml
 <UserControl xmlns:viewmodels="using:MyApp.ViewModels"
              x:DataType="viewmodels:ControlViewModel">
     <UserControl.DataTemplates>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/get-started/wpf/grid.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/get-started/wpf/grid.md
@@ -2,7 +2,7 @@
 
 在Avalonia中，可以使用字符串来指定列和行定义，避免了WPF中笨重的语法：
 
-```markup
+```xml
 <Grid ColumnDefinitions="Auto,*,32" RowDefinitions="*,Auto">
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/get-started/wpf/styling.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/get-started/wpf/styling.md
@@ -9,7 +9,7 @@ Avalonia与其他XAML框架最明显的不同之一在于其样式系统。在Av
 
 以下代码显示了一个`UserControl`，其中定义了自己的CSS样式。
 
-```markup
+```xml
 <UserControl>
     <UserControl.Styles>
         <!-- 让带有 h1 样式类的 TextBlock 具有 24 点的字体大小 -->

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/custom-controls/how-to-create-attached-properties.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/custom-controls/how-to-create-attached-properties.md
@@ -121,7 +121,7 @@ public class DoubleTappedBehav : AvaloniaObject
 
 这个示例UI展示了如何使用附加属性。在将命名空间告知XAML编译器后，可以通过在前面加上一个点来使用它。然后可以使用绑定。
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:MyApp.Behaviors"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/custom-controls/how-to-create-templated-controls.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/custom-controls/how-to-create-templated-controls.md
@@ -10,7 +10,7 @@ title: 如何创建模板化控件
 
 当你创建一个控件模板并且想要绑定到模板化的父级时，你可以使用以下方式：
 
-```markup
+```xml
 <TextBlock Name="tb" Text="{TemplateBinding Caption}"/>
 
 <!-- 这与以下方式相同 -->
@@ -21,7 +21,7 @@ title: 如何创建模板化控件
 
 1. `TemplateBinding` 只接受单个属性而不是属性路径，所以如果你想要使用属性路径进行绑定，你必须使用第二种语法：
 
-    ```markup
+    ```xml
     <!-- 这样是行不通的，因为 TemplateBinding 只接受单个属性 -->
     <TextBlock Name="tb" Text="{TemplateBinding Caption.Length}"/>
 
@@ -35,7 +35,7 @@ title: 如何创建模板化控件
     ```
 3. `TemplateBinding` 只能在 `IStyledElement` 上使用。
 
-```markup
+```xml
 <!-- 这样是行不通的，因为 GeometryDrawing 不是 IStyledElement。 -->
 <GeometryDrawing Brush="{TemplateBinding Foreground}"/>
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/binding-to-controls.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/binding-to-controls.md
@@ -16,7 +16,7 @@ title: 如何绑定到控件
 
 如果要绑定到另一个命名控件上的属性，可以使用以 `#` 字符为前缀的控件名称。
 
-```markup
+```xml
 <TextBox Name="other">
 
 <!-- 绑定到命名为 other 控件的 Text 属性 -->
@@ -25,7 +25,7 @@ title: 如何绑定到控件
 
 这相当于 WPF 和 UWP 开发者熟悉的长格式绑定：
 
-```markup
+```xml
 <TextBox Name="other">
 <TextBlock Text="{Binding Text, ElementName=other}"/>
 ```
@@ -36,7 +36,7 @@ _Avalonia UI_ 支持这两种语法。
 
 您可以使用 `$parent` 语法绑定到目标的（逻辑控件树）父级：
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <TextBlock Text="{Binding $parent.Tag}"/>
 </Border>
@@ -44,7 +44,7 @@ _Avalonia UI_ 支持这两种语法。
 
 或者使用带有 `$parent` 语法的索引绑定到任何级别的祖先：
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Border>
     <TextBlock Text="{Binding $parent[1].Tag}"/>
@@ -56,7 +56,7 @@ _Avalonia UI_ 支持这两种语法。
 
 您还可以绑定到指定类型的最近祖先，如下所示：
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Decorator>
     <TextBlock Text="{Binding $parent[Border].Tag}"/>
@@ -66,7 +66,7 @@ _Avalonia UI_ 支持这两种语法。
 
 最后，您可以结合索引和类型：
 
-```markup
+```xml
 <Border Tag="Hello World!">
   <Border>
     <Decorator>
@@ -78,7 +78,7 @@ _Avalonia UI_ 支持这两种语法。
 
 如果需要在祖先类型中包含 XAML 命名空间，则使用冒号分隔命名空间和类名，如下所示：
 
-```markup
+```xml
 <local:MyControl Tag="Hello World!">
   <Decorator>
     <TextBlock Text="{Binding $parent[local:MyControl].Tag}"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-tabs.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-tabs.md
@@ -38,7 +38,7 @@ DataContext = new TabItemModel[] {
 
 最后，创建一个 `TabControl`，并将其 `Items` 属性绑定到数据上下文(`DataContext`)。
 
-```markup
+```xml
 <TabControl ItemsSource="{Binding}">
     <TabControl.ItemTemplate>
       <DataTemplate>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-a-command-with-reactiveui.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-a-command-with-reactiveui.md
@@ -79,7 +79,7 @@ namespace AvaloniaGuides.ViewModels
 
 通常需要向绑定到控件的Reactive命令传递参数。您可以在XAML中使用 `CommandParameter` 属性来实现这一点。例如：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
    ...
    <StackPanel Margin="20">
@@ -114,7 +114,7 @@ namespace AvaloniaGuides.ViewModels
 
 例如，要传递整数参数：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:sys="clr-namespace:System;assembly=mscorlib">
  ...   

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-a-task-result.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-a-task-result.md
@@ -26,7 +26,7 @@ private async Task<string> GetTextAsync()
 
 您可以按照以下方式绑定到结果：
 
-```markup
+```xml
 <TextBlock Text="{Binding MyAsyncText^, FallbackValue='Wait a second'}" />
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-an-observable.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-bind-to-an-observable.md
@@ -14,6 +14,6 @@ title: 如何绑定到可观察对象
 
 例如，如果 `DataContext.Name` 是一个 `IObservable<string>`，那么以下示例将绑定到可观察对象产生的每个字符串的长度，随着每个值的产生而变化：
 
-```markup
+```xml
 <TextBlock Text="{Binding Name^.Length}"/>
 ```

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-create-a-custom-data-binding-converter.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/how-to-create-a-custom-data-binding-converter.md
@@ -18,7 +18,7 @@ title: 如何创建自定义数据绑定转换器
 
 在使用自定义转换器之前，您必须在某些资源中引用它。这可以在应用程序的任何级别进行。在此示例中，自定义转换器 `myConverter` 被引用在 Window 资源中：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:ExampleApp;assembly=ExampleApp">
@@ -35,7 +35,7 @@ title: 如何创建自定义数据绑定转换器
 
 此示例数据绑定转换器可以将文本转换为特定的大小写形式，使用参数进行控制：
 
-```markup
+```xml
 <TextBlock Text="{Binding TheContent, 
     Converter={StaticResource textCaseConverter},
     ConverterParameter=lower}" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/graphics-and-animations.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/graphics-and-animations.md
@@ -22,7 +22,7 @@ Avalonia引入了一个广泛、可伸缩、灵活的图形功能集，具有以
 
 Avalonia提供了一组常见的矢量绘制2D形状，如`Ellipse`（椭圆）、`Line`（线）、`Path`（路径）、`Polygon`（多边形）和`Rectangle`（矩形）。
 
-```markup
+```xml
 <Canvas Background="Yellow" Width="300" Height="400">
     <Rectangle Fill="Blue" Width="63" Height="41" Canvas.Left="40" Canvas.Top="31">
         <Rectangle.OpacityMask>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/keyframe-animations.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/keyframe-animations.md
@@ -75,7 +75,7 @@ import BounceEaseInScreenshot from '/img/guides/graphics-and-animations/bounce-e
 
 此示例展示了如何在同一时间轴上同时动画两个属性。
 
-```markup
+```xml
 <Window.Styles>
     <Style Selector="Rectangle.red">
       <Setter Property="Fill" Value="Red"/>
@@ -103,7 +103,7 @@ import BounceEaseInScreenshot from '/img/guides/graphics-and-animations/bounce-e
 
 您可以通过设置动画元素的延迟属性来延迟动画的启动。例如：
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"> 
     ...
@@ -170,7 +170,7 @@ import BounceEaseInScreenshot from '/img/guides/graphics-and-animations/bounce-e
 
 默认的缓动函数是线性的（上图左），但您可以通过在缓动属性中设置所需函数的名称来使用其他模式。例如，要使用“弹跳淡入”函数（上图右）：
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"
            Easing="BounceEaseIn"> 
@@ -184,7 +184,7 @@ import BounceEaseInScreenshot from '/img/guides/graphics-and-animations/bounce-e
 
 您还可以添加自定义的缓动函数类，如下所示：
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1">
     <Animation.Easing>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/page-transitions/page-slide-transition.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/page-transitions/page-slide-transition.md
@@ -7,7 +7,7 @@ title: Page Slide Transition
 
 页面滑动过渡将旧页面移出视图，并将新页面视图移入，持续一定的时间。您可以使用orientation属性指定滑动方向（默认为水平）。
 
-```markup title='XAML'
+```xml title='XAML'
 <PageSlide Duration="0:00:00.500" Orientation="Vertical" />
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/transitions.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/graphics-and-animation/transitions.md
@@ -8,7 +8,7 @@ title: 如何使用过渡效果
 
 Avalonia中的过渡效果也受到CSS动画的很大启发。它们监听目标属性的值的任何变化，并根据其参数对变化进行动画处理。可以通过`Transitions`属性在任何`Control`上定义过渡效果：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -37,7 +37,7 @@ Avalonia中的过渡效果也受到CSS动画的很大启发。它们监听目标
 
 过渡效果也可以在任何样式中使用`Setter`来定义，目标属性设为`Transitions`，并将它们封装在`Transitions`对象中，如下所示：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -90,7 +90,7 @@ Avalonia中的过渡效果也受到CSS动画的很大启发。它们监听目标
 
 可以过渡应用于使用类似CSS语法的控件的渲染变换。以下示例显示了一个边框，在指针悬停在其上方时旋转45度：
 
-```markup title='XAML'
+```xml title='XAML'
 <Border Width="100" Height="100" Background="Red">
     <Border.Styles>
         <Style Selector="Border">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/implementation-guides/code-behind.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/implementation-guides/code-behind.md
@@ -40,7 +40,7 @@ namespace AvaloniaApplication1.Views
 
 Notice that this class name is the same as name of the XAML file, and is also referenced in the `x:Class` attribute of the window element.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:AvaloniaApplication1.ViewModels"
@@ -68,7 +68,7 @@ To do this you will first need a reference to a control. Your code will use find
 
 In this example, the button in the XAML has the name attribute defined:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication5.MainWindow">
@@ -94,7 +94,7 @@ Any useful application will require you to implement some action! When you use t
 
 You write event handlers as methods in the code-behind file, and then reference them in the XAML with an event attribute. For example to add a handler for a button click:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/implementation-guides/ide-support.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/implementation-guides/ide-support.md
@@ -39,7 +39,7 @@ xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 
 `d:DesignWidth` 和 `d:DesignHeight` 属性为预览的控件应用宽度和高度。
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -53,7 +53,7 @@ xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 
 `d:DataContext` 属性仅在设计时应用 `DataContext` 。建议您与 `{x:Static}` 指令结合使用此属性，以引用您的一个程序集中的静态属性：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -81,7 +81,7 @@ namespace My.Namespace
 
 或者您可以使用 `Design.DataContext` 附加属性，以及 `Design.Width` 和 `Design.Height`。
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/platforms/rpi/running-on-raspbian-lite-via-drm.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/platforms/rpi/running-on-raspbian-lite-via-drm.md
@@ -89,7 +89,7 @@ dotnet add package Avalonia.LinuxFramebuffer
 
 `MainView` 将是我们开发 UI 的应用基础：
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -112,7 +112,7 @@ dotnet add package Avalonia.LinuxFramebuffer
 
 现在创建一个名为 `MainSingleView` 的新 `UserControl`，并托管 `MainView`：
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -128,7 +128,7 @@ dotnet add package Avalonia.LinuxFramebuffer
 
 还要更改 `MainWindow.axaml` 以在其中托管 `MainView`：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/styles-and-resources/how-to-use-included-styles.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/styles-and-resources/how-to-use-included-styles.md
@@ -11,7 +11,7 @@ import VsStylesTemplateScreenshot from '/img/guides/styles-and-resources/vs-styl
 
 要实现这一点，您需要在一个新的XAML文件中定义样式。在这里，根元素必须是`Style`或`Styles`元素之一。例如：
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="TextBlock.h1">
@@ -34,7 +34,7 @@ _Avalonia UI_ 解决方案模板提供了一种快速添加样式文件到您的
 
 例如，要使用在名为`AppStyles.axaml`的文件中定义的样式（保存在`/Styles`文件夹中），您可以在窗口中添加如下的`StyleInclude`元素：
 
-```markup
+```xml
 <Window ... >
     <Window.Styles>
         <StyleInclude Source="/Styles/AppStyles.axaml" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/styles-and-resources/property-setters.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/styles-and-resources/property-setters.md
@@ -13,14 +13,14 @@ title: 属性设置器
 
 例如：
 
-```markup
+```xml
 <Setter Property="FontSize" Value="24"/>
 <Setter Property="Padding" Value="4 2 0 4"/>
 ```
 
 您也可以使用长格式语法将控件属性设置为具有多个设置的对象，如下所示：
 
-```markup
+```xml
 <Setter Property="MyProperty">
    <MyObject Property1="My Value" Property2="999"/>
 </Setter>
@@ -28,7 +28,7 @@ title: 属性设置器
 
 样式还可以使用绑定来设置属性。在常规选择过程之后，这将使 _Avalonia UI_ 使用目标控件的数据上下文中的值。例如，可以这样定义设置器：
 
-```markup
+```xml
 <Setter Property="FontSize" Value="{Binding SelectedFontSize}"/>
 ```
 
@@ -60,7 +60,7 @@ title: 属性设置器
 
 还要注意，在设置器值中定义的对象上的绑定将无法访问目标控件的数据上下文。这是因为可能有多个目标控件。这种情况可能在像这样定义的样式中出现：
 
-```markup
+```xml
 <Style Selector="local|MyControl">
   <Setter Property="MyProperty">
      <MyObject Property1="{Binding MyViewModelProperty}"/>
@@ -72,7 +72,7 @@ title: 属性设置器
 
 注意：如果您使用编译后的绑定，需要在 `<Style>` 元素中显式设置绑定源的数据类型：
 
-```markup
+```xml
 <Style Selector="MyControl" x:DataType="MyViewModelClass">
   <Setter Property="ControlProperty" Value="{Binding MyViewModelProperty}" />
 </Style>
@@ -86,7 +86,7 @@ For more information about compiled bindings, see here. --> TO DO
 
 如前面所述，当使用没有**数据模板**的设置器时，将创建一个设置器值的单个实例，并在所有匹配的控件之间共享。要根据数据模板更改值，请将目标控件放置在模板元素内，如下所示：
 
-```markup
+```xml
 <Style Selector="Border.empty">
   <Setter Property="Child">
     <Template>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/styles-and-resources/troubleshooting.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/styles-and-resources/troubleshooting.md
@@ -24,20 +24,20 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 
 样式按照声明的顺序应用。如果有多个包含了针对相同控件属性的样式文件，则最后一个包含的样式将覆盖之前的样式。例如：
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Green" />
 </Style>
 ```
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Blue" />
     <Style Property="FontSize" Value="16" />
 </Style>
 ```
 
-```markup
+```xml
 <StyleInclude Source="Style1.axaml" />
 <StyleInclude Source="Style2.axaml" />
 ```
@@ -48,7 +48,7 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 
 直接在控件上定义的本地值通常比任何样式值具有更高的优先级。因此，在这个例子中，文本块的前景色将是红色的：
 
-```markup
+```xml
 <Style Selector="TextBlock.header">
     <Setter Property="Foreground" Value="Green" />
 </Style>
@@ -72,7 +72,7 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 
 假设有一种情况，您希望第二个样式覆盖前一个样式，但实际上并没有覆盖：
 
-```markup
+```xml
 <Style Selector="Border:pointerover">
     <Setter Property="Background" Value="Blue" />
 </Style>
@@ -93,7 +93,7 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 
 以下代码示例中的样式应该在默认样式之上起作用：
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="Red" />
 </Style>
@@ -106,7 +106,7 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 
 原因在于 Button 的模板中。您可以在 Avalonia 源代码中找到默认模板（旧版 [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) 主题和新版 [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) 主题），但为了方便起见，我们在此处简化了来自 Fluent 主题的模板：
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="{DynamicResource ButtonBackground}"/>
     <Setter Property="Template">
@@ -124,7 +124,7 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 
 实际背景是由 `ContentPresenter` 渲染的，在默认情况下它与按钮的 `Background` 属性绑定。然而，在 pointerover 状态下，选择器直接将背景应用于 `ContentPresenter (Button:pointerover /template/ ContentPresenter#PART_ContentPresenter)`。这就是为什么在前一个代码示例中我们的 setter 被忽略的原因。修正后的代码应该直接针对 content presenter：
 
-```markup
+```xml
 <!-- 这里的 #PART_ContentPresenter 名称选择器不是必需的，但为了具有更具体的样式而添加 -->
 <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Blue" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/built-in-data-binding-converters.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/built-in-data-binding-converters.md
@@ -20,7 +20,7 @@ _Avalonia UI_ 包含许多用于常见场景的内置数据绑定转换器：
 
 这个例子展示了当绑定的值为false时，文本块的情况：
 
-```markup
+```xml
 <StackPanel>
   <TextBox Name="input" IsEnabled="{Binding AllowInput}"/>
   <TextBlock IsVisible="{Binding !AllowInput}">Input is not allowed</TextBlock>
@@ -31,7 +31,7 @@ _Avalonia UI_ 包含许多用于常见场景的内置数据绑定转换器：
 
 例如，整数零会被转换为false（通过函数`Convert.ToBoolean`），而其他所有整数值都会被转换为true，因此你可以使用否定运算符来在集合为空时显示一条消息，像这样：
 
-```markup
+```xml
 <Panel>
   <ListBox ItemsSource="{Binding Items}"/>
   <TextBlock IsVisible="{Binding !Items.Count}">No results found</TextBlock>
@@ -42,7 +42,7 @@ _Avalonia UI_ 包含许多用于常见场景的内置数据绑定转换器：
 
 你可以使用这种方式来在集合为空时隐藏一个控件（计数为零），像这样：
 
-```markup
+```xml
 <Panel>
   <ListBox ItemsSource="{Binding Items}" IsVisible="{Binding !!Items.Count}"/>
 </Panel>
@@ -52,7 +52,7 @@ _Avalonia UI_ 包含许多用于常见场景的内置数据绑定转换器：
 
 这个绑定示例将在绑定的文本为null或空字符串时隐藏文本块：
 
-```markup
+```xml
 <TextBlock Text="{Binding MyText}"
            IsVisible="{Binding MyText, 
                        Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
@@ -60,7 +60,7 @@ _Avalonia UI_ 包含许多用于常见场景的内置数据绑定转换器：
 
 而这个示例将在绑定的对象为null或为空时隐藏内容控件：
 
-```markup
+```xml
 <ContentControl Content="{Binding MyContent}"
                 IsVisible="{Binding MyContent, 
                             Converter={x:Static ObjectConverters.IsNotNull}}"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/checkbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/checkbox.md
@@ -24,7 +24,7 @@ You will probably use these properties most often:
 
 This is an example of two-state check boxes:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -45,7 +45,7 @@ Looks like this when running on Windows:
 
 This is an example of a three-state checkbox:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/combobox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/combobox.md
@@ -34,7 +34,7 @@ You will probably use these properties most often:
 
 This is basic example with text items has a limit set on the drop-down list height.
 
-```markup
+```xml
 <StackPanel Margin="20">
   <ComboBox SelectedIndex="0" MaxDropDownHeight="100">
     <ComboBoxItem>Text Item 1</ComboBoxItem>
@@ -54,7 +54,7 @@ This is basic example with text items has a limit set on the drop-down list heig
 
 This example uses a composed view for each item:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <ComboBox SelectedIndex="0">
     <ComboBoxItem>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/datagrid/README.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/datagrid/README.md
@@ -49,7 +49,7 @@ dotnet add package Avalonia.Controls.DataGrid
 
 例如：
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
@@ -128,7 +128,7 @@ public class Person
 
 通常来说，从项类中获取的属性名称通常不会成为好的列名。下面这个示例为网格添加了自定义的列头名称。它还允许列重新排序和调整大小，并禁用了默认的列排序选项：
 
-```markup
+```xml
 <DataGrid Margin="20" ItemsSource="{Binding People}"
           IsReadOnly="True"
           CanUserReorderColumns="True"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/border.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/border.md
@@ -39,7 +39,7 @@ If you use the four value pattern; you must provide all four values, even if one
 
 This example adds some border controls to create a 'pod' look in the layout:
 
-```markup
+```xml
 <StackPanel>
   <Border Background="Gainsboro"
         BorderBrush="Black"
@@ -86,7 +86,7 @@ If both offset values are set to zero, the shadow is placed behind the element, 
 
 This is an example of a drop-shadow:
 
-```markup
+```xml
 <<StackPanel>
   <Border Background="Gainsboro"
         BorderBrush="Black"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/calendar/README.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/calendar/README.md
@@ -23,7 +23,7 @@ You will probably use these properties most often:
 
 This is a basic calendar allowing a single date selection. The calendar's selected date is shown in the text block below.
 
-```markup
+```xml
 <StackPanel Margin="20">
   <Calendar x:Name="calendar" SelectionMode="MultipleRange"/>
   <TextBlock Margin="20" 
@@ -35,7 +35,7 @@ This is a basic calendar allowing a single date selection. The calendar's select
 
 This example allows multiple range selections:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <Calendar SelectionMode="MultipleRange"/>
 </StackPanel>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/tabcontrol.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/tabcontrol.md
@@ -23,7 +23,7 @@ If you only need the function of the tab headers part of this control, consider 
 
 This is simple tab example. The tab content is just some text: 
 
-```markup
+```xml
 <TabControl Margin="5">
   <TabItem Header="Tab 1">
     <TextBlock Margin="5">This is tab 1 content</TextBlock>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/textbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/textbox.md
@@ -18,7 +18,7 @@ You will probably use these properties most often:
 
 This example has a basic one line text box, a password box, and a text-wrapping multiline text box:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5" >Name:</TextBlock>
   <TextBox  Watermark="Enter your name"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/timepicker.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/timepicker.md
@@ -32,7 +32,7 @@ This example shows how to create a time picker for the 24 hour clock, with 20 mi
 
 You can set the time value as an attribute in XAML.  Use a string in the form _Hh:Mm_ where _Hh_ is hours and can be between 0 and 23 and _Mm_ is minutes and can be between 0 and 59.
 
-```markup
+```xml
 <TimePicker SelectedTime="09:15"/>
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/tooltip.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/tooltip.md
@@ -19,7 +19,7 @@ You will probably use these properties most often:
 
 This is a simple text-based tooltip, using default values for the placement and delay properties; this rectangle is placed in a window with larger dimensions:
 
-```markup
+```xml
 <Rectangle Fill="Aqua" Height="200" Width="400"
             ToolTip.Tip="This is a rectangle" />
 ```
@@ -28,7 +28,7 @@ This is a simple text-based tooltip, using default values for the placement and 
 
 To provide a richer presentation for a tooltip, use a `<ToolTip.Tip>` element. For example:
 
-```markup
+```xml
 <Rectangle Fill="Aqua" Height="200" Width="400"
     ToolTip.Placement="Bottom">
     <ToolTip.Tip>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/transitioningcontentcontrol.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/transitioningcontentcontrol.md
@@ -21,7 +21,7 @@ You will probably use these properties most often:
 
 In this example, the view model contains a collection of different images to show them in a slideshow. The following XAML will use the default page transition to change the image (in the data template) whenever the bound `SelectedImage` property changes:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">
@@ -35,7 +35,7 @@ In this example, the view model contains a collection of different images to sho
 
 In this example, a different page transition has been specified to slide the images horizontally:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.PageTransition>
         <PageSlide Orientation="Horizontal" Duration="0:00:00.500" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/treedatagrid/README.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/treedatagrid/README.md
@@ -62,7 +62,7 @@ You must reference the data grid themes to include the additional styles that th
 
 For example:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AvaloniaApplication.App">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/viewbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/detailed-reference/viewbox.md
@@ -39,7 +39,7 @@ The values for the `StretchDirecton` property are as follows:
 
 This simple example shows a `Viewbox` scaling up a circle uniformly (both stretch and direction are default).
 
-```markup
+```xml
 <Viewbox Stretch="Uniform" Width="300" Height="300">
    <Ellipse Width="50" Height="50" Fill="CornflowerBlue" />  
 </Viewbox>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/dockpanel.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/dockpanel.md
@@ -37,7 +37,7 @@ You will probably use these properties most often:
 
 Setting the opacity of the orange rectangle to 0.5 demonstrates that there are no overlaps.
 
-```markup
+```xml
 <DockPanel Width="300" Height="300">
     <Rectangle Fill="Red" Height="100" DockPanel.Dock="Top"/>
     <Rectangle Fill="Blue" Width="100" DockPanel.Dock="Left" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/flyouts.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/flyouts.md
@@ -30,7 +30,7 @@ Only the button and split button controls support the `Flyout` property. You can
 
 For controls that do not have the `Flyout` property, use the `AttachedFlyout` property like this:
 
-```markup
+```xml
 <Border Background="Red" PointerPressed="Border_PointerPressed">
     <FlyoutBase.AttachedFlyout>
         <Flyout>
@@ -82,7 +82,7 @@ This setting describes how the flyout shows and hides:
 
 You can share flyouts between two or more elements in your app. For example, to share a flyout from the resources collection of a window:
 
-```markup
+```xml
 <Window.Resources>
     <Flyout x:Key="MySharedFlyout">
         <!-- Flyout content here -->
@@ -98,7 +98,7 @@ You can share flyouts between two or more elements in your app. For example, to 
 
 Although flyouts are not themselves controls, their general appearance can be customized by targeting the presenter the `Flyout` uses to display its content. For a normal `Flyout` this is `FlyoutPresenter` and for `MenuFlyout` this is `MenuFlyoutPresenter`. Because flyout presenters are not exposed, special style classes that should pertain to specific flyouts can be passed using the `FlyoutPresenterClasses` property on `FlyoutBase`
 
-```markup
+```xml
 <Style Selector="FlyoutPresenter.mySpecialClass">
     <Setter Property="Background" Value="Red" />
 </Style>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/grid.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/grid.md
@@ -135,7 +135,7 @@ This example shows:
 
 An example of a Grid with 3 equal Rows and 3 Columns with (1 fixed width), (2 grabbing the rest proportionally) would be:
 
-```markup
+```xml
 <Grid ColumnDefinitions="100,1.5*,4*" RowDefinitions="Auto,Auto,Auto"  Margin="4">
   <TextBlock Text="Col0Row0:" Grid.Row="0" Grid.Column="0"/>
   <TextBlock Text="Col0Row1:" Grid.Row="1" Grid.Column="0"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/gridsplitter.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/gridsplitter.md
@@ -23,7 +23,7 @@ To provide any meaningful movement, the direction of travel of the splitter must
 
 This is a column splitter:
 
-```markup
+```xml
 <Grid ColumnDefinitions="*, 4, *">
     <Rectangle Grid.Column="0" Fill="Blue"/>
     <GridSplitter Grid.Column="1" Background="Black" ResizeDirection="Columns"/>
@@ -35,7 +35,7 @@ This is a column splitter:
 
 This is a row splitter:
 
-```markup
+```xml
 <Grid RowDefinitions="*, 4, *">
     <Rectangle Grid.Row="0" Fill="Blue"/>
     <GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/listbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/listbox.md
@@ -41,7 +41,7 @@ The following selection modes are available for the list box:
 
 These values can be combined, for example:
 
-```markup
+```xml
 <ListBox SelectionMode="Multiple,Toggle">
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/maskedtextbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/maskedtextbox.md
@@ -30,7 +30,7 @@ The escape character (backslash) can be used to include a special character as a
 
 This is a basic example:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">International phone number:</TextBlock>
   <MaskedTextBox Mask="(+09) 000 000 0000" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/menu.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/menu.md
@@ -35,7 +35,7 @@ You will probably use these properties most often:
 
 This example creates a menu docked at the top edge of a window.
 
-```markup
+```xml
 <Window ...>
     <DockPanel>
     <Menu DockPanel.Dock="Top">
@@ -76,7 +76,7 @@ Once keyboard interaction has been initiated with the Alt key, the user can also
 
 To initiate an action, the command property of a menu item can be bound to an `ICommand` object. The command will be executed when the menu item is clicked or selected with the keyboard. For example:
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem Header="_Open..." Command="{Binding OpenCommand}"/>
@@ -92,7 +92,7 @@ For guidance on how to bind to commands, see [here](../../basics/user-interface/
 
 A menu icon can be displayed by placing an image or a path icon in the `<MenuItem.Icon>` attached property. For example:
 
-```markup
+```xml
 <MenuItem Header="_Edit">
   <MenuItem Header="Copy">
      <MenuItem.Icon>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/numericupdown.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/numericupdown.md
@@ -28,7 +28,7 @@ You will probably use these properties most often:
 
 This is a basic example of a numeric up-down control. There are no limits to the value here:
 
-```markup
+```xml
 <StackPanel Margin="20">
   <TextBlock Margin="0 5">Number of items:</TextBlock>
   <NumericUpDown Value="10" />
@@ -45,7 +45,7 @@ Remember to specify a `FormatString` property when you create a custom decimal i
 
 For example:
 
-```markup
+```xml
 <StackPanel Margin="20">  
   <TextBlock Margin="0 5">Opacity:</TextBlock>
   <NumericUpDown Value="0.5" Increment="0.05" 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/panel.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/panel.md
@@ -16,7 +16,7 @@ For a discussion about using other panels, see [here](../../basics/user-interfac
 
 This example uses some 50% opacities to demonstrate that child controls overlap.
 
-```markup
+```xml
 <Panel Height="300" Width="300">
     <Rectangle Fill="Red" Height="100" VerticalAlignment="Top"/>
     <Rectangle Fill="Blue" Opacity="0.5" Width="100" HorizontalAlignment="Right" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/refreshcontainer.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/refreshcontainer.md
@@ -11,7 +11,7 @@ The refresh container allows a user to pull down on content or a list of data to
 This example shows hows to use a RefreshContainer with a
 
 _In the axaml file._
-```markup
+```xml
 <RefreshContainer PullDirection="TopToBottom"
                 RefreshRequested="RefreshContainerPage_RefreshRequested">
     <ListBox ItemsSource="{Binding Items}"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/relativepanel.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/relativepanel.md
@@ -48,7 +48,7 @@ You will probably use these properties most often:
 
 This XAML shows how to arrange some child controls in different ways:
 
-```markup
+```xml
 <Border BorderBrush="DarkGray" BorderThickness="1" Width="300" Height="300">
   <RelativePanel >
     <Rectangle x:Name="RedRect" Fill="Red" Height="50" Width="50"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/splitview.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/splitview.md
@@ -38,7 +38,7 @@ The display mode property controls how the pane is drawn in its open and closed 
 
 ## Example
 
-```markup
+```xml
 <SplitView IsPaneOpen="True"
            DisplayMode="Inline"
            OpenPaneLength="300">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/stackpanel.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/stackpanel.md
@@ -25,7 +25,7 @@ You will probably use these properties most often:
 
 The following XAML shows how to create a vertical stack panel.
 
-```markup
+```xml
 <StackPanel Width="200">
     <Rectangle Fill="Red" Height="50"/>
     <Rectangle Fill="Blue" Height="50"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/styles/style-selector-syntax.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/styles/style-selector-syntax.md
@@ -10,7 +10,7 @@ description: REFERENCE - Styles
 
 
 
-```markup
+```xml
 <Style Selector="Button">
 <Style Selector="local|Button">
 ```
@@ -41,7 +41,7 @@ new Style(x => x.OfType(typeof(Button)));
 
 
 
-```markup
+```xml
 <Style Selector="#myButton">
 <Style Selector="Button#myButton">
 ```
@@ -60,7 +60,7 @@ new Style(x => x.OfType<Button>().Name("myButton"));
 
 
 
-```markup
+```xml
 <Style Selector="Button.large">
 <Style Selector="Button.large.red">
 ```
@@ -102,7 +102,7 @@ new Style(x => x.OfType<Button>().Class("large").Class(":focus"));
 
 
 
-```markup
+```xml
 <Style Selector=":is(Button)">
 <Style Selector=":is(local|Button)">
 ```
@@ -125,7 +125,7 @@ new Style(x => x.Is(typeof(Button)));
 
 
 
-```markup
+```xml
 <Style Selector=":is(Control).margin2">
 <Style Selector=":is(local|Control.margin2)">
 ```
@@ -142,7 +142,7 @@ new Style(x => x.Is(typeof(Control)).Class("margin2"));
 
 
 
-```markup
+```xml
 <Style Selector="StackPanel > Button">
 ```
 
@@ -177,7 +177,7 @@ new Style(x => x.OfType<StackPanel>().Child().OfType<Button>());
 
 
 
-```markup
+```xml
 <Style Selector="StackPanel Button">
 ```
 
@@ -196,7 +196,7 @@ new Style(x => x.OfType<StackPanel>().Descendant().OfType<Button>());
 
 
 
-```markup
+```xml
 <Style Selector="Button[IsDefault=true]">
 ```
 
@@ -221,7 +221,7 @@ new Style(x => x.OfType<Button>().PropertyEquals(Button.IsDefaultProperty, true)
 :::info
 注意：当您将附加属性用作属性匹配时，属性名必须用括号括起来。例如：
 
-```markup
+```xml
 <Style Selector="TextBlock[(Grid.Row)=0]">
 ```
 :::
@@ -234,7 +234,7 @@ new Style(x => x.OfType<Button>().PropertyEquals(Button.IsDefaultProperty, true)
 
 
 
-```markup
+```xml
 <Style Selector="Button /template/ ContentPresenter">
 ```
 
@@ -253,7 +253,7 @@ new Style(x => x.OfType<Button>().Template().OfType<ContentPresenter>());
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:not(.h1)">
 ```
 
@@ -270,7 +270,7 @@ new Style(x => x.OfType<TextBlock>().Not(y => y.Class("h1")));
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock, Button">
 ```
 
@@ -287,7 +287,7 @@ new Style(x => Selectors.Or(x.OfType<TextBlock>(), x.OfType<Button>()))
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-child(2n+3)">
 ```
 
@@ -312,7 +312,7 @@ new Style(x => x.OfType<TextBlock>().NthChild(2, 3));
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-last-child(2n+3)">
 ```
 
@@ -329,7 +329,7 @@ new Style(x => x.OfType<TextBlock>().NthLastChild(2, 3));
 
 
 
-```markup
+```xml
 <Style Selector="TextBlock:nth-child(3)">
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/add-and-layout-controls.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/add-and-layout-controls.md
@@ -20,7 +20,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - 转到并打开 **MainWindow.axaml** 文件。
 - 在 Panel 元素内，添加以下用于按钮的 XAML 代码。Panel 的 XAML 代码应如下所示：
 
-```markup
+```xml
 <Panel>
     <ExperimentalAcrylicBorder IsHitTestVisible="False">
         <ExperimentalAcrylicBorder.Material>
@@ -49,7 +49,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - 在新的 Panel 元素上添加 Margin 属性，值为 40。
 - 在 Button 元素上添加水平和垂直对齐属性，如下所示：
 
-```markup
+```xml
 <Panel Margin="40">
   <Button Content="Buy Music" 
      HorizontalAlignment="Right" VerticalAlignment="Top" />
@@ -69,7 +69,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - 导航到 _Avalonia UI_ 的 _GitHub_，找到 Fluent Icons 列表，网址为 [https://avaloniaui.github.io/icons.html](https://avaloniaui.github.io/icons.html)
 - 使用浏览器的文本搜索功能找到图标名称 'store\_microsoft\_regular'。应该会有一些类似以下代码的内容：
 
-```markup
+```xml
 <StreamGeometry x:Key="store_microsoft_regular">M11.5 9.5V13H8V9.5H11.5Z M11.5 17.5V14H8V17.5H11.5Z M16 9.5V13H12.5V9.5H16Z M16 17.5V14H12.5V17.5H16Z M8 6V3.75C8 2.7835 8.7835 2 9.75 2H14.25C15.2165 2 16 2.7835 16 3.75V6H21.25C21.6642 6 22 6.33579 22 6.75V18.25C22 19.7688 20.7688 21 19.25 21H4.75C3.23122 21 2 19.7688 2 18.25V6.75C2 6.33579 2.33579 6 2.75 6H8ZM9.5 3.75V6H14.5V3.75C14.5 3.61193 14.3881 3.5 14.25 3.5H9.75C9.61193 3.5 9.5 3.61193 9.5 3.75ZM3.5 18.25C3.5 18.9404 4.05964 19.5 4.75 19.5H19.25C19.9404 19.5 20.5 18.9404 20.5 18.25V7.5H3.5V18.25Z</StreamGeometry>
 ```
 
@@ -82,7 +82,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - 输入 **名称** 'Icons'，然后按回车键。
 - 找到并打开新创建的 **Icons.axaml** 文件。XAML 代码将如下所示：
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -101,7 +101,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 
 现在，图标文件的代码如下所示：
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -126,7 +126,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - 找到并打开 **App.axaml** 文件。
 - 添加一个 `<StyleInclude>` 元素，如下所示：
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.MusicStore/Icons.axaml" />
@@ -140,7 +140,7 @@ import MusicStorePrettyButtonScreenshot from '/img/tutorials/music-store-app/add
 - 找到并打开 **MainWindow.axaml** 文件。
 - 修改按钮的 XAML 代码，如下所示：
 
-```markup
+```xml
 <Button HorizontalAlignment="Right" VerticalAlignment="Top">       
     <PathIcon Data="{StaticResource store_microsoft_regular}" /> 
 </Button>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/album-view.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/album-view.md
@@ -20,7 +20,7 @@ import MusicStoreWrapPanelScreenshot from '/img/tutorials/music-store-app/add-co
 - 导航到 _Avalonia UI_ 的 _GitHub_，在 [https://avaloniaui.github.io/icons.html](https://avaloniaui.github.io/icons.html) 找到 Fluent 图标列表。
 - 使用浏览器的文本搜索来查找图标 “music\_regular” 的名称。应该有一些类似于以下代码的代码：
 
-```markup
+```xml
 <StreamGeometry x:Key="music_regular">M11.5,2.75 C11.5,2.22634895 12.0230228,1.86388952 12.5133347,2.04775015 L18.8913911,4.43943933 C20.1598961,4.91511241 21.0002742,6.1277638 21.0002742,7.48252202 L21.0002742,10.7513533 C21.0002742,11.2750044 20.4772513,11.6374638 19.9869395,11.4536032 L13,8.83332147 L13,17.5 C13,17.5545945 12.9941667,17.6078265 12.9830895,17.6591069 C12.9940859,17.7709636 13,17.884807 13,18 C13,20.2596863 10.7242052,22 8,22 C5.27579485,22 3,20.2596863 3,18 C3,15.7403137 5.27579485,14 8,14 C9.3521238,14 10.5937815,14.428727 11.5015337,15.1368931 L11.5,2.75 Z M8,15.5 C6.02978478,15.5 4.5,16.6698354 4.5,18 C4.5,19.3301646 6.02978478,20.5 8,20.5 C9.97021522,20.5 11.5,19.3301646 11.5,18 C11.5,16.6698354 9.97021522,15.5 8,15.5 Z M13,3.83223733 L13,7.23159672 L19.5002742,9.669116 L19.5002742,7.48252202 C19.5002742,6.75303682 19.0477629,6.10007069 18.3647217,5.84393903 L13,3.83223733 Z</StreamGeometry>
 ```
 
@@ -41,7 +41,7 @@ import MusicStoreWrapPanelScreenshot from '/img/tutorials/music-store-app/add-co
 - 将属性 `Width="200"` 添加到 `<UserControl>` 元素中。
 - 如下修改用户控件内容区域的 XAML：
 
-```markup
+```xml
 <StackPanel Spacing="5" Width="200">
     <Border CornerRadius="10" ClipToBounds="True">
         <Panel Background="#7FFF22DD">
@@ -122,7 +122,7 @@ public class AlbumViewModel : ViewModelBase
 - 展开 `<ListBox>` 元素，使其具有开始和结束标记。
 - 添加所示的 `<ListBox.ItemsPanel>` XAML：
 
-```markup
+```xml
 <ListBox ItemsSource="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}"
     Background="Transparent" Margin="0 20">
     <ListBox.ItemsPanel>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/creating-a-modern-looking-window.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/creating-a-modern-looking-window.md
@@ -18,7 +18,7 @@ import MusicStoreFullAcrylicWindowScreenshot from '/img/tutorials/music-store-ap
 - 找到并打开文件 **App.axaml**。
 - 在 XAML 中，将 `<Application>` 元素中的 `RequestedThemeVariant` 属性从 `Default` 更改为 `Dark`：
 
-```markup
+```xml
 <Application ...
     RequestedThemeVariant="Dark">
 ```
@@ -41,7 +41,7 @@ import MusicStoreFullAcrylicWindowScreenshot from '/img/tutorials/music-store-ap
 - 找到 `<Window>` 元素的结束标签。
 - 在 `Title="Avalonia.MusicStore"` 属性后添加两个新属性，如下所示：
 
-```markup
+```xml
 <Window ...
         Title="Avalonia.MusicStore"
 
@@ -51,7 +51,7 @@ import MusicStoreFullAcrylicWindowScreenshot from '/img/tutorials/music-store-ap
 
 - 为了将亚克力效果应用到整个窗口，将主窗口的内容区域中的 `<TextBlock>` 元素替换为以下用于 Panel 的 XAML 代码：
 
-```markup
+```xml
 <Window ... >
        <Panel>
            <ExperimentalAcrylicBorder IsHitTestVisible="False">
@@ -83,7 +83,7 @@ import MusicStoreFullAcrylicWindowScreenshot from '/img/tutorials/music-store-ap
 - 再次找到 `<Window>` 元素的结束标签。
 - 添加 `ExtendClientAreaToDecorationsHint` 属性，如下所示：
 
-```markup
+```xml
    <Window ...
            TransparencyLevelHint="AcrylicBlur"
            Background="Transparent"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
@@ -30,7 +30,7 @@ import MusicStoreDialogOpenedScreenshot from '/img/tutorials/music-store-app/ope
 - 找到并打开 **MusicStoreWindow.axaml** 文件。
 - 如下更改代码，以添加亚克力模糊背景，并将其延伸到标题栏中（与之前相同）：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/add-item-buttons.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/add-item-buttons.md
@@ -110,7 +110,7 @@ CancelCommand = ReactiveCommand.Create(() => { });
 - 在 **/Views** 文件夹中找到 **AddItemView.axaml** 文件。
 - 编辑 XAML 如下。
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:ToDoList.ViewModels"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/creating-a-view.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/creating-a-view.md
@@ -34,7 +34,7 @@ dotnet new avalonia.usercontrol -o Views -n ToDoListView  --namespace ToDoList.V
 
 您会看到在 `/Views` 文件夹中创建了新的 AXAML 文件
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -81,7 +81,7 @@ namespace ToDoList.Views
 
 编辑 `Views/TodoListView.axaml` 的内容如下：
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/inspect-the-xaml.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/inspect-the-xaml.md
@@ -52,7 +52,7 @@ XAML 文件中的根元素以 `<UserControl` 开始，后面跟着一些 _Avalon
 
 最后一行将 XAML 文件链接到其代码后台类。请注意，这里必须使用完全限定的类名。
 
-```markup
+```xml
 <UserControl ...
    x:Class="ToDoList.Views.ToDoListView">
 ```
@@ -97,7 +97,7 @@ StackPanel 在默认情况下会将其子控件垂直堆叠。（您可以通过
 
 剩余的 XAML 将硬编码的待办事项列表项作为复选框添加：
 
-```markup
+```xml
 <CheckBox Margin="4">Walk the dog</CheckBox>
 <CheckBox Margin="4">Buy some milk</CheckBox>
 ```

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/locating-views.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/locating-views.md
@@ -50,7 +50,7 @@ namespace ToDoList
 
 视图定位器的一个实例存在于应用程序项目的 **App.axaml** 文件中（它由解决方案模板添加）。它应该如下所示：
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ToDoList.App"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/main-window-content.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/main-window-content.md
@@ -17,7 +17,7 @@ import ToDoMainWindowContentScreenshot from '/img/gitbook-import/assets/image (4
 
 现在，主窗口的 XAML 应如下所示：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:ToDoList.ViewModels"
@@ -53,7 +53,7 @@ import ToDoMainWindowContentScreenshot from '/img/gitbook-import/assets/image (4
 
 最后一步将窗口的内容区域设置为显示您的新用户控件视图：
 
-```markup
+```xml
 <views:ToDoListView/>
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/navigate-views.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/todo-list-app/navigate-views.md
@@ -71,7 +71,7 @@ namespace ToDoList.ViewModels
 - 在 **/Views** 文件夹中找到 **MainWindow.axaml** 文件。
 - 编辑 XAML 如下：
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:ToDoList.ViewModels"
@@ -95,7 +95,7 @@ namespace ToDoList.ViewModels
 * 在 **/Views** 文件夹中找到 **ToDoListView.axaml** 文件。
 * 编辑按钮的 XAML 如下：
 
-```markup
+```xml
 <Button DockPanel.Dock="Bottom"
         HorizontalAlignment="Stretch"
         HorizontalContentAlignment="Center"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/animations/keyframe-animations.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/animations/keyframe-animations.md
@@ -9,7 +9,7 @@ Keyframe animations in Avalonia are heavily inspired by CSS Animations. They can
 
 Keyframe animations are applied using styles. They can be defined on any style by adding an `Animation` object to the `Style.Animation` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -51,7 +51,7 @@ All `Animation` objects should contain at least one `KeyFrame`, with a `Setter` 
 
 Multiple properties can be also animated in a single Animation by adding additional `Setter` objects on the desired `KeyFrame`:
 
-```markup
+```xml
 <Animation Duration="0:0:1"> 
     <KeyFrame Cue="0%">
         <Setter Property="Opacity" Value="0.0"/>
@@ -68,7 +68,7 @@ Multiple properties can be also animated in a single Animation by adding additio
 
 You can add a delay in a `Animation` by defining the desired delay time on its `Delay` property:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"> 
     ...
@@ -114,7 +114,7 @@ The following table describes the possible behaviors:
 
 Easing functions can be set by setting the name of the desired function to the `Animation`'s `Easing` property:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"
            Easing="BounceEaseIn"> 
@@ -124,7 +124,7 @@ Easing functions can be set by setting the name of the desired function to the `
 
 You can also add your custom easing function class like this:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1">
     <Animation.Easing>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/animations/transitions.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/animations/transitions.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 Transitions in Avalonia are also heavily inspired by CSS Animations. They listen to any changes in target property's value and subsequently animates the change according to its parameters. They can be defined on any `Control` via `Transitions` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -38,7 +38,7 @@ The above example will listen to changes in the `Rectangle`'s `Opacity` property
 
 Transitions can also be defined in any style by using a `Setter` with `Transitions` as the target property and encapsulating them in a `Transitions` object, like so:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/border.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/border.md
@@ -10,7 +10,7 @@ The `Border` control decorates a child with a border and background. It can also
 
 An example of a border with a red background, 2 pixel black border, 3 pixel corner radius and a 4 pixel padding around its content:
 
-```markup
+```xml
 <Border Background="Red"
         BorderBrush="Black"
         BorderThickness="2"
@@ -48,7 +48,7 @@ To specify multiple shadows, provide a comma-separated list of shadows.
 * `spread-radius`: Positive values will cause the shadow to expand and grow bigger, negative values will cause the shadow to shrink. If not specified, it will be 0 \(the shadow will be the same size as the element\).
 * `color`: The color of the shadow using a color name \(such as `red`\) or a `#` hexadecimal color value
 
-```markup
+```xml
 <Border Background="Red"
         BorderBrush="Black"
         BorderThickness="2"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/button.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/button.md
@@ -49,7 +49,7 @@ The Button control's full documentation can be found [here](http://reference.ava
 
 ### Basic button
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -69,7 +69,7 @@ produces following output with **Windows 10**
 
 ### Colored button
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -91,7 +91,7 @@ produces following output with **Windows 10**
 
 Toggles between a "Play" icon and a "Pause" icon on click.
 
-```markup
+```xml
 <UserControl.Resources>
     <Bitmap x:Key="Play">
         <x:Arguments>
@@ -106,7 +106,7 @@ Toggles between a "Play" icon and a "Pause" icon on click.
 </UserControl.Resources>
 ```
 
-```markup
+```xml
 <Button Name="PlayButton" HorizontalAlignment="Center" Width="36" Command="{Binding PlayCommand}">
     <Panel>
         <Image Source="{DynamicResource Play}" IsVisible="{Binding !IsPlaying}" Width="20"
@@ -121,7 +121,7 @@ Toggles between a "Play" icon and a "Pause" icon on click.
 
 It is possible to bind a view model command to a simple method or with a ReactiveCommand. There are lots of advantages to the ReactiveCommand binding for all but the simplest user interfaces such as being able to pass an `IObservable<bool>` object in to have it dynamically calculate state. Both methods are displayed below. First the "simple" method binding:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -157,7 +157,7 @@ public ReactiveCommand OnClickCommand { get; }
 
 ### Binding to Events
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/radiobutton.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/radiobutton.md
@@ -5,7 +5,7 @@ title: RadioButton
 
 The `RadioButton` control allows users to select one or more things from a collection of presented things.
 
-```markup
+```xml
 <!-- First Group -->
 <RadioButton IsChecked="{Binding Option1Enabled }"
              GroupName="First Group"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/togglebutton.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/buttons/togglebutton.md
@@ -15,7 +15,7 @@ The `ToggleButton` control is a subclass of the `Button` control that has a buil
 
 This button will show a muted speaker icon or an un-muted speaker icon based on whether the button is checked or unchecked, which the `ToggleButton` control toggles between when users click on the button.
 
-```markup
+```xml
 <Style Selector="ToggleButton DrawingPresenter.tbchecked">
     <Setter Property="IsVisible" Value="False"/>
 </Style>
@@ -32,7 +32,7 @@ This button will show a muted speaker icon or an un-muted speaker icon based on 
 
 The style code above reacts to `ToggleButton`'s `:checked` pseudoclass, so that if the `ToggleButton` is checked, any `DrawingPresenter` with the class `.tbchecked` will be visible, and any `DrawingPresenter` with the class `.tbunchecked` will not be visible.
 
-```markup
+```xml
 <ToggleButton Classes="vtrx" IsChecked="{Binding Path=vtrx.muted}" ToolTip.Tip="stop audio">
     <Panel>
         <DrawingPresenter Drawing="{DynamicResource Icon.Speaker}" Classes="tbunchecked"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/calendar.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/calendar.md
@@ -30,7 +30,7 @@ The `Calendar` control is a standard Calendar control for users to select date\(
 
 ### Basic Calendar
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -46,7 +46,7 @@ The `Calendar` control is a standard Calendar control for users to select date\(
 
 ### Range selection Calendar
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -64,7 +64,7 @@ After selecting the start date, a single range can be selected by holding the sh
 
 ### Calendar with custom start and end dates
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/calendardatepicker.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/calendardatepicker.md
@@ -11,7 +11,7 @@ The `CalendarDatePicker` control allows the user to pick a date value using a ca
 
 The placeholder (the text that appears when the input is empty) can be changed using the `Watermark` property.
 
-```markup
+```xml
 <CalendarDatePicker
 	Watermark="01/01/1970" />
 ```
@@ -20,7 +20,7 @@ The placeholder (the text that appears when the input is empty) can be changed u
 
 The format of the date displayed can be customised by setting the `SelectedDateFormat` to `Custom` and providing a custom format in `CustomDateFormatString` in the same way `DateTime.ToString(string format)` accepts.
 
-```markup
+```xml
 <CalendarDatePicker 
 	SelectedDateFormat="Custom"
 	CustomDateFormatString="yyyy-MM-dd" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/canvas.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/canvas.md
@@ -15,7 +15,7 @@ The Canvas does not do any sizing of its children. Each element must specify its
 
 Here's an example of a Canvas in XAML.
 
-```markup
+```xml
 <Canvas Width="120" Height="120">
     <Rectangle Fill="Red" Height="44" Width="44"/>
     <Rectangle Fill="Blue" Height="44" Width="44" Canvas.Left="20" Canvas.Top="20"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/checkbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/checkbox.md
@@ -27,7 +27,7 @@ The `CheckBox` control is a [`ContentControl`](../controls/contentcontrol) which
 
 ### Basic checkbox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -48,7 +48,7 @@ produces following output with **Windows 10**
 
 ### Three state checkbox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/combobox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/combobox.md
@@ -27,7 +27,7 @@ title: ComboBox
 
 ### Basic ComboBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -48,7 +48,7 @@ title: ComboBox
 
 ### ComboBox with custom item templates
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -79,7 +79,7 @@ title: ComboBox
 
 This example binds the fonts installed to a ComboBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/contentcontrol.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/contentcontrol.md
@@ -25,19 +25,19 @@ At its simplest, a `ContentControl` displays the data assigned to its [`Content`
 
 For example:
 
-```markup
+```xml
 <ContentControl Content="Hello World!"/>
 ```
 
 Will display the string "Hello World!". The `Content` property is the control's default property and so the above example can also be written as:
 
-```markup
+```xml
 <ContentControl>Hello World!</ContentControl>
 ```
 
 If you assign a control to a `ContentControl` then it will display the control, for example:
 
-```markup
+```xml
 <ContentControl>
   <Button>Click Me!</Button>
 </ContentControl>
@@ -79,7 +79,7 @@ namespace Example
 
 We can display the student's first and last name in a `ContentControl` using the `ContentTemplate` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
   <ContentControl Content="{Binding Content}">
     <ContentControl.ContentTemplate>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/datagrid/datagridcolumns.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/datagrid/datagridcolumns.md
@@ -27,7 +27,7 @@ This column is used to display text data, normally represented by a `string`. In
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid" Items="{Binding People}" AutoGenerateColumns="False" >
     <DataGrid.Columns>
         <DataGridTextColumn Header="Forename" Binding="{Binding FirstName}"/>
@@ -50,7 +50,7 @@ This column is used to represent a `bool` value. The  value is represented by a 
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid" Items="{Binding ToDoListItems}" AutoGenerateColumns="False" >
     <DataGrid.Columns>
         <DataGridCheckBoxColumn Header="✔" Binding="{Binding IsChecked}"/>
@@ -77,7 +77,7 @@ The DataGridTemplateColumn is editable from Avalonia version 0.10.12 onward. If 
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid"
           xmlns:model="using:MyApp.Models"  >
   <DataGrid.Columns>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/datagrid/index.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/datagrid/index.md
@@ -28,7 +28,7 @@ Note, that version should match Avalonia version you are using.
 
 The Themes can be changed to light or dark to fit your application theme.
 
-```markup
+```xml
 <Application.Styles>
     <StyleInclude Source="avares://Avalonia.Themes.Default/DefaultTheme.xaml"/>
     <StyleInclude Source="avares://Avalonia.Themes.Default/Accents/BaseLight.xaml"/>
@@ -38,7 +38,7 @@ The Themes can be changed to light or dark to fit your application theme.
 
 Or if you are using new Fluent theme, you will need to include styles created specifically for that:
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme Mode="Light" />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
@@ -51,7 +51,7 @@ Or if you are using new Fluent theme, you will need to include styles created sp
 
 This will generate a DataGrid with column header names. FirstName and LastName.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -78,7 +78,7 @@ public class Person
 
 The DataGrid uses the same class Person as before, but now with custom column header name. Forename and Surname.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/dockpanel.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/dockpanel.md
@@ -9,7 +9,7 @@ import DockPanelFillNoOverlapScreenshot from '/img/controls/dockpanel/dockpanel.
 
 The `DockPanel` control is a `Panel` which lays out its children by "docking" them to the sides or floating in the center.
 
-```markup
+```xml
 <DockPanel Width="300" Height="300">
     <Rectangle Fill="Red" Height="100" DockPanel.Dock="Top"/>
     <Rectangle Fill="Blue" Width="100" DockPanel.Dock="Left"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/flyouts.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/flyouts.md
@@ -69,7 +69,7 @@ There are two built-in types of Flyouts: `Flyout` and `MenuFlyout`. A regular `F
 
 In order to be shown Flyouts have to be attached to a specific control, though this is not a static assignment and can be changed at runtime. `Button` has a `Flyout` property that can be used to open a Flyout upon click.
 
-```markup
+```xml
 <Button Content="Click me">
     <Button.Flyout>
         <Flyout>
@@ -83,7 +83,7 @@ In order to be shown Flyouts have to be attached to a specific control, though t
 
 For other controls that don't have built-in support for flyouts, one can be assigned using attached flyouts
 
-```markup
+```xml
 <Border Background="Red" PointerPressed="Border_PointerPressed">
     <FlyoutBase.AttachedFlyout>
         <Flyout>
@@ -112,7 +112,7 @@ ContextFlyouts are invoked automatically like normal `ContextMenu`s. Although cu
 
 As previously mentioned, Flyouts can be shared between various elements within your app.
 
-```markup
+```xml
 <Window.Resources>
     <Flyout x:Key="MySharedFlyout">
         <!-- Flyout content here -->
@@ -128,7 +128,7 @@ As previously mentioned, Flyouts can be shared between various elements within y
 
 Although `Flyout`s are not controls themselves, their general appearance can still be customized by targeting the presenter the `Flyout` uses to display its content. For a normal `Flyout` this is `FlyoutPresenter` and for `MenuFlyout` this is `MenuFlyoutPresenter`. Because flyout presenters are not exposed, special style classes that should pertain to specific flyouts can be passed using the `FlyoutPresenterClasses` property on `FlyoutBase`
 
-```markup
+```xml
 <Style Selector="FlyoutPresenter.mySpecialClass">
     <Setter Property="Background" Value="Red" />
 </Style>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/grid.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/grid.md
@@ -31,7 +31,7 @@ Below is an example that shows:
 
 An example of a Grid with 3 equal Rows and 3 Columns with \(1 fixed width\), \(2 grabbing the rest proportionally\) would be:
 
-```markup
+```xml
 <Grid ColumnDefinitions="100,1.5*,4*" RowDefinitions="Auto,Auto,Auto"  Margin="4">
   <TextBlock Text="Col0Row0:" Grid.Row="0" Grid.Column="0"/>
   <TextBlock Text="Col0Row1:" Grid.Row="1" Grid.Column="0"/>
@@ -54,7 +54,7 @@ Here is another example showing the difference between those two.
 
 First let's create sample 2x2 grid in our View, we can achieve this simply by writing code looking like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
@@ -77,7 +77,7 @@ Now let's fill our grid with some elements, I will fill every field with button,
 
 Now our View code look's like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
@@ -103,7 +103,7 @@ As you can see our grid become sticky to its content, it is very useful when we 
 
 This new View code looks like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -125,7 +125,7 @@ This new View code looks like this:
 
 For more complex row and column definitions it's possible to explicitly use `Grid.ColumnDefinitions` and `Grid.RowDefinitions` XAML fields to provide access to these additional settings. The below code produces is exactly the same except for the fact we set the minimum width on the second column to be 300.
 
-```markup
+```xml
 <Grid Margin="4">
   <Grid.ColumnDefinitions>
     <ColumnDefinition Width="100" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/gridsplitter.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/gridsplitter.md
@@ -8,7 +8,7 @@ import GridSplitterRowsScreenshot from '/img/controls/gridsplitter/gridsplitter-
 
 The `GridSplitter` control is a control that allows a user to resize the space between `Grid` rows or columns.
 
-```markup
+```xml
 <Grid ColumnDefinitions="*, 4, *">
     <Rectangle Grid.Column="0" Fill="Blue"/>
     <GridSplitter Grid.Column="1" Background="Black" ResizeDirection="Columns"/>
@@ -18,7 +18,7 @@ The `GridSplitter` control is a control that allows a user to resize the space b
 
 <img className="center" src={GridSplitterColumnsScreenshot} alt="GridSplitter in Action for Columns" />
 
-```markup
+```xml
 <Grid RowDefinitions="*, 4, *">
     <Rectangle Grid.Row="0" Fill="Blue"/>
     <GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/image.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/image.md
@@ -21,13 +21,13 @@ The declarative approaches keep images in memory and won't have to load them in 
 
 **Binding Converter Approach**
 
-```markup
+```xml
 <UserControl.Resources>
     <ext:BitmapAssetValueConverter x:Key="variableImage"/>
 </UserControl.Resources>
 ```
 
-```markup
+```xml
 <Image Width="75"
        Height="73"
        Source="{Binding PlaySource, Converter={StaticResource variableImage}}">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/listbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/listbox.md
@@ -7,7 +7,7 @@ The `ListBox` is an `ItemsControl` which displays items in a multi-line list box
 
 The items to display in the `ListBox` are specified using the `Items` property. This property will often be bound to a collection on the control's `DataContext`:
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}"/>
 ```
 
@@ -15,7 +15,7 @@ The items to display in the `ListBox` are specified using the `Items` property. 
 
 You can customize how an item is displayed by specifying an `ItemTemplate`. For example to display each item inside a red border with rounded corners:
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}">
     <ListBox.ItemTemplate>
         <DataTemplate>
@@ -33,7 +33,7 @@ Each item displayed in a `ListBox` will be wrapped in a `ListBoxItem` - this is 
 
 Sometimes you will want to customize the container itself. You can do this by including a style targeting `ListBoxItem` in the `ListBox`:
 
-```markup
+```xml
 <ListBox Items="{Binding Items}">
     <ListBox.Styles>
         <!-- Give the ListBoxItems a fixed with of 100 and right-align them -->
@@ -66,7 +66,7 @@ Controls the type of selection that can be made on the `ListBox`:
 
 These values can be combined, e.g.:
 
-```markup
+```xml
 <ListBox SelectionMode="Multiple,Toggle"/>
 ```
 
@@ -74,7 +74,7 @@ These values can be combined, e.g.:
 
 Exposes the index of the selected item, or in the case of multiple selection the first selected item. You will often want to bind this to a view model if your list `SelectionMode` is set to `Single`.
 
-```markup
+```xml
 <ListBox SelectedIndex="{Binding SelectedIndex}"/>
 ```
 
@@ -97,7 +97,7 @@ By default bindings to this property are two-way.
 
 Exposes the selected item in the `Items` collection, or in the case of multiple selection the first selected item. You will often want to bind this to a view model if your list `SelectionMode` is set to `Single`.
 
-```markup
+```xml
 <ListBox SelectedItem="{Binding SelectedItem}"/>
 ```
 
@@ -128,7 +128,7 @@ Once `Selection` is bound to a `SelectionModel`, `SelectedItems` will no longer 
 
 `SelectionModel` also exposes batching functionality through its `Update()` method and a `SelectionChanged` event which details exactly which items have been selected and deselected.
 
-```markup
+```xml
 <ListBox Items="{Binding Items}" Selection="{Binding Selection}"/>
 ```
 
@@ -172,7 +172,7 @@ This property holds the selected items in an `IList`. It can be bound to any lis
 
 For various reasons the performance of `SelectedItems` can be very poor, particularly on large collections. It is recommended that you use the `Selection` property instead.
 
-```markup
+```xml
 <ListBox SelectedItems="{Binding SelectedItems}"/>
 ```
 
@@ -187,7 +187,7 @@ public MyViewModel : ReactiveObject
 
 By default if an item is too wide to display in the `ListBox`, a horizontal scrollbar will be displayed. If instead you want items to be constrained to the width of the `ListBox` \(for example if you want wrapping text in the items\) you can disable the horizontal scrollbar by setting `ScrollViewer.HorizontalScrollBarVisibility="Disabled"`.
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}" Width="250" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
     <ListBox.ItemTemplate>
         <DataTemplate>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/maskedtextbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/maskedtextbox.md
@@ -14,7 +14,7 @@ The `MaskedTextBox` control is an editable text field where a user can input tex
 
 ### Basic example line TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/menu.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/menu.md
@@ -5,7 +5,7 @@ title: Menu
 
 The `Menu` control adds a top-level menu to an application. A `Menu` is usually placed in a `DockPanel` in a `Window`, docked to the top of the window:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <DockPanel>
@@ -40,7 +40,7 @@ If you will press Alt with the example above you will see that some letters are 
 
 Like `Button`, commands can be [bound](../data-binding/binding-to-commands) to `MenuItem`s. The command will be executed when the menu item is clicked or selected with the keyboard:
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem Header="_Open..." Command="{Binding OpenCommand}"/>
@@ -54,7 +54,7 @@ Like `Button`, commands can be [bound](../data-binding/binding-to-commands) to `
 
 A menu icon can be displayed by placing an `Image` in the `Icon` property:
 
-```markup
+```xml
     <MenuItem Header="_Open...">
         <MenuItem.Icon>
             <Image Source="resm:MyApp.Assets.Open.png"/>
@@ -66,7 +66,7 @@ A menu icon can be displayed by placing an `Image` in the `Icon` property:
 
 Similarly, a `CheckBox` can be displayed in the `Icon` property to make the `MenuItem` checkable:
 
-```markup
+```xml
     <MenuItem Header="_Open...">
         <MenuItem.Icon>
             <CheckBox BorderThickness="0"
@@ -192,7 +192,7 @@ public MainWindow()
 
 Finally assign the bindings to the view model in a `Style` within the menu:
 
-```markup
+```xml
 <Menu Items="{Binding MenuItems}">
     <Menu.Styles>
         <Style Selector="MenuItem">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/numericupdown.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/numericupdown.md
@@ -23,7 +23,7 @@ The control has a up and down button spinner attached, used to increment and dec
 
 The value stored in the `NumericUpDown` is a double.
 
-```markup
+```xml
 <NumericUpDown Value="10" Width="100"/>
 ```
 
@@ -35,13 +35,13 @@ produces the following output on **Linux**
 
 A custom increment/decrement value can be set for the button spinner. The default increment value is set to 1.
 
-```markup
+```xml
 <NumericUpDown Value="0.5" Increment="0.01" Minimum="0" Maximum="1"/>
 ```
 
 ### NumericUpDown without a button spinner
 
-```markup
+```xml
 <NumericUpDown Value="42" AllowSpin="False" ShowButtonSpinner="False"/>
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/panel.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/panel.md
@@ -9,7 +9,7 @@ The `Panel` is the base class for controls that can contain multiple children li
 
 The `Panel` class can be useful on its own for very basic layouts, or simply to allow multiple controls to be to be contained.
 
-```markup
+```xml
 <Panel Height="300" Width="300">
     <Rectangle Fill="Red" Height="100" VerticalAlignment="Top"/>
     <Rectangle Fill="Blue" Width="100" HorizontalAlignment="Right" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/relativepanel.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/relativepanel.md
@@ -22,7 +22,7 @@ Attached properties are used to control the layout of elements. This table shows
 
 This XAML shows how to arrange elements in a RelativePanel.
 
-```markup
+```xml
 <RelativePanel BorderBrush="Gray" BorderThickness="1">
     <Rectangle x:Name="RedRect" Fill="Red" Height="44" Width="44"/>
     <Rectangle x:Name="BlueRect" Fill="Blue"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/splitview.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/splitview.md
@@ -7,7 +7,7 @@ import SplitViewScreenshot from '/img/controls/splitview/image (9).png';
 
 Represents a container with two views; one view for the main content and another view that is typically used for navigation commands.
 
-```markup
+```xml
 <SplitView IsPaneOpen="True"
            DisplayMode="Inline"
            OpenPaneLength="296">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/stackpanel.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/stackpanel.md
@@ -12,7 +12,7 @@ You can use the [**Orientation**](https://docs.microsoft.com/en-us/uwp/api/windo
 
 The following XAML shows how to create a vertical StackPanel of items.
 
-```markup
+```xml
 <StackPanel>
     <Rectangle Fill="Red" Height="44"/>
     <Rectangle Fill="Blue" Height="44"/>
@@ -29,7 +29,7 @@ In a StackPanel, if a child element's size is not set explicitly, it stretches t
 
 StackPanel has a `Spacing` property to allow an even spacing between items.
 
-```markup
+```xml
 <StackPanel Spacing="5">
     <Rectangle Fill="Red" Height="44"/>
     <Rectangle Fill="Blue" Height="44"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/tabcontrol.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/tabcontrol.md
@@ -14,7 +14,7 @@ Here is an animation of what you can achieve :
 
 To create this, we'll describe the entire control \(TabControl\) and each individual tab+page \(TabItem\). Here is an example :
 
-```markup
+```xml
 <TabControl>
   <TabItem Header="Circle" VerticalContentAlignment="Center">
     <TextBlock Text="I am in the circle page !" HorizontalAlignment="Left" VerticalAlignment="Center"/>
@@ -48,7 +48,7 @@ Let's have a look at a customized `TabControl` :
 
 The grey part is the `TabItem`... Yes, the `TabItem` includes the tab **AND** the page associated to the tab. The tab is called the `header`of the `TabItem`. Moreover, given the way `TabControl` has been implemented, tabs are in a `WrapPanel`. Thus, if you want to color in blue \(like this is done above\) the empty bar of the tabbed bar, you must change the background color of the `WrapPanel` of the `TabControl`. Here is the code used to obtain the result above \(_Note the workaround used to color some tabs : this is due to the way the control is implemented. It might change in the future._\)
 
-```markup
+```xml
 <Window.Styles>
 
   <Style Selector="TabControl">
@@ -123,7 +123,7 @@ DataContext = new TabItemModel[] {
 
 Finally create a `TabControl` and bind its Items property to the DataContext.
 
-```markup
+```xml
 <TabControl Items="{Binding}">
     <TabControl.ItemTemplate>
       <DataTemplate>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/textbox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/textbox.md
@@ -22,7 +22,7 @@ The `TextBox` control is an editable text field where a user can input text.
 
 ### Basic one line TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -42,7 +42,7 @@ produces the following output in **Windows 10**
 
 ### Password input TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -62,7 +62,7 @@ produces the following output in **Windows 10** when text is input
 
 When using the Fluent theme, you can apply the style class, `revealPasswordButton`, and the TextBox will provide an eye 👁 glyph for the user to show the plane text temporally. Please note, the `TextBox` may be written to but not copied from.
 
-```markup
+```xml
 <TextBox Classes="revealPasswordButton" PasswordChar="•" />
 ```
 
@@ -70,7 +70,7 @@ When using the Fluent theme, you can apply the style class, `revealPasswordButto
 
 Avalonia can show a "watermark" in a `TextBox`, which is a piece of text that is displayed when the `TextBox` is empty \(in HTML5 this is called a _placeholder_\)
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -90,7 +90,7 @@ produces the following output in **Windows 10**
 
 ### Multiline TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/timepicker.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/timepicker.md
@@ -50,7 +50,7 @@ Use a `TimePicker` to let a user enter a single time value. You can customize th
 
 By default, the time picker shows a 12-hour clock with an AM/PM selector. You can set the [ClockIdentifier](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker.clockidentifier?view=winrt-19041#Windows\_UI\_Xaml\_Controls\_TimePicker\_ClockIdentifier) property to "24HourClock" to show a 24-hour clock instead.
 
-```markup
+```xml
 <TimePicker Header="12HourClock" SelectedTime="14:30"/>
 <TimePicker Header="24HourClock" SelectedTime="14:30" ClockIdentifier="24HourClock"/>
 ```
@@ -61,7 +61,7 @@ By default, the time picker shows a 12-hour clock with an AM/PM selector. You ca
 
 You can set the [MinuteIncrement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker.minuteincrement?view=winrt-19041#Windows\_UI\_Xaml\_Controls\_TimePicker\_MinuteIncrement) property to indicate the time increments shown in the minute picker. For example, 15 specifies that the `TimePicker` minute control displays only the choices 00, 15, 30, 45.
 
-```markup
+```xml
 <TimePicker MinuteIncrement="15"/>
 ```
 
@@ -88,7 +88,7 @@ TimePicker timePicker = new TimePicker
 
 You can set the time value as an attribute in XAML. This is probably easiest if you're already declaring the `TimePicker` object in XAML and aren't using bindings for the time value. Use a string in the form _Hh:Mm_ where _Hh_ is hours and can be between 0 and 23 and _Mm_ is minutes and can be between 0 and 59.
 
-```markup
+```xml
 <TimePicker SelectedTime="14:15"/>
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/tooltip.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/tooltip.md
@@ -28,7 +28,7 @@ The `ToolTip` is a control that pops up with hint text when hovered over the app
 
 ### Text ToolTip
 
-```markup
+```xml
 <Border Margin="5"
         Padding="10"
         Background="{DynamicResource ThemeAccentBrush}"
@@ -39,7 +39,7 @@ The `ToolTip` is a control that pops up with hint text when hovered over the app
 
 ### Rich Tooltip
 
-```markup
+```xml
 <Border Margin="5"
         Padding="10"
         Background="{DynamicResource ThemeAccentBrush}"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/transitioningcontentcontrol.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/transitioningcontentcontrol.md
@@ -26,7 +26,7 @@ import TransitioningContentControlSlideScreenshot from '/img/controls/transition
 
 Let's assume we have a collection of different images and we want to show them in a slideshow like view. In order to do this we can setup our `TransitioningContentControl` like this:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">
@@ -44,7 +44,7 @@ If you don't like the `PageTransition` which is provided by the applied theme, y
 
 In the sample below we will change the [PageTransition](../animations/page-transitions.md) to slide the images horizontally.
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.PageTransition>
         <PageSlide Orientation="Horizontal" Duration="0:00:00.500" />
@@ -63,7 +63,7 @@ In the sample below we will change the [PageTransition](../animations/page-trans
 
 If you want to disable the transition, set the `PageTransition` to `null`.
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" PageTransition="{x:Null}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/creating-a-flat-treedatagrid.md.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/creating-a-flat-treedatagrid.md.md
@@ -88,7 +88,7 @@ The columns above are defined as `TextColumn`s - again, `TextColumn` is a generi
 
 It's now time to add the `TreeDataGrid` control to a window and bind it to the source.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication.MainWindow">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/creating-a-hierarchical-treedatagrid.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/creating-a-hierarchical-treedatagrid.md
@@ -119,7 +119,7 @@ The remaining columns are also defined as `TextColumn`s - again, `TextColumn` is
 
 It's now time to add the `TreeDataGrid` control to a window and bind it to the source.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication.MainWindow">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/index.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/treedatagrid/index.md
@@ -36,7 +36,7 @@ We accept issues and pull requests but we answer and review only pull requests a
 * Add the `Avalonia.Controls.TreeDataGrid` NuGet package to your project
 * Add the `TreeDataGrid` theme to your `App.xaml` file (the `StyleInclude` in the following markup):
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AvaloniaApplication.App">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/treeview.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/controls/treeview.md
@@ -7,7 +7,7 @@ The `TreeView` is a control that presents hierarchical tree data and allows sele
 
 One example for populating a `TreeView` can be from a directory on the computer. You can create a `TreeView` in the `MainWindow.axaml` file in an Avalonia MVVM project.
 
-```markup
+```xml
 <TreeView Items="{Binding Items}" 
 	  Width="400" Height="480" 
 	  HorizontalAlignment="Left">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-classes.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-classes.md
@@ -4,7 +4,7 @@ title: Binding Classes
 ---
 In Avalonia, you also can bind classes. Sometimes it could be useful to switch classes depending on some logic, and for those purposes, you can use Binding Classes API. There is the sample usage of Binding Classes. We have two different styles and we want to switch between them depending on `MyProperty` state.
 
-```markup
+```xml
  <ListBox Items="{Binding MyItems}">
     <ListBox.Styles>
         <Style Selector="TextBlock.myClass">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-in-a-control-template.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-in-a-control-template.md
@@ -5,7 +5,7 @@ title: Binding in a Control Template
 
 When you're creating a control template and you want to bind to the templated parent you can use:
 
-```markup
+```xml
 <TextBlock Name="tb" Text="{TemplateBinding Caption}"/>
 
 <!-- Which is the same as -->
@@ -16,7 +16,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
 
  1. `TemplateBinding` accepts only a single property rather than a property path, so if you want to bind using a property path you must use the second syntax:
 
-    ```markup
+    ```xml
     <!-- This WON'T work as TemplateBinding only accepts single properties -->
     <TextBlock Name="tb" Text="{TemplateBinding Caption.Length}"/>
 
@@ -32,7 +32,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
 
  3. `TemplateBinding` can only be used on `IStyledElement`.
 
-   ```markup
+   ```xml
    <!-- This WON'T work as GeometryDrawing is not a IStyledElement. -->
    <GeometryDrawing Brush="{TemplateBinding Foreground}"/>
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-to-commands.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-to-commands.md
@@ -29,7 +29,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Button Command="{Binding DoTheThing}">Do the thing!</Button>
 </Window>
@@ -59,7 +59,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Button Command="{Binding DoTheThing}" CommandParameter="Hello World">Do the thing!</Button>
 </Window>
@@ -67,7 +67,7 @@ namespace Example
 
 Note that no type conversion is carried out on `CommandParameter`, so if you need your type parameter to be something other than `string` you must supply an object of that type in XAML. For example to pass an `int` parameter you could use:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <Button Command="{Binding DoTheThing}">
@@ -100,7 +100,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
   <Button Command="{Binding RunTheThing}" CommandParameter="Hello World">Do the thing!</Button>
 </Window>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-to-tasks-and-observables.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/binding-to-tasks-and-observables.md
@@ -9,7 +9,7 @@ You can subscribe to the result of a task or an observable by using the `^` stre
 
 For example if `DataContext.Name` is an `IObservable<string>` then the following example will bind to the length of each string produced by the observable as each value is produced
 
-```markup
+```xml
 <TextBlock Text="{Binding Name^.Length}"/>
 ```
 
@@ -30,7 +30,7 @@ private async Task<string> GetTextAsync()
 ```
 
 You can bind to the result in the following way: 
-```markup
+```xml
 <TextBlock Text="{Binding MyAsyncText^, FallbackValue='Wait a second'}" />
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/bindings.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/bindings.md
@@ -7,7 +7,7 @@ You bind in XAML using the `{Binding}` markup extension. By using bindings \(ass
 
 By default a binding binds to a property on the [`DataContext`](the-datacontext), e.g.:
 
-```markup
+```xml
 <!-- Binds to the TextBlock's DataContext.Name property -->
 <TextBlock Text="{Binding Name}"/>
 
@@ -17,7 +17,7 @@ By default a binding binds to a property on the [`DataContext`](the-datacontext)
 
 An empty binding binds to DataContext itself
 
-```markup
+```xml
 <!-- Binds to the TextBlock's DataContext property -->
 <TextBlock Text="{Binding}"/>
 
@@ -31,13 +31,13 @@ We call the property on the control the binding _target_ and the property on the
 
 The binding path above can be a single property, or it can be a chain of properties. For example if the object assigned to the `DataContext` has a `Student` property, and the value of this property has a `Name`, you can bind to the student name using:
 
-```markup
+```xml
 <TextBlock Text="{Binding Student.Name}"/>
 ```
 
 You can also include array/list indexers in binding paths:
 
-```markup
+```xml
 <TextBlock Text="{Binding Students[0].Name}"/>
 ```
 
@@ -45,7 +45,7 @@ You can also include array/list indexers in binding paths:
 
 You can change the behavior of a `{Binding}` by specifying a binding `Mode`:
 
-```markup
+```xml
 <TextBlock Text="{Binding Name, Mode=OneTime}">
 ```
 
@@ -65,7 +65,7 @@ The `Default` mode is assumed if one is not specified. This mode is generally `O
 
 You can apply a format string to the binding to influence how the value is represented in the UI:
 
-```markup
+```xml
 <!-- Option 1: Use string format without curly braces -->
 <TextBlock Text="{Binding FloatValue, StringFormat=0.0}" />
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/compiled-bindings.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/compiled-bindings.md
@@ -13,7 +13,7 @@ Compiled bindings are not enabled by default. To enable compiled bindings, you w
 
 You can now enable or disable compiled bindings by setting `x:CompileBindings="[True|False]"`. All child nodes will inherit this property, so you can enable it in your root node and disable it for a specific child, if needed.
 
-```markup
+```xml
 <!-- Set DataType and enable compiled bindings -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -48,7 +48,7 @@ Starting from Avalonia `11.0-preview5` you can also enable or disable it in whol
 
 If you don't want to enable compiled bindings for all child nodes, you can also use the `CompiledBinding`-markup. You still need to define the `DataType`, but you can omit `x:CompileBindings="True"`.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -73,7 +73,7 @@ If you don't want to enable compiled bindings for all child nodes, you can also 
 ## ReflectionBinding-Markup
 If you have compiled bindings enabled in the root node (via `x:CompileBindings="True"`) and you either don't want to use compiled binding at a certain position or you hit one of the [known limitations](#known-limitations), you can use the `ReflectionBinding`-markup.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/converting-binding-values.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/converting-binding-values.md
@@ -27,7 +27,7 @@ Negation also works when binding to non-boolean values. First of all, the value 
 
 A "double-bang" can be used to convert a non-boolean value to a boolean value. For example to hide a control when a collection is empty:
 
-```markup
+```xml
 <Panel>
   <ListBox Items="{Binding Items}" IsVisible="{Binding !!Items.Count}"/>
 </Panel>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/creating-and-binding-attached-properties.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/creating-and-binding-attached-properties.md
@@ -122,7 +122,7 @@ In the verify method we utilize the routed event system to attach a new handler.
 
 This example UI shows how to use the attached property. After making the namespace known to the XAML compiler it can be used by qualifying it with a dot. Then bindings can be used.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:MyApp.Behaviors"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/the-datacontext.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/data-binding/the-datacontext.md
@@ -23,7 +23,7 @@ private static void AppMain(Application app, string[] args)
 
 This means that when the `MainWindow` is created, a new instance of `MainWindowViewModel` will be created and assigned to the window's `DataContext` property. From here all bindings will by default bind to properties on this object:
 
-```markup
+```xml
 <Window>
     <Button Content="{Binding ButtonCaption}"/>
 </Window>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/distribution-publishing/macos.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/distribution-publishing/macos.md
@@ -94,7 +94,7 @@ More documentation on possible `Info.plist` keys is available [here](https://dev
 
 If at any point the tooling gives you an error that your assets file doesn't have a target for `osx-64`, add the following [runtime identifiers](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) to the top `<PropertyGroup>` in your `.csproj`:
 
-```markup
+```xml
 <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
 ```
 
@@ -114,7 +114,7 @@ The file that is actually executed by macOS when starting your `.app` bundle wil
 
 * Add the following to your `.csproj` file:
 
-```markup
+```xml
 <PropertyGroup>
   <UseAppHost>true</UseAppHost>
 </PropertyGroup>
@@ -128,7 +128,7 @@ The file that is actually executed by macOS when starting your `.app` bundle wil
 
 You'll first have to add the project as a `PackageReference` in your project. Add it to your project via NuGet package manager or by adding the following line to your `.csproj` file:
 
-```markup
+```xml
 <PackageReference Include="Dotnet.Bundle" Version="*" />
 ```
 
@@ -153,7 +153,7 @@ dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-x64 -p:CFBundleDisplayName=
 
 Instead of specifying `CFBundleDisplayName`, etc., on the command line, you can also specify them in your project file:
 
-```markup
+```xml
 <PropertyGroup>
     <CFBundleName>AppName</CFBundleName> <!-- Also defines .app file name -->
     <CFBundleDisplayName>MyBestThingEver</CFBundleDisplayName>
@@ -514,7 +514,7 @@ When upload succeeds - you will see your package in App Store Connect.
 
 This means that your application most likely does not specify a menu. On startup, Avalonia creates the default menu items for an application and automatically adds the _About Avalonia_ item when no menu has been configured. This can be resolved by adding one to your `App.xaml`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:RoadCaptain.App.RouteBuilder"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/assets.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/assets.md
@@ -9,7 +9,7 @@ Many applications need to include assets such as bitmaps and [resource dictionar
 
 Assets can be included in an application by using the `<AvaloniaResource>` item in your project file. The MVVM Application template by default includes all files in the `Assets` directory as an `<AvaloniaResource>`:
 
-```markup
+```xml
 <ItemGroup>
   <AvaloniaResource Include="Assets\**"/>
 </ItemGroup>
@@ -23,7 +23,7 @@ You will notice that we're referring to _assets_ here whereas the MSBuild item i
 
 Assets can be referenced in XAML by specifying their relative path:
 
-```markup
+```xml
 <Image Source="icon.png"/>
 <Image Source="images/icon.png"/>
 <Image Source="../icon.png"/>
@@ -31,19 +31,19 @@ Assets can be referenced in XAML by specifying their relative path:
 
 Or their rooted path:
 
-```markup
+```xml
 <Image Source="/Assets/icon.png"/>
 ```
 
 If the asset is located in a different assembly from the XAML file, then use the `avares:` URI scheme. For example, if the asset is contained in an assembly called `MyAssembly.dll`, then you would use:
 
-```markup
+```xml
 <Image Source="avares://MyAssembly/Assets/icon.png"/>
 ```
 
 In case of fonts, you can provide a font name after a '#' sign:
 
-```markup
+```xml
 <TextBlock FontFamily="avares://MyAssembly/Assets/font.ttf#FontName">test</TextBlock>
 ```
 
@@ -55,13 +55,13 @@ Assets can also be included in .NET applications by using the `<EmbeddedResource
 
 You can reference manifest resources using the `resm:` URL scheme:
 
-```markup
+```xml
 <Image Source="resm:MyApp.Assets.icon.png"/>
 ```
 
 Or if the resource is embedded in a different assembly to the XAML file:
 
-```markup
+```xml
 <Image Source="resm:MyApp.Assets.icon.png?assembly=MyAssembly"/>
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/ide-support.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/ide-support.md
@@ -50,7 +50,7 @@ With the namespace added, the following design-time properties become available:
 
 The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to the control being previewed.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -64,7 +64,7 @@ The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to 
 
 The `d:DataContext` property applies a `DataContext` only at design-time. It is recommended that you use this property in conjunction with the `{x:Static}` directive to reference a static property in one of your assemblies:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -91,7 +91,7 @@ namespace My.Namespace
 ### Design.DataContext
 
 Alternatively you can use `Design.DataContext` attached property. As well as Design.Width and Design.Height.
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/data-binding.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/data-binding.md
@@ -13,7 +13,7 @@ Avalonia includes comprehensive support for [binding](../../data-binding/binding
 
 The following example shows a `TextBlock` when an associated `TextBox` is disabled, by using a binding:
 
-```markup
+```xml
 <StackPanel>
     <TextBox Name="input" IsEnabled="False"/>
     <TextBlock IsVisible="{Binding !#input.IsEnabled}">Sorry, no can do!</TextBlock>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/graphics-and-animations.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/graphics-and-animations.md
@@ -16,7 +16,7 @@ Avalonia introduces an extensive, scalable, and flexible set of graphics feature
 
 Avalonia provides a library of common vector-drawn 2D shapes such as `Ellipse`, `Line`, `Path`, `Polygon` and `Rectangle`.
 
-```markup
+```xml
 <Canvas Background="Yellow" Width="300" Height="400">
     <Rectangle Fill="Blue" Width="63" Height="41" Canvas.Left="40" Canvas.Top="31">
         <Rectangle.OpacityMask>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/index.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/getting-started/programming-with-avalonia/index.md
@@ -11,7 +11,7 @@ XAML is an XML-based markup language that implements an application's appearance
 
 The following example uses XAML to implement the appearance of a window that contains a single button:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/accessing-the-ui-thread.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/accessing-the-ui-thread.md
@@ -19,7 +19,7 @@ In the below example we have a `TextBlock` which shows the result and a `Button`
 
 Our view looks like this: 
 
-```markup
+```xml
 <StackPanel>
   <TextBlock x:Name="TextBlock_Result" />
   <Button Content="Run long running process" Click="Button_OnClick" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/code-behind.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/code-behind.md
@@ -39,7 +39,7 @@ namespace AvaloniaApplication1
 
 Note that this class definition corresponds closely to the XAML file:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -60,7 +60,7 @@ In addition, the class contains two more things of interest:
 
 One of the main uses of the code-behind file is to manipulate controls using C\# code. To do this you'll usually first want to get a reference to a named control. This can be done using the `FindControl<T>` method:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">
@@ -154,7 +154,7 @@ For the rest of the documentation, we'll assume you're either using Avalonia tem
 
 Another common use for the code-behind file is to define _event handlers_. Event handlers are defined as methods in the code-behind and referenced from XAML. For example to add a handler for a button click:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/introduction-to-xaml.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/basics/introduction-to-xaml.md
@@ -19,7 +19,7 @@ Both `.xaml` and `.axaml` will be supported going forward, so feel free to use t
 
 A basic Avalonia XAML file looks like this:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -97,7 +97,7 @@ using Avalonia.Metadata;
 
 Controls are added to the XAML by adding an XML element with the control's class name. For example to add a button as the child of the window you would write:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button>Hello World!</Button>
@@ -110,7 +110,7 @@ See the [controls documentation](../../controls) for a list of the controls incl
 
 You can set a property of a control by adding an XML attribute to an element. For example to create a button with a blue background you could write:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Background="Blue">Hello World!</Button>
@@ -123,7 +123,7 @@ You can also use _property element syntax_ for setting properties. For more info
 
 You may notice that the button above has its "Hello World!" content placed directly inside the XML element. This could also be written as a property using:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="Hello World"/>
@@ -136,7 +136,7 @@ This is because [`Button.Content`](http://reference.avaloniaui.net/api/Avalonia.
 
 You can bind a property using the `{Binding}` markup extension:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="{Binding Greeting}"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/data-persistence.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/data-persistence.md
@@ -57,7 +57,7 @@ public class MainWindow : ReactiveWindow<MainViewModel>
 
 The XAML of our `ReactiveWindow` will look like as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="ReactiveUI.Samples.Suspension.MainWindow"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/routing.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/routing.md
@@ -41,7 +41,7 @@ namespace RoutingExample
 
 **FirstView.xaml**
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="RoutingExample.FirstView">
@@ -113,7 +113,7 @@ namespace RoutingExample
 
 Now we need to place the `RoutedViewHost` XAML control to our main view. It will resolve and embed appropriate views for the view models based on the supplied `IViewLocator` implementation and the passed `Router` instance of type `RoutingState`. Note, that you need to import `rxui` namespace for `RoutedViewHost` to work. Additionally, you can override animations that are played when `RoutedViewHost` changes a view — simply override `RoutedViewHost.PageTransition` property in XAML. For latest builds from MyGet use `xmlns:rxui="http://reactiveui.net"`, for 0.8.0 release on NuGet use `xmlns:rxui="clr-namespace:Avalonia;assembly=Avalonia.ReactiveUI"` as in the example below.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:rxui="clr-namespace:Avalonia.ReactiveUI;assembly=Avalonia.ReactiveUI"
         xmlns:app="clr-namespace:RoutingExample"
@@ -158,7 +158,7 @@ Now we need to place the `RoutedViewHost` XAML control to our main view. It will
 
 To disable the animations, simply set the `RoutedViewHost.PageTransition` property to `{x:Null}`, like so:
 
-```markup
+```xml
 <rxui:RoutedViewHost Grid.Row="0" Router="{Binding Router}" PageTransition="{x:Null}">
     <rxui:RoutedViewHost.DefaultContent>
         <TextBlock Text="Default content"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/view-activation.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/reactiveui/view-activation.md
@@ -34,7 +34,7 @@ public class ViewModel : ReactiveObject, IActivatableViewModel
 
 This is the UI for the view model you see above.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         Background="#f0f0f0" FontFamily="Ubuntu"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/running-on-raspbian-lite-via-drm.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/guides/deep-dives/running-on-raspbian-lite-via-drm.md
@@ -91,7 +91,7 @@ When we work via FrameBuffer there are no windows, so we need a separate view (U
 counterpart to the normal window.
 
 `MainView` will be our app base in which we develop our UI:
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -113,7 +113,7 @@ counterpart to the normal window.
 ```
 
 Now create a new UserControl with name `MainSingleView` and host the `MainView`:
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -128,7 +128,7 @@ Now create a new UserControl with name `MainSingleView` and host the `MainView`:
 ```
 
 Also change the `MainWindow.axaml` to host the `MainView` inside:
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/input/hotkeys.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/input/hotkeys.md
@@ -5,7 +5,7 @@ title: Hotkeys
 
 Various Controls that implement `ICommandSource` have a `HotKey` property that you can set or bind to. Pressing the hotkey will execute the command [bound](../data-binding/binding-to-commands) to the Control.
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem x:Name="SaveMenuItem" Header="_Save" Command="{Binding SaveCommand}" HotKey="Ctrl+S"/>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/input/routed-events.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/input/routed-events.md
@@ -68,7 +68,7 @@ public class SampleControl: Control
 
 To add a handler for an event using XAML, you declare the event name as an attribute on the element that is an event listener. The value of the attribute is the name of your implemented handler method, which must exist in the class of the code-behind file.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -105,7 +105,7 @@ Each of the above considerations is discussed in a separate section of this topi
 
 To add an event handler in XAML, you simply add the event name to an element as an attribute and set the attribute value as the name of the event handler that implements an appropriate delegate, as in the following example.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -202,7 +202,7 @@ The Avalonia input system uses attached events extensively. However, nearly all 
 
 Another syntax usage that resembles _typename_._eventname_ attached event syntax but is not strictly speaking an attached event usage is when you attach handlers for routed events that are raised by child elements. You attach the handlers to a common parent, to take advantage of event routing, even though the common parent might not have the relevant routed event as a member. Consider this example again:
 
-```markup
+```xml
 <Border Height="50" Width="300">
   <StackPanel Orientation="Horizontal" Button.Click="CommonClickHandler">
     <Button Name="YesButton">Yes</Button>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/layout/alignment-margins-and-padding.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/layout/alignment-margins-and-padding.md
@@ -23,7 +23,7 @@ At first glance, the `Button` elements in this illustration may appear to be pla
 
 The following example describes how to create the layout in the preceding illustration. A `Border` element encapsulates a parent `StackPanel`, with a `Padding` value of 15 device independent pixels. This accounts for the narrow `LightBlue` band that surrounds the child `StackPanel`. Child elements of the `StackPanel` are used to illustrate each of the various positioning properties that are detailed in this topic. Three `Button` elements are used to demonstrate both the `Margin` and `HorizontalAlignment` properties.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication2.MainWindow"
@@ -72,7 +72,7 @@ The `HorizontalAlignment` property declares the horizontal alignment characteris
 
 The following example shows how to apply the `HorizontalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors.
 
-```markup
+```xml
 <Button HorizontalAlignment="Left">Button 1 (Left)</Button>
 <Button HorizontalAlignment="Right">Button 2 (Right)</Button>
 <Button HorizontalAlignment="Center">Button 3 (Center)</Button>
@@ -96,7 +96,7 @@ The `VerticalAlignment` property describes the vertical alignment characteristic
 
 The following example shows how to apply the `VerticalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors. For purposes of this sample, a `Grid` element with visible gridlines is used as the parent, to better illustrate the layout behavior of each property value.
 
-```markup
+```xml
 <Border Background="LightBlue" BorderBrush="Black" BorderThickness="2" Padding="15">
     <Grid Background="White" ShowGridLines="True">
       <Grid.RowDefinitions>
@@ -131,7 +131,7 @@ A non-zero margin applies space outside the element's `Bounds`.
 
 The following example shows how to apply uniform margins around a group of `Button` elements. The `Button` elements are spaced evenly with a ten-pixel margin buffer in each direction.
 
-```markup
+```xml
 <Button Margin="10">Button 7</Button>
 <Button Margin="10">Button 8</Button>
 <Button Margin="10">Button 9</Button>
@@ -139,7 +139,7 @@ The following example shows how to apply uniform margins around a group of `Butt
 
 In many instances, a uniform margin is not appropriate. In these cases, non-uniform spacing can be applied. The following example shows how to apply non-uniform margin spacing to child elements. Margins are described in this order: left, top, right, bottom.
 
-```markup
+```xml
 <Button Margin="0,10,0,10">Button 1</Button>
 <Button Margin="0,10,0,10">Button 2</Button>
 <Button Margin="0,10,0,10">Button 3</Button>
@@ -151,7 +151,7 @@ Padding is similar to `Margin` in most respects. The Padding property is exposed
 
 The following example shows how to apply `Padding` to a parent `Border` element.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"
@@ -165,7 +165,7 @@ The following example shows how to apply `Padding` to a parent `Border` element.
 
 The following example demonstrates each of the concepts that are detailed in this topic. Building on the infrastructure found in the first sample in this topic, this example adds a`Grid` element as a child of the `Border` in the first sample. `Padding` is applied to the parent `Border` element. The`Grid` is used to partition space between three child `StackPanel` elements. `Button` elements are again used to show the various effects of `Margin` and `HorizontalAlignment`. `TextBlock` elements are added to each `ColumnDefinition` to better define the various properties applied to the `Button` elements in each column.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/layout/panels-overview.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/layout/panels-overview.md
@@ -79,7 +79,7 @@ myParentCanvas.Children.Add(myCanvas3);
 
 XAML
 
-```markup
+```xml
 <Canvas Height="400" Width="400">
   <Canvas Height="100" Width="100" Top="0" Left="0" Background="Red"/>
   <Canvas Height="100" Width="100" Top="100" Left="100" Background="Green"/>
@@ -176,7 +176,7 @@ myDockPanel.Children.Add(myBorder5);
 
 XAML
 
-```markup
+```xml
 <DockPanel LastChildFill="True">
   <Border Height="25" Background="SkyBlue" BorderBrush="Black" BorderThickness="1" DockPanel.Dock="Top">
     <TextBlock Foreground="Black">Dock = "Top"</TextBlock>
@@ -378,7 +378,7 @@ myWrapPanel.Children.Add(btn4);
 
 XAML
 
-```markup
+```xml
 <Border HorizontalAlignment="Left" VerticalAlignment="Top" BorderBrush="Black" BorderThickness="2">
   <WrapPanel Background="LightBlue" Width="200" Height="100">
     <Button Width="200">Button 1</Button>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/index.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/index.md
@@ -4,7 +4,7 @@
 
 The following style selects any `TextBlock` in the `Window` with a `h1` _style class_ and sets its font size to 24 point and font weight to bold:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/resources.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/resources.md
@@ -9,7 +9,7 @@ Often, styles and controls will need to share resources such as \(but not limite
 
 If a resource is to be available to your entire application, you can define it in `App.xaml`/`App.axaml`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.App">
@@ -21,7 +21,7 @@ If a resource is to be available to your entire application, you can define it i
 
 Alternatively you can declare resources on a `Window` or `UserControl`: the resource will be available to the `Window`/`UserControl` and its children:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MyUserControl">
@@ -33,7 +33,7 @@ Alternatively you can declare resources on a `Window` or `UserControl`: the reso
 
 Or in fact any control at all:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MainWindow">
@@ -47,7 +47,7 @@ Or in fact any control at all:
 
 You can also declare resources on styles:
 
-```markup
+```xml
 <Style Selector="TextBlock.warn">
   <Style.Resources>
     <SolidColorBrush x:Key="Warning">Yellow</SolidColorBrush>
@@ -59,7 +59,7 @@ You can also declare resources on styles:
 
 You can references resources from controls using the `{DynamicResource}` markup extensions, e.g.:
 
-```markup
+```xml
 <Border Background="{DynamicResource Warning}">
   Look out!
 </Border>
@@ -76,7 +76,7 @@ In return, `StaticResource` doesn't need to add an event handler to listen for c
 
 Resources are resolved by walking up the logical tree from the point of the `DynamicResource` or `StaticResource` until a resource with the requested key is found. This means that resources can be "overridden" in sub-trees of the application, for example:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MyUserControl">
@@ -102,7 +102,7 @@ Here's the `Border`'s background will be `Orange` because its parent `StackPanel
 
 The `Resources` property on each control and style is of type `ResourceDictionary`. Resource dictionaries can also include other resource dictionaries by making use of the `MergedDictionaries` property. To include a resource dictionary in another you can use the `ResourceInclude` class, e.g.:
 
-```markup
+```xml
 <Window.Resources>
   <ResourceDictionary>
     <ResourceDictionary.MergedDictionaries>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/selectors.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/selectors.md
@@ -227,7 +227,7 @@ Matches any control which has the specified property set to the specified value.
 :::info
 **Note:** When using a `AttachedProperty` in selectors inside XAML, it has to be wrapped in parenthesis.
 
-```markup
+```xml
 <Style Selector="TextBlock[(Grid.Row)=0]">
 ```
 :::

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/styles.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/styles.md
@@ -9,7 +9,7 @@ A style applies to the control that it is defined on and all descendent controls
 
 The following style selects any `TextBlock` with a `h1` _style class_ and sets its font size to 24 point and font weight to bold:
 
-```markup
+```xml
 <Style Selector="TextBlock.h1">
     <Setter Property="FontSize" Value="24"/>
     <Setter Property="FontWeight" Value="Bold"/>
@@ -18,7 +18,7 @@ The following style selects any `TextBlock` with a `h1` _style class_ and sets i
 
 Styles can be defined on any control or on the `Application` object by adding them to the [`Control.Styles`](http://reference.avaloniaui.net/api/Avalonia/StyledElement/0A46A84A) or [`Application.Styles`](http://reference.avaloniaui.net/api/Avalonia/Application/04017CAF) collections.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>
@@ -34,7 +34,7 @@ Styles can be defined on any control or on the `Application` object by adding th
 
 Styles can also be included from other files using the `StyleInclude` class, e.g.:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>
@@ -49,7 +49,7 @@ Where `CustomStyles.xaml` is a XAML file with a root of either `Style` or `Style
 
 CustomStyles.xaml
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="TextBlock.h1">
@@ -64,12 +64,12 @@ Note that unlike WPF/UWP, styles will have no effect if they're added to a contr
 
 As in CSS, controls can be given _style classes_ which can be used in selectors. Style classes can be assigned in XAML by setting the `Classes` property to a space-separated list of strings. The following example applies the `h1` and `blue` style classes to a `Button`:
 
-```markup
+```xml
 <Button Classes="h1 blue"/>
 ```
 
 If you need to add or remove class by condition, you can use the following special syntax:
-```markup
+```xml
 <Button Classes.blue="{Binding IsSpecial}" />
 ```
 
@@ -88,7 +88,7 @@ One example of a pseudoclass is the `:pointerover` \(similar to `:hover` in CSS\
 
 Pseudoclasses provide the functionality of `Triggers` in WPF and `VisualStateManager` in UWP:
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Border:pointerover">
@@ -103,7 +103,7 @@ Pseudoclasses provide the functionality of `Triggers` in WPF and `VisualStateMan
 
 Another example that involves changing properties inside of control [template](selectors.md#template):
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Button:pressed /template/ ContentPresenter">
@@ -147,14 +147,14 @@ For more information see the [selectors documentation](selectors.md).
 
 A style's setters describe what will happen when the selector matches a control. They are simple property/value pairs written in the format:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="24"/>
 <Setter Property="Padding" Value="4 2 0 4"/>
 ```
 
 You can also use long-form syntax to declare more complex object values:
 
-```markup
+```xml
 <Setter Property="MyProperty">
    <MyObject Property1="My Value"/>
 </Setter>
@@ -162,7 +162,7 @@ You can also use long-form syntax to declare more complex object values:
 
 Bindings can also be applied using setters and can bind to the target control's `DataContext`:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="{Binding SelectedFontSize}"/>
 ```
 
@@ -170,7 +170,7 @@ Whenever a style is matched with a control, all of the setters will be applied t
 
 Note that the `Setter` creates a single instance of `Value` which will be applied to all controls that the style matches: if the object is mutable then changes will be reflected on all controls. Following on from this, any bindings on an _object within the setter `Value`_ will not have access to the target control's `DataContext` as there may be multiple target controls:
 
-```markup
+```xml
 <Style Selector="local|MyControl">
   <Setter Property="MyProperty">
      <MyObject Property1="{Binding MyViewModelProperty}"/>
@@ -182,7 +182,7 @@ In the above example, the binding source will be `MyObject.DataContext`, not `My
 
 Note: at present, if you are using compiled bindings, you need to explicitly set the data type of the binding source in the `<Style>` element:
 
-```markup
+```xml
 <Style Selector="MyControl" x:DataType="MyViewModelClass">
   <Setter Property="ControlProperty" Value="{Binding MyViewModelProperty}" />
 </Style>
@@ -192,7 +192,7 @@ Note: at present, if you are using compiled bindings, you need to explicitly set
 
 As mentioned above, usually a single instance of a setter's `Value` is created and shared across all matching controls. Due to this, to use a control as a setter value, the control must be wrapped in a `<Template>`:
 
-```markup
+```xml
 <Style Selector="Border.empty">
   <Setter Property="Child">
     <Template>
@@ -206,7 +206,7 @@ As mentioned above, usually a single instance of a setter's `Value` is created a
 
 If multiple styles match a control, and they both attempt to set the same property then the style _closest to the control_ will win. Consider the following example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/troubleshooting.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/styling/troubleshooting.md
@@ -14,7 +14,7 @@ Avalonia selectors, like CSS selectors, do not raise any errors or warnings, whe
 
 Styles are applied in order of declaration. If there are **multiple** style files that target the same control property, one style can override the other:
 
-```markup title="Styles1.axaml"
+```xml title="Styles1.axaml"
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Blue" />
     <Style Property="FontSize" Value="16" />
@@ -22,13 +22,13 @@ Styles are applied in order of declaration. If there are **multiple** style file
 ```
 
 
-```markup title="Styles2.axaml"
+```xml title="Styles2.axaml"
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Green" />
 </Style>
 ```
 
-```markup title="App.axaml"
+```xml title="App.axaml"
 <StyleInclude Source="Style1.axaml" />
 <StyleInclude Source="Style2.axaml" />
 ```
@@ -42,7 +42,7 @@ Similarly, to WPF, Avalonia properties can have multiple values, often of differ
 
 In this example you can see that local value (defined directly on the control) has higher priority than style value, so text block will have red foreground:
 
-```markup
+```xml
 <TextBlock Classes="header" Foreground="Red" />
 ...
 <Style Selector="TextBlock.header">
@@ -60,7 +60,7 @@ Some default Avalonia styles use local values in their templates instead of temp
 
 Let's imagine a situation in which you might expect a second style to override previous one, but it doesn't:
 
-```markup
+```xml
 <Style Selector="Border:pointerover">
     <Setter Property="Background" Value="Blue" />
 </Style>
@@ -81,7 +81,7 @@ Visit the Avalonia source code to find the [original templates](https://github.c
 
 The following code example of styles that can be expected to work on top of default styles:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="Red" />
 </Style>
@@ -94,7 +94,7 @@ You might expect the `Button` to be red by default and blue when pointer is over
 
 The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code (old [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) theme and new [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="{DynamicResource ButtonBackground}"/>
     <Setter Property="Template">
@@ -112,7 +112,7 @@ The reason is hidden in the Button's template. You can find the default template
 
 The actual background is rendered by a `ContentPresenter`, which in the default is bound to the Buttons `Background` property. However in the pointer-over state the selector is directly applying the background to the `ContentPresenter (Button:pointerover /template/ ContentPresenter#PART_ContentPresenter`) That's why when our setter was ignored in the previous code example. The corrected code should target content presenter directly as well:
 
-```markup
+```xml
 <!-- Here #PART_ContentPresenter name selector is not necessary, but was added to have more specific style -->
 <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Blue" />

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/templates/creating-data-templates-in-code.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/templates/creating-data-templates-in-code.md
@@ -17,7 +17,7 @@ var template = new FuncDataTemplate<Student>((value, namescope) =>
 
 Is equivalent to:
 
-```markup
+```xml
 <DataTemplate DataType="{x:Type local:Student}">
     <TextBlock Text="{Binding FirstName}"/>
 </DataTemplate>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/templates/data-templates.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/templates/data-templates.md
@@ -10,7 +10,7 @@ import ControlContentStudentScreenshot from '/img/templates/data-templates/stude
 
 Many controls have a `Content` property, such as [`ContentControl.Content`](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756). `Window` inherits from [`ContentControl`](../controls/contentcontrol), so lets use that as an example. You're probably familiar with what happens when you put a control in the `Window.Content` property - the window displays the control:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Button HorizontalAlignment="Center"
@@ -24,7 +24,7 @@ Many controls have a `Content` property, such as [`ContentControl.Content`](http
 
 Similarly if you put a string as the window content, the window will display the string:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   Hello World!
@@ -52,7 +52,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -66,7 +66,7 @@ Not very helpful. That's because Avalonia doesn't know _how_ to display an objec
 
 The easiest way to do this on `Window` (and any control that inherits from `ContentControl`) is to set the [`ContentTemplate`](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/7AA9343E) property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -97,7 +97,7 @@ The data template for the window content doesn't only come from the `ContentTemp
 
 Using the `DataTemplates` collection the previous example could be written as:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -139,7 +139,7 @@ namespace Example
 
 Now we can add a separate data template for the `Teacher` type and depending on the type of object in the `MainWindowViewModel.Content` property, the appropriate view will be displayed:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/templates/implement-idatatemplates.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/templates/implement-idatatemplates.md
@@ -37,7 +37,7 @@ public class MyDataTemplate : IDataTemplate
 
 You can now use the class `MyDataTemplate` in your view like this:
 
-```markup
+```xml
 <!-- remember to add the needed prefix in your view -->
 <!-- xmlns:dataTemplates="using:MyApp.DataTemplates" -->
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-and-layout-controls.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-and-layout-controls.md
@@ -13,7 +13,7 @@ Let's start by adding a `Button` to the `MainWindow`. The button will allow the 
 
 In `MainWindow.axaml` change the code as follows, adding a Button inside the Panel.
 
-```markup
+```xml
 <Panel>
     <ExperimentalAcrylicBorder IsHitTestVisible="False">
         <ExperimentalAcrylicBorder.Material>
@@ -72,7 +72,7 @@ Place the `<Button>` element inside a simple `<Panel>` element.
 
 The simplest way to control the layout of a control is with the `HorizontalAlignment`and `VerticalAlignment` properties.
 
-```markup
+```xml
 <Panel>
   <Button Content="Buy Music" Margin="40" Command="{Binding BuyMusicCommand}" HorizontalAlignment="Right" VerticalAlignment="Top" />
 </Panel>
@@ -88,7 +88,7 @@ Find the name, in this case `store_microsoft_regular`.
 
 There should be some code similar to:
 
-```markup
+```xml
 <StreamGeometry x:Key="store_microsoft_regular">M11.5 9.5V13H8V9.5H11.5Z M11.5 17.5V14H8V17.5H11.5Z M16 9.5V13H12.5V9.5H16Z M16 17.5V14H12.5V17.5H16Z M8 6V3.75C8 2.7835 8.7835 2 9.75 2H14.25C15.2165 2 16 2.7835 16 3.75V6H21.25C21.6642 6 22 6.33579 22 6.75V18.25C22 19.7688 20.7688 21 19.25 21H4.75C3.23122 21 2 19.7688 2 18.25V6.75C2 6.33579 2.33579 6 2.75 6H8ZM9.5 3.75V6H14.5V3.75C14.5 3.61193 14.3881 3.5 14.25 3.5H9.75C9.61193 3.5 9.5 3.61193 9.5 3.75ZM3.5 18.25C3.5 18.9404 4.05964 19.5 4.75 19.5H19.25C19.9404 19.5 20.5 18.9404 20.5 18.25V7.5H3.5V18.25Z</StreamGeometry>
 ```
 
@@ -102,7 +102,7 @@ Enter the name `Icons` when prompted and press `Enter`.
 
 A new `xaml` file will be created that we can put styles or icons inside.
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -117,7 +117,7 @@ A new `xaml` file will be created that we can put styles or icons inside.
 
 Add your Icon code inside wrapped in a `Style` element as a resource like so.
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -137,7 +137,7 @@ Add your Icon code inside wrapped in a `Style` element as a resource like so.
 
 Open `App.axaml` and add a `StyleInclude` so that the `Icons.axaml`can be loaded.
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme Mode="Dark"/>
     <StyleInclude Source="avares://Avalonia.MusicStore/Icons.axaml" />
@@ -148,7 +148,7 @@ Now build the application so that the Icons are available in the previewer.
 
 Return to `MainWindow.axaml`, we can add the Icon to the Button like so...
 
-```markup
+```xml
 <Button Margin="40" HorizontalAlignment="Right" VerticalAlignment="Top" Command="{Binding BuyMusicCommand}">
     <PathIcon Data="{StaticResource store_microsoft_regular}" />
 </Button>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-content-to-dialog.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-content-to-dialog.md
@@ -34,7 +34,7 @@ Build the project so that the previewer will work.
 
 Declare a `<DockPanel>`.
 
-```markup
+```xml
 <DockPanel>
 
 </DockPanel>
@@ -42,7 +42,7 @@ Declare a `<DockPanel>`.
 
 Inside the `DockPanel` add a `<StackPanel>`. Set `DockPanel.Dock="Top"` on the `StackPanel` so that it will be positioned at the top.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
 
@@ -52,7 +52,7 @@ Inside the `DockPanel` add a `<StackPanel>`. Set `DockPanel.Dock="Top"` on the `
 
 Inside the `StackPanel` add a `TextBox` and a `ProgressBar`.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
         <TextBox Text="{Binding SearchText}" Watermark="Search for Albums...." />
@@ -124,7 +124,7 @@ Back inside our DockPanel, add a `Button` and set it to Dock at the bottom. Set 
 
 Then bind its `Command` to `BuyMusicCommand` which we will create in the next chapter.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
         <TextBox Text="{Binding SearchText}" Watermark="Search for Albums...." />
@@ -138,7 +138,7 @@ Add a `ListBox` to the `DockPanel`. Since this is the last item in the Panel it 
 
 Bind the `Items` and `SelectedItem` properties as shown, set the `Background` to `Transparent`. Add a `Margin` of `0 20`. This means left and right sides have 0 and top and bottom have 20. This creates some space between the other controls.
 
-```markup
+```xml
 <ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" Background="Transparent" Margin="0 20" />
 ```
 
@@ -209,7 +209,7 @@ namespace Avalonia.MusicStore
 
 And then add that to `App.axaml`:
 
- ```markup
+ ```xml
 <Application.DataTemplates>
     <local:ViewLocator />
 </Application.DataTemplates>
@@ -234,19 +234,19 @@ Before we can run this we need to add our `MusicStoreView` to our `MusicStoreWin
 
 At the top of `MusicStoreWindow.axaml` you will find some lines that begin `xmlns:x` etc.. add a line:
 
-```markup
+```xml
 xmlns:local="using:Avalonia.MusicStore.Views"
 ```
 
 Then inside the `<Panel>` add.
 
-```markup
+```xml
 <local:MusicStoreView />
 ```
 
 Your `MusicStoreWindow.axaml` should look like this.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -297,7 +297,7 @@ public class AlbumViewModel : ViewModelBase
 
 In your newly created `AlbumView` add the following code:
 
-```markup
+```xml
 <StackPanel Spacing="5" Width="200">
     <Border CornerRadius="10" ClipToBounds="True">
         <Panel Background="#7FFF22DD">
@@ -320,7 +320,7 @@ The border contains a `Panel` with a `Background` set, using a hexadecimal colou
 
 This `Panel` contains an `Image` and a `PathIcon` in front of it. Add the source for the Icon to `Icons.axaml`:
 
-```markup
+```xml
 <StreamGeometry x:Key="music_regular">M11.5,2.75 C11.5,2.22634895 12.0230228,1.86388952 12.5133347,2.04775015 L18.8913911,4.43943933 C20.1598961,4.91511241 21.0002742,6.1277638 21.0002742,7.48252202 L21.0002742,10.7513533 C21.0002742,11.2750044 20.4772513,11.6374638 19.9869395,11.4536032 L13,8.83332147 L13,17.5 C13,17.5545945 12.9941667,17.6078265 12.9830895,17.6591069 C12.9940859,17.7709636 13,17.884807 13,18 C13,20.2596863 10.7242052,22 8,22 C5.27579485,22 3,20.2596863 3,18 C3,15.7403137 5.27579485,14 8,14 C9.3521238,14 10.5937815,14.428727 11.5015337,15.1368931 L11.5,2.75 Z M8,15.5 C6.02978478,15.5 4.5,16.6698354 4.5,18 C4.5,19.3301646 6.02978478,20.5 8,20.5 C9.97021522,20.5 11.5,19.3301646 11.5,18 C11.5,16.6698354 9.97021522,15.5 8,15.5 Z M13,3.83223733 L13,7.23159672 L19.5002742,9.669116 L19.5002742,7.48252202 C19.5002742,6.75303682 19.0477629,6.10007069 18.3647217,5.84393903 L13,3.83223733 Z</StreamGeometry>
 ```
 
@@ -338,7 +338,7 @@ As can be seen the albums are displayed vertically. However it would be nice to 
 
 Luckily `ListBox` provides a solution to this with something called `ItemsPanelTemplate`. By default the `ListBox` has its `ItemPanel` property set to an `ItemsPanelTemplate` which contains a `StackPanel`, we can change this to a `WrapPanel` like so.
 
-```markup
+```xml
 <ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" Background="Transparent" Margin="0 20">
     <ListBox.ItemsPanel>
         <ItemsPanelTemplate>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-items-to-users-collection.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/add-items-to-users-collection.md
@@ -13,7 +13,7 @@ Modify the `MainWindow.axaml` so that it places the existing `Button` inside a p
 
 We can then use an `ItemsControl` instead of a `ListBox` as we did before. An `ItemsControl` is the exact same as a `ListBox` except it doesn't allow the user to select anything.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Avalonia.MusicStore.ViewModels"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/creating-a-modern-looking-window.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/creating-a-modern-looking-window.md
@@ -15,7 +15,7 @@ Let's try and make this look a little more modern by applying `Dark` mode and so
 
    Change the FluentTheme Mode from Default to Dark.
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Avolonia.MusicStore.App"
@@ -38,7 +38,7 @@ Let's try and make this look a little more modern by applying `Dark` mode and so
 
 1. After where it says `Title="Avalonia.MusicStore"` add the following code:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -57,7 +57,7 @@ This will make the Window Transparent and apply a Blur.
 
 To apply acrylic to the window, that we can tint and customize for a modern look, replace the `<TextBlock>` with the following code:
 
-```markup
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -102,7 +102,7 @@ Notice we have a nice acrylic window effect. Shame about the titlebar, though. L
 
    To enable this mode on the `Window` element set the `ExtendClientAreaToDecorationsHint` property to `True`.
 
-```markup
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/opening-a-dialog.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/music-store-app/opening-a-dialog.md
@@ -20,7 +20,7 @@ When prompted name this MusicStoreWindow and press the `Enter` key.
 
 This will add the following code:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -34,7 +34,7 @@ This will add the following code:
 
 Change this code as follows to enable the Acrylic and extended client area so the Window will look like our `MainWindow`.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/adding-new-items.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/adding-new-items.md
@@ -15,7 +15,7 @@ We start by creating the view \(see [here](../todo-list-app/creating-a-view#crea
 
 Views/AddItemView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -104,7 +104,7 @@ We now want to bind our `Window.Content` property to this new `Content` property
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -119,7 +119,7 @@ And finally we need to make the "Add an item" button call `MainWindowViewModel.A
 
 Views/TodoListView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -146,7 +146,7 @@ Views/TodoListView.axaml
 
 The binding we've added to `<Button>` is:
 
-```markup
+```xml
 Command="{Binding $parent[Window].DataContext.AddItem}"
 ```
 
@@ -254,7 +254,7 @@ We can now bind the OK and Cancel buttons in the view to the `Ok` and `Cancel` c
 
 Views/AddItemView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/creating-a-view.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/creating-a-view.md
@@ -37,7 +37,7 @@ dotnet new avalonia.usercontrol -o Views -n TodoListView  --namespace Todo.Views
 
 The template should create a XAML file with the following contents in the `Views` directory, alongside `MainWindow.axaml`
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -74,7 +74,7 @@ We're not going to touch the code-behind file for a little while, but notice tha
 
 Edit the contents of `Views/TodoListView.axaml` to contain the following:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -102,7 +102,7 @@ If you're using the Visual Studio extension you should see the contents of the c
 
 Lets take a look at the code we just entered line-by-line.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -131,7 +131,7 @@ This line tells the XAML engine where the class that accompanies the XAML can be
 
 Ok, that's the boilerplate out of the way! Now onto the meat of the code:
 
-```markup
+```xml
 <DockPanel>
 ```
 
@@ -139,13 +139,13 @@ First we add a `DockPanel` as the child of the `UserControl`. A `UserControl` ca
 
 `DockPanel` is a type of panel which lays out its controls at the top, bottom, left and right sides, with a single control filling the remaining space in the middle.
 
-```markup
+```xml
 <Button DockPanel.Dock="Bottom" HorizontalAlignment="Center">Add an item</Button>
 ```
 
 Now we declare the `Button` that appears at the bottom of the view. The `DockPanel.Dock` attribute tells the containing `DockPanel` that we want the button to appear at the bottom. `HorizontalAlignment` centers button in the middle of the parent. As the element content we set the button text: `"Add an item"`.
 
-```markup
+```xml
 <StackPanel>
 ```
 
@@ -153,7 +153,7 @@ Next we add another panel: a `StackPanel`. `StackPanel` lays out its child contr
 
 Because this is the last child in the `DockPanel` it will fill the remaining space in the center of the control.
 
-```markup
+```xml
 <CheckBox Margin="4">Walk the dog</CheckBox>
 <CheckBox Margin="4">Buy some milk</CheckBox>
 ```
@@ -166,7 +166,7 @@ To see the view we've just created, we need to add it to the application's main 
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Todo.Views"
@@ -186,7 +186,7 @@ xmlns:views="clr-namespace:Todo.Views"
 
 We want to display the `TodoListView` control we just created, which is in the `Todo.Views` C# namespace. Here we're mapping the `Todo.Views` namespace to the `views` XML namespace. Any control that is not a core Avalonia control will generally need this type of mapping in order for the XAML engine to find the control.
 
-```markup
+```xml
 <views:TodoListView/>
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/locating-views.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/locating-views.md
@@ -7,7 +7,7 @@ Hold on, rewind a second. An observant reader will have noticed something strang
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -66,7 +66,7 @@ namespace Todo
 
 An instance of `ViewLocator` is present in `Application.DataTemplates`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Todo"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/wiring-up-the-views.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/tutorials/todo-list-app/wiring-up-the-views.md
@@ -13,7 +13,7 @@ We're exposing the list in `MainWindowViewModel.List` so let's use that property
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -34,13 +34,13 @@ Content="{Binding List}"
 
 The `Window.Content` property can either be set by placing a control as a child of the `Window` \([as we were doing previously](creating-a-view#display-the-view-in-the-window)\), or by assigning a value to the `Content` property. Both of these syntaxes are equivalent, meaning that writing:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">Hello World!</Window>
 ```
 
 Is _exactly_ the same as writing:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui" Content="Hello World!"/>
 ```
 
@@ -50,7 +50,7 @@ Now we need to make `TodoListView` get the list of TODO items from the view mode
 
 Views/TodoListView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -77,7 +77,7 @@ Views/TodoListView.axaml
 
 The first thing to notice here is that we've changed the `<StackPanel>` control to an `ItemsControl`:
 
-```markup
+```xml
 <ItemsControl Items="{Binding Items}">
 ```
 
@@ -85,7 +85,7 @@ The `ItemsControl` is a very simple control which displays each item in the coll
 
 How each item is displayed is controlled by the `ItemTemplate`. The `ItemTemplate` takes a [`DataTemplate`](https://avaloniaui.net/docs/templates/datatemplate) whose content is repeated for each item. In this case we display each item as a `CheckBox`, with the check state bound to the `IsChecked` property of the `TodoItemViewModel` and the content bound to the `Description`. We also set a `Margin` as before to space the items out a little:
 
-```markup
+```xml
 <ItemsControl.ItemTemplate>
   <DataTemplate>
     <CheckBox Margin="4"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/datatemplates.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/datatemplates.md
@@ -5,7 +5,7 @@ title: DataTemplates
 
 As styles aren't stored in `Resources`, neither are `DataTemplates`. Instead, `DataTemplates` are placed in a `DataTemplates` collection on each control \(and on `Application`\):
 
-```markup
+```xml
 <UserControl xmlns:viewmodels="clr-namespace:MyApp.ViewModels;assembly=MyApp">
     <UserControl.DataTemplates>
         <DataTemplate DataType="viewmodels:FooViewModel">

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/grid.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/grid.md
@@ -5,7 +5,7 @@ title: Grid
 
 Column and row definitions can be specified in Avalonia using strings, avoiding the clunky syntax in WPF:
 
-```markup
+```xml
 <Grid ColumnDefinitions="Auto,*,32" RowDefinitions="*,Auto">
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/styling.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.x/wpf-developer-tips/styling.md
@@ -5,7 +5,7 @@ title: Styling
 
 The most obvious difference from other XAML frameworks is that Avalonia uses a [CSS-like styling system](../styling/styles). Styles aren't stored in a `Resources` collection as in WPF, they are stored in a separate `Styles` collection:
 
-```markup
+```xml
 <UserControl>
     <UserControl.Styles>
         <!-- Make TextBlocks with the h1 style class have a font size of 24 points -->

--- a/versioned_docs/version-0.10.x/animations/keyframe-animations.md
+++ b/versioned_docs/version-0.10.x/animations/keyframe-animations.md
@@ -9,7 +9,7 @@ Keyframe animations in Avalonia are heavily inspired by CSS Animations. They can
 
 Keyframe animations are applied using styles. They can be defined on any style by adding an `Animation` object to the `Style.Animation` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -51,7 +51,7 @@ All `Animation` objects should contain at least one `KeyFrame`, with a `Setter` 
 
 Multiple properties can be also animated in a single Animation by adding additional `Setter` objects on the desired `KeyFrame`:
 
-```markup
+```xml
 <Animation Duration="0:0:1"> 
     <KeyFrame Cue="0%">
         <Setter Property="Opacity" Value="0.0"/>
@@ -68,7 +68,7 @@ Multiple properties can be also animated in a single Animation by adding additio
 
 You can add a delay in a `Animation` by defining the desired delay time on its `Delay` property:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"> 
     ...
@@ -114,7 +114,7 @@ The following table describes the possible behaviors:
 
 Easing functions can be set by setting the name of the desired function to the `Animation`'s `Easing` property:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1"
            Easing="BounceEaseIn"> 
@@ -124,7 +124,7 @@ Easing functions can be set by setting the name of the desired function to the `
 
 You can also add your custom easing function class like this:
 
-```markup
+```xml
 <Animation Duration="0:0:1"
            Delay="0:0:1">
     <Animation.Easing>

--- a/versioned_docs/version-0.10.x/animations/transitions.md
+++ b/versioned_docs/version-0.10.x/animations/transitions.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 Transitions in Avalonia are also heavily inspired by CSS Animations. They listen to any changes in target property's value and subsequently animates the change according to its parameters. They can be defined on any `Control` via `Transitions` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">
@@ -38,7 +38,7 @@ The above example will listen to changes in the `Rectangle`'s `Opacity` property
 
 Transitions can also be defined in any style by using a `Setter` with `Transitions` as the target property and encapsulating them in a `Transitions` object, like so:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Window.Styles>
         <Style Selector="Rectangle.red">

--- a/versioned_docs/version-0.10.x/controls/border.md
+++ b/versioned_docs/version-0.10.x/controls/border.md
@@ -10,7 +10,7 @@ The `Border` control decorates a child with a border and background. It can also
 
 An example of a border with a red background, 2 pixel black border, 3 pixel corner radius and a 4 pixel padding around its content:
 
-```markup
+```xml
 <Border Background="Red"
         BorderBrush="Black"
         BorderThickness="2"
@@ -48,7 +48,7 @@ To specify multiple shadows, provide a comma-separated list of shadows.
 * `spread-radius`: Positive values will cause the shadow to expand and grow bigger, negative values will cause the shadow to shrink. If not specified, it will be 0 \(the shadow will be the same size as the element\).
 * `color`: The color of the shadow using a color name \(such as `red`\) or a `#` hexadecimal color value
 
-```markup
+```xml
 <Border Background="Red"
         BorderBrush="Black"
         BorderThickness="2"

--- a/versioned_docs/version-0.10.x/controls/buttons/button.md
+++ b/versioned_docs/version-0.10.x/controls/buttons/button.md
@@ -49,7 +49,7 @@ The Button control's full documentation can be found [here](http://reference.ava
 
 ### Basic button
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -69,7 +69,7 @@ produces following output with **Windows 10**
 
 ### Colored button
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -91,7 +91,7 @@ produces following output with **Windows 10**
 
 Toggles between a "Play" icon and a "Pause" icon on click.
 
-```markup
+```xml
 <UserControl.Resources>
     <Bitmap x:Key="Play">
         <x:Arguments>
@@ -106,7 +106,7 @@ Toggles between a "Play" icon and a "Pause" icon on click.
 </UserControl.Resources>
 ```
 
-```markup
+```xml
 <Button Name="PlayButton" HorizontalAlignment="Center" Width="36" Command="{Binding PlayCommand}">
     <Panel>
         <Image Source="{DynamicResource Play}" IsVisible="{Binding !IsPlaying}" Width="20"
@@ -121,7 +121,7 @@ Toggles between a "Play" icon and a "Pause" icon on click.
 
 It is possible to bind a view model command to a simple method or with a ReactiveCommand. There are lots of advantages to the ReactiveCommand binding for all but the simplest user interfaces such as being able to pass an `IObservable<bool>` object in to have it dynamically calculate state. Both methods are displayed below. First the "simple" method binding:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -157,7 +157,7 @@ public ReactiveCommand OnClickCommand { get; }
 
 ### Binding to Events
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/controls/buttons/radiobutton.md
+++ b/versioned_docs/version-0.10.x/controls/buttons/radiobutton.md
@@ -5,7 +5,7 @@ title: RadioButton
 
 The `RadioButton` control allows users to select one or more things from a collection of presented things.
 
-```markup
+```xml
 <!-- First Group -->
 <RadioButton IsChecked="{Binding Option1Enabled }"
              GroupName="First Group"

--- a/versioned_docs/version-0.10.x/controls/buttons/togglebutton.md
+++ b/versioned_docs/version-0.10.x/controls/buttons/togglebutton.md
@@ -15,7 +15,7 @@ The `ToggleButton` control is a subclass of the `Button` control that has a buil
 
 This button will show a muted speaker icon or an un-muted speaker icon based on whether the button is checked or unchecked, which the `ToggleButton` control toggles between when users click on the button.
 
-```markup
+```xml
 <Style Selector="ToggleButton DrawingPresenter.tbchecked">
     <Setter Property="IsVisible" Value="False"/>
 </Style>
@@ -32,7 +32,7 @@ This button will show a muted speaker icon or an un-muted speaker icon based on 
 
 The style code above reacts to `ToggleButton`'s `:checked` pseudoclass, so that if the `ToggleButton` is checked, any `DrawingPresenter` with the class `.tbchecked` will be visible, and any `DrawingPresenter` with the class `.tbunchecked` will not be visible.
 
-```markup
+```xml
 <ToggleButton Classes="vtrx" IsChecked="{Binding Path=vtrx.muted}" ToolTip.Tip="stop audio">
     <Panel>
         <DrawingPresenter Drawing="{DynamicResource Icon.Speaker}" Classes="tbunchecked"/>

--- a/versioned_docs/version-0.10.x/controls/calendar.md
+++ b/versioned_docs/version-0.10.x/controls/calendar.md
@@ -30,7 +30,7 @@ The `Calendar` control is a standard Calendar control for users to select date\(
 
 ### Basic Calendar
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -46,7 +46,7 @@ The `Calendar` control is a standard Calendar control for users to select date\(
 
 ### Range selection Calendar
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -64,7 +64,7 @@ After selecting the start date, a single range can be selected by holding the sh
 
 ### Calendar with custom start and end dates
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/controls/calendardatepicker.md
+++ b/versioned_docs/version-0.10.x/controls/calendardatepicker.md
@@ -11,7 +11,7 @@ The `CalendarDatePicker` control allows the user to pick a date value using a ca
 
 The placeholder (the text that appears when the input is empty) can be changed using the `Watermark` property.
 
-```markup
+```xml
 <CalendarDatePicker
 	Watermark="01/01/1970" />
 ```
@@ -20,7 +20,7 @@ The placeholder (the text that appears when the input is empty) can be changed u
 
 The format of the date displayed can be customised by setting the `SelectedDateFormat` to `Custom` and providing a custom format in `CustomDateFormatString` in the same way `DateTime.ToString(string format)` accepts.
 
-```markup
+```xml
 <CalendarDatePicker 
 	SelectedDateFormat="Custom"
 	CustomDateFormatString="yyyy-MM-dd" />

--- a/versioned_docs/version-0.10.x/controls/canvas.md
+++ b/versioned_docs/version-0.10.x/controls/canvas.md
@@ -15,7 +15,7 @@ The Canvas does not do any sizing of its children. Each element must specify its
 
 Here's an example of a Canvas in XAML.
 
-```markup
+```xml
 <Canvas Width="120" Height="120">
     <Rectangle Fill="Red" Height="44" Width="44"/>
     <Rectangle Fill="Blue" Height="44" Width="44" Canvas.Left="20" Canvas.Top="20"/>

--- a/versioned_docs/version-0.10.x/controls/checkbox.md
+++ b/versioned_docs/version-0.10.x/controls/checkbox.md
@@ -27,7 +27,7 @@ The `CheckBox` control is a [`ContentControl`](../controls/contentcontrol) which
 
 ### Basic checkbox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -48,7 +48,7 @@ produces following output with **Windows 10**
 
 ### Three state checkbox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/controls/combobox.md
+++ b/versioned_docs/version-0.10.x/controls/combobox.md
@@ -27,7 +27,7 @@ title: ComboBox
 
 ### Basic ComboBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -48,7 +48,7 @@ title: ComboBox
 
 ### ComboBox with custom item templates
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -79,7 +79,7 @@ title: ComboBox
 
 This example binds the fonts installed to a ComboBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/controls/contentcontrol.md
+++ b/versioned_docs/version-0.10.x/controls/contentcontrol.md
@@ -25,19 +25,19 @@ At its simplest, a `ContentControl` displays the data assigned to its [`Content`
 
 For example:
 
-```markup
+```xml
 <ContentControl Content="Hello World!"/>
 ```
 
 Will display the string "Hello World!". The `Content` property is the control's default property and so the above example can also be written as:
 
-```markup
+```xml
 <ContentControl>Hello World!</ContentControl>
 ```
 
 If you assign a control to a `ContentControl` then it will display the control, for example:
 
-```markup
+```xml
 <ContentControl>
   <Button>Click Me!</Button>
 </ContentControl>
@@ -79,7 +79,7 @@ namespace Example
 
 We can display the student's first and last name in a `ContentControl` using the `ContentTemplate` property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
   <ContentControl Content="{Binding Content}">
     <ContentControl.ContentTemplate>

--- a/versioned_docs/version-0.10.x/controls/datagrid/datagridcolumns.md
+++ b/versioned_docs/version-0.10.x/controls/datagrid/datagridcolumns.md
@@ -27,7 +27,7 @@ This column is used to display text data, normally represented by a `string`. In
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid" Items="{Binding People}" AutoGenerateColumns="False" >
     <DataGrid.Columns>
         <DataGridTextColumn Header="Forename" Binding="{Binding FirstName}"/>
@@ -50,7 +50,7 @@ This column is used to represent a `bool` value. The  value is represented by a 
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid" Items="{Binding ToDoListItems}" AutoGenerateColumns="False" >
     <DataGrid.Columns>
         <DataGridCheckBoxColumn Header="✔" Binding="{Binding IsChecked}"/>
@@ -77,7 +77,7 @@ The DataGridTemplateColumn is editable from Avalonia version 0.10.12 onward. If 
 
 ### Example
 
-```markup
+```xml
 <DataGrid Name="MyDataGrid"
           xmlns:model="using:MyApp.Models"  >
   <DataGrid.Columns>

--- a/versioned_docs/version-0.10.x/controls/datagrid/index.md
+++ b/versioned_docs/version-0.10.x/controls/datagrid/index.md
@@ -28,7 +28,7 @@ Note, that version should match Avalonia version you are using.
 
 The Themes can be changed to light or dark to fit your application theme.
 
-```markup
+```xml
 <Application.Styles>
     <StyleInclude Source="avares://Avalonia.Themes.Default/DefaultTheme.xaml"/>
     <StyleInclude Source="avares://Avalonia.Themes.Default/Accents/BaseLight.xaml"/>
@@ -38,7 +38,7 @@ The Themes can be changed to light or dark to fit your application theme.
 
 Or if you are using new Fluent theme, you will need to include styles created specifically for that:
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme Mode="Light" />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
@@ -51,7 +51,7 @@ Or if you are using new Fluent theme, you will need to include styles created sp
 
 This will generate a DataGrid with column header names. FirstName and LastName.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -78,7 +78,7 @@ public class Person
 
 The DataGrid uses the same class Person as before, but now with custom column header name. Forename and Surname.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/controls/dockpanel.md
+++ b/versioned_docs/version-0.10.x/controls/dockpanel.md
@@ -9,7 +9,7 @@ import DockPanelFillNoOverlapScreenshot from '/img/controls/dockpanel/dockpanel.
 
 The `DockPanel` control is a `Panel` which lays out its children by "docking" them to the sides or floating in the center.
 
-```markup
+```xml
 <DockPanel Width="300" Height="300">
     <Rectangle Fill="Red" Height="100" DockPanel.Dock="Top"/>
     <Rectangle Fill="Blue" Width="100" DockPanel.Dock="Left"/>

--- a/versioned_docs/version-0.10.x/controls/flyouts.md
+++ b/versioned_docs/version-0.10.x/controls/flyouts.md
@@ -69,7 +69,7 @@ There are two built-in types of Flyouts: `Flyout` and `MenuFlyout`. A regular `F
 
 In order to be shown Flyouts have to be attached to a specific control, though this is not a static assignment and can be changed at runtime. `Button` has a `Flyout` property that can be used to open a Flyout upon click.
 
-```markup
+```xml
 <Button Content="Click me">
     <Button.Flyout>
         <Flyout>
@@ -83,7 +83,7 @@ In order to be shown Flyouts have to be attached to a specific control, though t
 
 For other controls that don't have built-in support for flyouts, one can be assigned using attached flyouts
 
-```markup
+```xml
 <Border Background="Red" PointerPressed="Border_PointerPressed">
     <FlyoutBase.AttachedFlyout>
         <Flyout>
@@ -112,7 +112,7 @@ ContextFlyouts are invoked automatically like normal `ContextMenu`s. Although cu
 
 As previously mentioned, Flyouts can be shared between various elements within your app.
 
-```markup
+```xml
 <Window.Resources>
     <Flyout x:Key="MySharedFlyout">
         <!-- Flyout content here -->
@@ -128,7 +128,7 @@ As previously mentioned, Flyouts can be shared between various elements within y
 
 Although `Flyout`s are not controls themselves, their general appearance can still be customized by targeting the presenter the `Flyout` uses to display its content. For a normal `Flyout` this is `FlyoutPresenter` and for `MenuFlyout` this is `MenuFlyoutPresenter`. Because flyout presenters are not exposed, special style classes that should pertain to specific flyouts can be passed using the `FlyoutPresenterClasses` property on `FlyoutBase`
 
-```markup
+```xml
 <Style Selector="FlyoutPresenter.mySpecialClass">
     <Setter Property="Background" Value="Red" />
 </Style>

--- a/versioned_docs/version-0.10.x/controls/grid.md
+++ b/versioned_docs/version-0.10.x/controls/grid.md
@@ -31,7 +31,7 @@ Below is an example that shows:
 
 An example of a Grid with 3 equal Rows and 3 Columns with \(1 fixed width\), \(2 grabbing the rest proportionally\) would be:
 
-```markup
+```xml
 <Grid ColumnDefinitions="100,1.5*,4*" RowDefinitions="Auto,Auto,Auto"  Margin="4">
   <TextBlock Text="Col0Row0:" Grid.Row="0" Grid.Column="0"/>
   <TextBlock Text="Col0Row1:" Grid.Row="1" Grid.Column="0"/>
@@ -54,7 +54,7 @@ Here is another example showing the difference between those two.
 
 First let's create sample 2x2 grid in our View, we can achieve this simply by writing code looking like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
@@ -77,7 +77,7 @@ Now let's fill our grid with some elements, I will fill every field with button,
 
 Now our View code look's like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
@@ -103,7 +103,7 @@ As you can see our grid become sticky to its content, it is very useful when we 
 
 This new View code looks like this:
 
-```markup
+```xml
     <Grid ShowGridLines="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -125,7 +125,7 @@ This new View code looks like this:
 
 For more complex row and column definitions it's possible to explicitly use `Grid.ColumnDefinitions` and `Grid.RowDefinitions` XAML fields to provide access to these additional settings. The below code produces is exactly the same except for the fact we set the minimum width on the second column to be 300.
 
-```markup
+```xml
 <Grid Margin="4">
   <Grid.ColumnDefinitions>
     <ColumnDefinition Width="100" />

--- a/versioned_docs/version-0.10.x/controls/gridsplitter.md
+++ b/versioned_docs/version-0.10.x/controls/gridsplitter.md
@@ -8,7 +8,7 @@ import GridSplitterRowsScreenshot from '/img/controls/gridsplitter/gridsplitter-
 
 The `GridSplitter` control is a control that allows a user to resize the space between `Grid` rows or columns.
 
-```markup
+```xml
 <Grid ColumnDefinitions="*, 4, *">
     <Rectangle Grid.Column="0" Fill="Blue"/>
     <GridSplitter Grid.Column="1" Background="Black" ResizeDirection="Columns"/>
@@ -18,7 +18,7 @@ The `GridSplitter` control is a control that allows a user to resize the space b
 
 <img className="center" src={GridSplitterColumnsScreenshot} alt="GridSplitter in Action for Columns" />
 
-```markup
+```xml
 <Grid RowDefinitions="*, 4, *">
     <Rectangle Grid.Row="0" Fill="Blue"/>
     <GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>

--- a/versioned_docs/version-0.10.x/controls/image.md
+++ b/versioned_docs/version-0.10.x/controls/image.md
@@ -21,13 +21,13 @@ The declarative approaches keep images in memory and won't have to load them in 
 
 **Binding Converter Approach**
 
-```markup
+```xml
 <UserControl.Resources>
     <ext:BitmapAssetValueConverter x:Key="variableImage"/>
 </UserControl.Resources>
 ```
 
-```markup
+```xml
 <Image Width="75"
        Height="73"
        Source="{Binding PlaySource, Converter={StaticResource variableImage}}">

--- a/versioned_docs/version-0.10.x/controls/listbox.md
+++ b/versioned_docs/version-0.10.x/controls/listbox.md
@@ -7,7 +7,7 @@ The `ListBox` is an `ItemsControl` which displays items in a multi-line list box
 
 The items to display in the `ListBox` are specified using the `Items` property. This property will often be bound to a collection on the control's `DataContext`:
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}"/>
 ```
 
@@ -15,7 +15,7 @@ The items to display in the `ListBox` are specified using the `Items` property. 
 
 You can customize how an item is displayed by specifying an `ItemTemplate`. For example to display each item inside a red border with rounded corners:
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}">
     <ListBox.ItemTemplate>
         <DataTemplate>
@@ -33,7 +33,7 @@ Each item displayed in a `ListBox` will be wrapped in a `ListBoxItem` - this is 
 
 Sometimes you will want to customize the container itself. You can do this by including a style targeting `ListBoxItem` in the `ListBox`:
 
-```markup
+```xml
 <ListBox Items="{Binding Items}">
     <ListBox.Styles>
         <!-- Give the ListBoxItems a fixed with of 100 and right-align them -->
@@ -66,7 +66,7 @@ Controls the type of selection that can be made on the `ListBox`:
 
 These values can be combined, e.g.:
 
-```markup
+```xml
 <ListBox SelectionMode="Multiple,Toggle"/>
 ```
 
@@ -74,7 +74,7 @@ These values can be combined, e.g.:
 
 Exposes the index of the selected item, or in the case of multiple selection the first selected item. You will often want to bind this to a view model if your list `SelectionMode` is set to `Single`.
 
-```markup
+```xml
 <ListBox SelectedIndex="{Binding SelectedIndex}"/>
 ```
 
@@ -97,7 +97,7 @@ By default bindings to this property are two-way.
 
 Exposes the selected item in the `Items` collection, or in the case of multiple selection the first selected item. You will often want to bind this to a view model if your list `SelectionMode` is set to `Single`.
 
-```markup
+```xml
 <ListBox SelectedItem="{Binding SelectedItem}"/>
 ```
 
@@ -128,7 +128,7 @@ Once `Selection` is bound to a `SelectionModel`, `SelectedItems` will no longer 
 
 `SelectionModel` also exposes batching functionality through its `Update()` method and a `SelectionChanged` event which details exactly which items have been selected and deselected.
 
-```markup
+```xml
 <ListBox Items="{Binding Items}" Selection="{Binding Selection}"/>
 ```
 
@@ -172,7 +172,7 @@ This property holds the selected items in an `IList`. It can be bound to any lis
 
 For various reasons the performance of `SelectedItems` can be very poor, particularly on large collections. It is recommended that you use the `Selection` property instead.
 
-```markup
+```xml
 <ListBox SelectedItems="{Binding SelectedItems}"/>
 ```
 
@@ -187,7 +187,7 @@ public MyViewModel : ReactiveObject
 
 By default if an item is too wide to display in the `ListBox`, a horizontal scrollbar will be displayed. If instead you want items to be constrained to the width of the `ListBox` \(for example if you want wrapping text in the items\) you can disable the horizontal scrollbar by setting `ScrollViewer.HorizontalScrollBarVisibility="Disabled"`.
 
-```markup
+```xml
 <ListBox Items="{Binding MyItems}" Width="250" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
     <ListBox.ItemTemplate>
         <DataTemplate>

--- a/versioned_docs/version-0.10.x/controls/maskedtextbox.md
+++ b/versioned_docs/version-0.10.x/controls/maskedtextbox.md
@@ -14,7 +14,7 @@ The `MaskedTextBox` control is an editable text field where a user can input tex
 
 ### Basic example line TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/controls/menu.md
+++ b/versioned_docs/version-0.10.x/controls/menu.md
@@ -5,7 +5,7 @@ title: Menu
 
 The `Menu` control adds a top-level menu to an application. A `Menu` is usually placed in a `DockPanel` in a `Window`, docked to the top of the window:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <DockPanel>
@@ -40,7 +40,7 @@ If you will press Alt with the example above you will see that some letters are 
 
 Like `Button`, commands can be [bound](../data-binding/binding-to-commands) to `MenuItem`s. The command will be executed when the menu item is clicked or selected with the keyboard:
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem Header="_Open..." Command="{Binding OpenCommand}"/>
@@ -54,7 +54,7 @@ Like `Button`, commands can be [bound](../data-binding/binding-to-commands) to `
 
 A menu icon can be displayed by placing an `Image` in the `Icon` property:
 
-```markup
+```xml
     <MenuItem Header="_Open...">
         <MenuItem.Icon>
             <Image Source="resm:MyApp.Assets.Open.png"/>
@@ -66,7 +66,7 @@ A menu icon can be displayed by placing an `Image` in the `Icon` property:
 
 Similarly, a `CheckBox` can be displayed in the `Icon` property to make the `MenuItem` checkable:
 
-```markup
+```xml
     <MenuItem Header="_Open...">
         <MenuItem.Icon>
             <CheckBox BorderThickness="0"
@@ -192,7 +192,7 @@ public MainWindow()
 
 Finally assign the bindings to the view model in a `Style` within the menu:
 
-```markup
+```xml
 <Menu Items="{Binding MenuItems}">
     <Menu.Styles>
         <Style Selector="MenuItem">

--- a/versioned_docs/version-0.10.x/controls/numericupdown.md
+++ b/versioned_docs/version-0.10.x/controls/numericupdown.md
@@ -23,7 +23,7 @@ The control has a up and down button spinner attached, used to increment and dec
 
 The value stored in the `NumericUpDown` is a double.
 
-```markup
+```xml
 <NumericUpDown Value="10" Width="100"/>
 ```
 
@@ -35,13 +35,13 @@ produces the following output on **Linux**
 
 A custom increment/decrement value can be set for the button spinner. The default increment value is set to 1.
 
-```markup
+```xml
 <NumericUpDown Value="0.5" Increment="0.01" Minimum="0" Maximum="1"/>
 ```
 
 ### NumericUpDown without a button spinner
 
-```markup
+```xml
 <NumericUpDown Value="42" AllowSpin="False" ShowButtonSpinner="False"/>
 ```
 

--- a/versioned_docs/version-0.10.x/controls/panel.md
+++ b/versioned_docs/version-0.10.x/controls/panel.md
@@ -9,7 +9,7 @@ The `Panel` is the base class for controls that can contain multiple children li
 
 The `Panel` class can be useful on its own for very basic layouts, or simply to allow multiple controls to be to be contained.
 
-```markup
+```xml
 <Panel Height="300" Width="300">
     <Rectangle Fill="Red" Height="100" VerticalAlignment="Top"/>
     <Rectangle Fill="Blue" Width="100" HorizontalAlignment="Right" />

--- a/versioned_docs/version-0.10.x/controls/relativepanel.md
+++ b/versioned_docs/version-0.10.x/controls/relativepanel.md
@@ -22,7 +22,7 @@ Attached properties are used to control the layout of elements. This table shows
 
 This XAML shows how to arrange elements in a RelativePanel.
 
-```markup
+```xml
 <RelativePanel BorderBrush="Gray" BorderThickness="1">
     <Rectangle x:Name="RedRect" Fill="Red" Height="44" Width="44"/>
     <Rectangle x:Name="BlueRect" Fill="Blue"

--- a/versioned_docs/version-0.10.x/controls/splitview.md
+++ b/versioned_docs/version-0.10.x/controls/splitview.md
@@ -7,7 +7,7 @@ import SplitViewScreenshot from '/img/controls/splitview/image (9).png';
 
 Represents a container with two views; one view for the main content and another view that is typically used for navigation commands.
 
-```markup
+```xml
 <SplitView IsPaneOpen="True"
            DisplayMode="Inline"
            OpenPaneLength="296">

--- a/versioned_docs/version-0.10.x/controls/stackpanel.md
+++ b/versioned_docs/version-0.10.x/controls/stackpanel.md
@@ -12,7 +12,7 @@ You can use the [**Orientation**](https://docs.microsoft.com/en-us/uwp/api/windo
 
 The following XAML shows how to create a vertical StackPanel of items.
 
-```markup
+```xml
 <StackPanel>
     <Rectangle Fill="Red" Height="44"/>
     <Rectangle Fill="Blue" Height="44"/>
@@ -29,7 +29,7 @@ In a StackPanel, if a child element's size is not set explicitly, it stretches t
 
 StackPanel has a `Spacing` property to allow an even spacing between items.
 
-```markup
+```xml
 <StackPanel Spacing="5">
     <Rectangle Fill="Red" Height="44"/>
     <Rectangle Fill="Blue" Height="44"/>

--- a/versioned_docs/version-0.10.x/controls/tabcontrol.md
+++ b/versioned_docs/version-0.10.x/controls/tabcontrol.md
@@ -14,7 +14,7 @@ Here is an animation of what you can achieve :
 
 To create this, we'll describe the entire control \(TabControl\) and each individual tab+page \(TabItem\). Here is an example :
 
-```markup
+```xml
 <TabControl>
   <TabItem Header="Circle" VerticalContentAlignment="Center">
     <TextBlock Text="I am in the circle page !" HorizontalAlignment="Left" VerticalAlignment="Center"/>
@@ -48,7 +48,7 @@ Let's have a look at a customized `TabControl` :
 
 The grey part is the `TabItem`... Yes, the `TabItem` includes the tab **AND** the page associated to the tab. The tab is called the `header`of the `TabItem`. Moreover, given the way `TabControl` has been implemented, tabs are in a `WrapPanel`. Thus, if you want to color in blue \(like this is done above\) the empty bar of the tabbed bar, you must change the background color of the `WrapPanel` of the `TabControl`. Here is the code used to obtain the result above \(_Note the workaround used to color some tabs : this is due to the way the control is implemented. It might change in the future._\)
 
-```markup
+```xml
 <Window.Styles>
 
   <Style Selector="TabControl">
@@ -123,7 +123,7 @@ DataContext = new TabItemModel[] {
 
 Finally create a `TabControl` and bind its Items property to the DataContext.
 
-```markup
+```xml
 <TabControl Items="{Binding}">
     <TabControl.ItemTemplate>
       <DataTemplate>

--- a/versioned_docs/version-0.10.x/controls/textbox.md
+++ b/versioned_docs/version-0.10.x/controls/textbox.md
@@ -22,7 +22,7 @@ The `TextBox` control is an editable text field where a user can input text.
 
 ### Basic one line TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -42,7 +42,7 @@ produces the following output in **Windows 10**
 
 ### Password input TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -62,7 +62,7 @@ produces the following output in **Windows 10** when text is input
 
 When using the Fluent theme, you can apply the style class, `revealPasswordButton`, and the TextBox will provide an eye 👁 glyph for the user to show the plane text temporally. Please note, the `TextBox` may be written to but not copied from.
 
-```markup
+```xml
 <TextBox Classes="revealPasswordButton" PasswordChar="•" />
 ```
 
@@ -70,7 +70,7 @@ When using the Fluent theme, you can apply the style class, `revealPasswordButto
 
 Avalonia can show a "watermark" in a `TextBox`, which is a piece of text that is displayed when the `TextBox` is empty \(in HTML5 this is called a _placeholder_\)
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -90,7 +90,7 @@ produces the following output in **Windows 10**
 
 ### Multiline TextBox
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/controls/timepicker.md
+++ b/versioned_docs/version-0.10.x/controls/timepicker.md
@@ -50,7 +50,7 @@ Use a `TimePicker` to let a user enter a single time value. You can customize th
 
 By default, the time picker shows a 12-hour clock with an AM/PM selector. You can set the [ClockIdentifier](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker.clockidentifier?view=winrt-19041#Windows\_UI\_Xaml\_Controls\_TimePicker\_ClockIdentifier) property to "24HourClock" to show a 24-hour clock instead.
 
-```markup
+```xml
 <TimePicker Header="12HourClock" SelectedTime="14:30"/>
 <TimePicker Header="24HourClock" SelectedTime="14:30" ClockIdentifier="24HourClock"/>
 ```
@@ -61,7 +61,7 @@ By default, the time picker shows a 12-hour clock with an AM/PM selector. You ca
 
 You can set the [MinuteIncrement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker.minuteincrement?view=winrt-19041#Windows\_UI\_Xaml\_Controls\_TimePicker\_MinuteIncrement) property to indicate the time increments shown in the minute picker. For example, 15 specifies that the `TimePicker` minute control displays only the choices 00, 15, 30, 45.
 
-```markup
+```xml
 <TimePicker MinuteIncrement="15"/>
 ```
 
@@ -88,7 +88,7 @@ TimePicker timePicker = new TimePicker
 
 You can set the time value as an attribute in XAML. This is probably easiest if you're already declaring the `TimePicker` object in XAML and aren't using bindings for the time value. Use a string in the form _Hh:Mm_ where _Hh_ is hours and can be between 0 and 23 and _Mm_ is minutes and can be between 0 and 59.
 
-```markup
+```xml
 <TimePicker SelectedTime="14:15"/>
 ```
 

--- a/versioned_docs/version-0.10.x/controls/tooltip.md
+++ b/versioned_docs/version-0.10.x/controls/tooltip.md
@@ -28,7 +28,7 @@ The `ToolTip` is a control that pops up with hint text when hovered over the app
 
 ### Text ToolTip
 
-```markup
+```xml
 <Border Margin="5"
         Padding="10"
         Background="{DynamicResource ThemeAccentBrush}"
@@ -39,7 +39,7 @@ The `ToolTip` is a control that pops up with hint text when hovered over the app
 
 ### Rich Tooltip
 
-```markup
+```xml
 <Border Margin="5"
         Padding="10"
         Background="{DynamicResource ThemeAccentBrush}"

--- a/versioned_docs/version-0.10.x/controls/transitioningcontentcontrol.md
+++ b/versioned_docs/version-0.10.x/controls/transitioningcontentcontrol.md
@@ -26,7 +26,7 @@ import TransitioningContentControlSlideScreenshot from '/img/controls/transition
 
 Let's assume we have a collection of different images and we want to show them in a slideshow like view. In order to do this we can setup our `TransitioningContentControl` like this:
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">
@@ -44,7 +44,7 @@ If you don't like the `PageTransition` which is provided by the applied theme, y
 
 In the sample below we will change the [PageTransition](../animations/page-transitions.md) to slide the images horizontally.
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" >
     <TransitioningContentControl.PageTransition>
         <PageSlide Orientation="Horizontal" Duration="0:00:00.500" />
@@ -63,7 +63,7 @@ In the sample below we will change the [PageTransition](../animations/page-trans
 
 If you want to disable the transition, set the `PageTransition` to `null`.
 
-```markup
+```xml
 <TransitioningContentControl Content="{Binding SelectedImage}" PageTransition="{x:Null}" >
     <TransitioningContentControl.ContentTemplate>
         <DataTemplate DataType="Bitmap">

--- a/versioned_docs/version-0.10.x/controls/treedatagrid/creating-a-flat-treedatagrid.md.md
+++ b/versioned_docs/version-0.10.x/controls/treedatagrid/creating-a-flat-treedatagrid.md.md
@@ -88,7 +88,7 @@ The columns above are defined as `TextColumn`s - again, `TextColumn` is a generi
 
 It's now time to add the `TreeDataGrid` control to a window and bind it to the source.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication.MainWindow">

--- a/versioned_docs/version-0.10.x/controls/treedatagrid/creating-a-hierarchical-treedatagrid.md
+++ b/versioned_docs/version-0.10.x/controls/treedatagrid/creating-a-hierarchical-treedatagrid.md
@@ -119,7 +119,7 @@ The remaining columns are also defined as `TextColumn`s - again, `TextColumn` is
 
 It's now time to add the `TreeDataGrid` control to a window and bind it to the source.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication.MainWindow">

--- a/versioned_docs/version-0.10.x/controls/treedatagrid/index.md
+++ b/versioned_docs/version-0.10.x/controls/treedatagrid/index.md
@@ -36,7 +36,7 @@ We accept issues and pull requests but we answer and review only pull requests a
 * Add the `Avalonia.Controls.TreeDataGrid` NuGet package to your project
 * Add the `TreeDataGrid` theme to your `App.xaml` file (the `StyleInclude` in the following markup):
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AvaloniaApplication.App">

--- a/versioned_docs/version-0.10.x/controls/treeview.md
+++ b/versioned_docs/version-0.10.x/controls/treeview.md
@@ -7,7 +7,7 @@ The `TreeView` is a control that presents hierarchical tree data and allows sele
 
 One example for populating a `TreeView` can be from a directory on the computer. You can create a `TreeView` in the `MainWindow.axaml` file in an Avalonia MVVM project.
 
-```markup
+```xml
 <TreeView Items="{Binding Items}" 
 	  Width="400" Height="480" 
 	  HorizontalAlignment="Left">

--- a/versioned_docs/version-0.10.x/data-binding/binding-classes.md
+++ b/versioned_docs/version-0.10.x/data-binding/binding-classes.md
@@ -4,7 +4,7 @@ title: Binding Classes
 ---
 In Avalonia, you also can bind classes. Sometimes it could be useful to switch classes depending on some logic, and for those purposes, you can use Binding Classes API. There is the sample usage of Binding Classes. We have two different styles and we want to switch between them depending on `MyProperty` state.
 
-```markup
+```xml
  <ListBox Items="{Binding MyItems}">
     <ListBox.Styles>
         <Style Selector="TextBlock.myClass">

--- a/versioned_docs/version-0.10.x/data-binding/binding-in-a-control-template.md
+++ b/versioned_docs/version-0.10.x/data-binding/binding-in-a-control-template.md
@@ -5,7 +5,7 @@ title: Binding in a Control Template
 
 When you're creating a control template and you want to bind to the templated parent you can use:
 
-```markup
+```xml
 <TextBlock Name="tb" Text="{TemplateBinding Caption}"/>
 
 <!-- Which is the same as -->
@@ -16,7 +16,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
 
  1. `TemplateBinding` accepts only a single property rather than a property path, so if you want to bind using a property path you must use the second syntax:
 
-    ```markup
+    ```xml
     <!-- This WON'T work as TemplateBinding only accepts single properties -->
     <TextBlock Name="tb" Text="{TemplateBinding Caption.Length}"/>
 
@@ -32,7 +32,7 @@ Although the two syntaxes shown here are equivalent in most cases, there are som
 
  3. `TemplateBinding` can only be used on `IStyledElement`.
 
-   ```markup
+   ```xml
    <!-- This WON'T work as GeometryDrawing is not a IStyledElement. -->
    <GeometryDrawing Brush="{TemplateBinding Foreground}"/>
 

--- a/versioned_docs/version-0.10.x/data-binding/binding-to-commands.md
+++ b/versioned_docs/version-0.10.x/data-binding/binding-to-commands.md
@@ -29,7 +29,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Button Command="{Binding DoTheThing}">Do the thing!</Button>
 </Window>
@@ -59,7 +59,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
     <Button Command="{Binding DoTheThing}" CommandParameter="Hello World">Do the thing!</Button>
 </Window>
@@ -67,7 +67,7 @@ namespace Example
 
 Note that no type conversion is carried out on `CommandParameter`, so if you need your type parameter to be something other than `string` you must supply an object of that type in XAML. For example to pass an `int` parameter you could use:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <Button Command="{Binding DoTheThing}">
@@ -100,7 +100,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">
   <Button Command="{Binding RunTheThing}" CommandParameter="Hello World">Do the thing!</Button>
 </Window>

--- a/versioned_docs/version-0.10.x/data-binding/binding-to-tasks-and-observables.md
+++ b/versioned_docs/version-0.10.x/data-binding/binding-to-tasks-and-observables.md
@@ -9,7 +9,7 @@ You can subscribe to the result of a task or an observable by using the `^` stre
 
 For example if `DataContext.Name` is an `IObservable<string>` then the following example will bind to the length of each string produced by the observable as each value is produced
 
-```markup
+```xml
 <TextBlock Text="{Binding Name^.Length}"/>
 ```
 
@@ -30,7 +30,7 @@ private async Task<string> GetTextAsync()
 ```
 
 You can bind to the result in the following way: 
-```markup
+```xml
 <TextBlock Text="{Binding MyAsyncText^, FallbackValue='Wait a second'}" />
 ```
 

--- a/versioned_docs/version-0.10.x/data-binding/bindings.md
+++ b/versioned_docs/version-0.10.x/data-binding/bindings.md
@@ -7,7 +7,7 @@ You bind in XAML using the `{Binding}` markup extension. By using bindings \(ass
 
 By default a binding binds to a property on the [`DataContext`](the-datacontext), e.g.:
 
-```markup
+```xml
 <!-- Binds to the TextBlock's DataContext.Name property -->
 <TextBlock Text="{Binding Name}"/>
 
@@ -17,7 +17,7 @@ By default a binding binds to a property on the [`DataContext`](the-datacontext)
 
 An empty binding binds to DataContext itself
 
-```markup
+```xml
 <!-- Binds to the TextBlock's DataContext property -->
 <TextBlock Text="{Binding}"/>
 
@@ -31,13 +31,13 @@ We call the property on the control the binding _target_ and the property on the
 
 The binding path above can be a single property, or it can be a chain of properties. For example if the object assigned to the `DataContext` has a `Student` property, and the value of this property has a `Name`, you can bind to the student name using:
 
-```markup
+```xml
 <TextBlock Text="{Binding Student.Name}"/>
 ```
 
 You can also include array/list indexers in binding paths:
 
-```markup
+```xml
 <TextBlock Text="{Binding Students[0].Name}"/>
 ```
 
@@ -45,7 +45,7 @@ You can also include array/list indexers in binding paths:
 
 You can change the behavior of a `{Binding}` by specifying a binding `Mode`:
 
-```markup
+```xml
 <TextBlock Text="{Binding Name, Mode=OneTime}">
 ```
 
@@ -65,7 +65,7 @@ The `Default` mode is assumed if one is not specified. This mode is generally `O
 
 You can apply a format string to the binding to influence how the value is represented in the UI:
 
-```markup
+```xml
 <!-- Option 1: Use string format without curly braces -->
 <TextBlock Text="{Binding FloatValue, StringFormat=0.0}" />
 

--- a/versioned_docs/version-0.10.x/data-binding/compiled-bindings.md
+++ b/versioned_docs/version-0.10.x/data-binding/compiled-bindings.md
@@ -13,7 +13,7 @@ Compiled bindings are not enabled by default. To enable compiled bindings, you w
 
 You can now enable or disable compiled bindings by setting `x:CompileBindings="[True|False]"`. All child nodes will inherit this property, so you can enable it in your root node and disable it for a specific child, if needed.
 
-```markup
+```xml
 <!-- Set DataType and enable compiled bindings -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -48,7 +48,7 @@ Starting from Avalonia `11.0-preview5` you can also enable or disable it in whol
 
 If you don't want to enable compiled bindings for all child nodes, you can also use the `CompiledBinding`-markup. You still need to define the `DataType`, but you can omit `x:CompileBindings="True"`.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -73,7 +73,7 @@ If you don't want to enable compiled bindings for all child nodes, you can also 
 ## ReflectionBinding-Markup
 If you have compiled bindings enabled in the root node (via `x:CompileBindings="True"`) and you either don't want to use compiled binding at a certain position or you hit one of the [known limitations](#known-limitations), you can use the `ReflectionBinding`-markup.
 
-```markup
+```xml
 <!-- Set DataType -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/versioned_docs/version-0.10.x/data-binding/converting-binding-values.md
+++ b/versioned_docs/version-0.10.x/data-binding/converting-binding-values.md
@@ -27,7 +27,7 @@ Negation also works when binding to non-boolean values. First of all, the value 
 
 A "double-bang" can be used to convert a non-boolean value to a boolean value. For example to hide a control when a collection is empty:
 
-```markup
+```xml
 <Panel>
   <ListBox Items="{Binding Items}" IsVisible="{Binding !!Items.Count}"/>
 </Panel>

--- a/versioned_docs/version-0.10.x/data-binding/creating-and-binding-attached-properties.md
+++ b/versioned_docs/version-0.10.x/data-binding/creating-and-binding-attached-properties.md
@@ -122,7 +122,7 @@ In the verify method we utilize the routed event system to attach a new handler.
 
 This example UI shows how to use the attached property. After making the namespace known to the XAML compiler it can be used by qualifying it with a dot. Then bindings can be used.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:MyApp.Behaviors"

--- a/versioned_docs/version-0.10.x/data-binding/the-datacontext.md
+++ b/versioned_docs/version-0.10.x/data-binding/the-datacontext.md
@@ -23,7 +23,7 @@ private static void AppMain(Application app, string[] args)
 
 This means that when the `MainWindow` is created, a new instance of `MainWindowViewModel` will be created and assigned to the window's `DataContext` property. From here all bindings will by default bind to properties on this object:
 
-```markup
+```xml
 <Window>
     <Button Content="{Binding ButtonCaption}"/>
 </Window>

--- a/versioned_docs/version-0.10.x/distribution-publishing/macos.md
+++ b/versioned_docs/version-0.10.x/distribution-publishing/macos.md
@@ -94,7 +94,7 @@ More documentation on possible `Info.plist` keys is available [here](https://dev
 
 If at any point the tooling gives you an error that your assets file doesn't have a target for `osx-64`, add the following [runtime identifiers](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) to the top `<PropertyGroup>` in your `.csproj`:
 
-```markup
+```xml
 <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
 ```
 
@@ -114,7 +114,7 @@ The file that is actually executed by macOS when starting your `.app` bundle wil
 
 * Add the following to your `.csproj` file:
 
-```markup
+```xml
 <PropertyGroup>
   <UseAppHost>true</UseAppHost>
 </PropertyGroup>
@@ -128,7 +128,7 @@ The file that is actually executed by macOS when starting your `.app` bundle wil
 
 You'll first have to add the project as a `PackageReference` in your project. Add it to your project via NuGet package manager or by adding the following line to your `.csproj` file:
 
-```markup
+```xml
 <PackageReference Include="Dotnet.Bundle" Version="*" />
 ```
 
@@ -153,7 +153,7 @@ dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-x64 -p:CFBundleDisplayName=
 
 Instead of specifying `CFBundleDisplayName`, etc., on the command line, you can also specify them in your project file:
 
-```markup
+```xml
 <PropertyGroup>
     <CFBundleName>AppName</CFBundleName> <!-- Also defines .app file name -->
     <CFBundleDisplayName>MyBestThingEver</CFBundleDisplayName>
@@ -514,7 +514,7 @@ When upload succeeds - you will see your package in App Store Connect.
 
 This means that your application most likely does not specify a menu. On startup, Avalonia creates the default menu items for an application and automatically adds the _About Avalonia_ item when no menu has been configured. This can be resolved by adding one to your `App.xaml`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:RoadCaptain.App.RouteBuilder"

--- a/versioned_docs/version-0.10.x/getting-started/assets.md
+++ b/versioned_docs/version-0.10.x/getting-started/assets.md
@@ -9,7 +9,7 @@ Many applications need to include assets such as bitmaps and [resource dictionar
 
 Assets can be included in an application by using the `<AvaloniaResource>` item in your project file. The MVVM Application template by default includes all files in the `Assets` directory as an `<AvaloniaResource>`:
 
-```markup
+```xml
 <ItemGroup>
   <AvaloniaResource Include="Assets\**"/>
 </ItemGroup>
@@ -23,7 +23,7 @@ You will notice that we're referring to _assets_ here whereas the MSBuild item i
 
 Assets can be referenced in XAML by specifying their relative path:
 
-```markup
+```xml
 <Image Source="icon.png"/>
 <Image Source="images/icon.png"/>
 <Image Source="../icon.png"/>
@@ -31,19 +31,19 @@ Assets can be referenced in XAML by specifying their relative path:
 
 Or their rooted path:
 
-```markup
+```xml
 <Image Source="/Assets/icon.png"/>
 ```
 
 If the asset is located in a different assembly from the XAML file, then use the `avares:` URI scheme. For example, if the asset is contained in an assembly called `MyAssembly.dll`, then you would use:
 
-```markup
+```xml
 <Image Source="avares://MyAssembly/Assets/icon.png"/>
 ```
 
 In case of fonts, you can provide a font name after a '#' sign:
 
-```markup
+```xml
 <TextBlock FontFamily="avares://MyAssembly/Assets/font.ttf#FontName">test</TextBlock>
 ```
 
@@ -55,13 +55,13 @@ Assets can also be included in .NET applications by using the `<EmbeddedResource
 
 You can reference manifest resources using the `resm:` URL scheme:
 
-```markup
+```xml
 <Image Source="resm:MyApp.Assets.icon.png"/>
 ```
 
 Or if the resource is embedded in a different assembly to the XAML file:
 
-```markup
+```xml
 <Image Source="resm:MyApp.Assets.icon.png?assembly=MyAssembly"/>
 ```
 

--- a/versioned_docs/version-0.10.x/getting-started/ide-support.md
+++ b/versioned_docs/version-0.10.x/getting-started/ide-support.md
@@ -50,7 +50,7 @@ With the namespace added, the following design-time properties become available:
 
 The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to the control being previewed.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -64,7 +64,7 @@ The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to 
 
 The `d:DataContext` property applies a `DataContext` only at design-time. It is recommended that you use this property in conjunction with the `{x:Static}` directive to reference a static property in one of your assemblies:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -91,7 +91,7 @@ namespace My.Namespace
 ### Design.DataContext
 
 Alternatively you can use `Design.DataContext` attached property. As well as Design.Width and Design.Height.
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/getting-started/programming-with-avalonia/data-binding.md
+++ b/versioned_docs/version-0.10.x/getting-started/programming-with-avalonia/data-binding.md
@@ -13,7 +13,7 @@ Avalonia includes comprehensive support for [binding](../../data-binding/binding
 
 The following example shows a `TextBlock` when an associated `TextBox` is disabled, by using a binding:
 
-```markup
+```xml
 <StackPanel>
     <TextBox Name="input" IsEnabled="False"/>
     <TextBlock IsVisible="{Binding !#input.IsEnabled}">Sorry, no can do!</TextBlock>

--- a/versioned_docs/version-0.10.x/getting-started/programming-with-avalonia/graphics-and-animations.md
+++ b/versioned_docs/version-0.10.x/getting-started/programming-with-avalonia/graphics-and-animations.md
@@ -16,7 +16,7 @@ Avalonia introduces an extensive, scalable, and flexible set of graphics feature
 
 Avalonia provides a library of common vector-drawn 2D shapes such as `Ellipse`, `Line`, `Path`, `Polygon` and `Rectangle`.
 
-```markup
+```xml
 <Canvas Background="Yellow" Width="300" Height="400">
     <Rectangle Fill="Blue" Width="63" Height="41" Canvas.Left="40" Canvas.Top="31">
         <Rectangle.OpacityMask>

--- a/versioned_docs/version-0.10.x/getting-started/programming-with-avalonia/index.md
+++ b/versioned_docs/version-0.10.x/getting-started/programming-with-avalonia/index.md
@@ -11,7 +11,7 @@ XAML is an XML-based markup language that implements an application's appearance
 
 The following example uses XAML to implement the appearance of a window that contains a single button:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow"

--- a/versioned_docs/version-0.10.x/guides/basics/accessing-the-ui-thread.md
+++ b/versioned_docs/version-0.10.x/guides/basics/accessing-the-ui-thread.md
@@ -19,7 +19,7 @@ In the below example we have a `TextBlock` which shows the result and a `Button`
 
 Our view looks like this: 
 
-```markup
+```xml
 <StackPanel>
   <TextBlock x:Name="TextBlock_Result" />
   <Button Content="Run long running process" Click="Button_OnClick" />

--- a/versioned_docs/version-0.10.x/guides/basics/code-behind.md
+++ b/versioned_docs/version-0.10.x/guides/basics/code-behind.md
@@ -39,7 +39,7 @@ namespace AvaloniaApplication1
 
 Note that this class definition corresponds closely to the XAML file:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -60,7 +60,7 @@ In addition, the class contains two more things of interest:
 
 One of the main uses of the code-behind file is to manipulate controls using C\# code. To do this you'll usually first want to get a reference to a named control. This can be done using the `FindControl<T>` method:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">
@@ -154,7 +154,7 @@ For the rest of the documentation, we'll assume you're either using Avalonia tem
 
 Another common use for the code-behind file is to define _event handlers_. Event handlers are defined as methods in the code-behind and referenced from XAML. For example to add a handler for a button click:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication4.MainWindow">

--- a/versioned_docs/version-0.10.x/guides/basics/introduction-to-xaml.md
+++ b/versioned_docs/version-0.10.x/guides/basics/introduction-to-xaml.md
@@ -19,7 +19,7 @@ Both `.xaml` and `.axaml` will be supported going forward, so feel free to use t
 
 A basic Avalonia XAML file looks like this:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication1.MainWindow">
@@ -97,7 +97,7 @@ using Avalonia.Metadata;
 
 Controls are added to the XAML by adding an XML element with the control's class name. For example to add a button as the child of the window you would write:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button>Hello World!</Button>
@@ -110,7 +110,7 @@ See the [controls documentation](../../controls) for a list of the controls incl
 
 You can set a property of a control by adding an XML attribute to an element. For example to create a button with a blue background you could write:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Background="Blue">Hello World!</Button>
@@ -123,7 +123,7 @@ You can also use _property element syntax_ for setting properties. For more info
 
 You may notice that the button above has its "Hello World!" content placed directly inside the XML element. This could also be written as a property using:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="Hello World"/>
@@ -136,7 +136,7 @@ This is because [`Button.Content`](http://reference.avaloniaui.net/api/Avalonia.
 
 You can bind a property using the `{Binding}` markup extension:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Button Content="{Binding Greeting}"/>

--- a/versioned_docs/version-0.10.x/guides/deep-dives/reactiveui/data-persistence.md
+++ b/versioned_docs/version-0.10.x/guides/deep-dives/reactiveui/data-persistence.md
@@ -57,7 +57,7 @@ public class MainWindow : ReactiveWindow<MainViewModel>
 
 The XAML of our `ReactiveWindow` will look like as follows:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="ReactiveUI.Samples.Suspension.MainWindow"

--- a/versioned_docs/version-0.10.x/guides/deep-dives/reactiveui/routing.md
+++ b/versioned_docs/version-0.10.x/guides/deep-dives/reactiveui/routing.md
@@ -41,7 +41,7 @@ namespace RoutingExample
 
 **FirstView.xaml**
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="RoutingExample.FirstView">
@@ -113,7 +113,7 @@ namespace RoutingExample
 
 Now we need to place the `RoutedViewHost` XAML control to our main view. It will resolve and embed appropriate views for the view models based on the supplied `IViewLocator` implementation and the passed `Router` instance of type `RoutingState`. Note, that you need to import `rxui` namespace for `RoutedViewHost` to work. Additionally, you can override animations that are played when `RoutedViewHost` changes a view — simply override `RoutedViewHost.PageTransition` property in XAML. For latest builds from MyGet use `xmlns:rxui="http://reactiveui.net"`, for 0.8.0 release on NuGet use `xmlns:rxui="clr-namespace:Avalonia;assembly=Avalonia.ReactiveUI"` as in the example below.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:rxui="clr-namespace:Avalonia.ReactiveUI;assembly=Avalonia.ReactiveUI"
         xmlns:app="clr-namespace:RoutingExample"
@@ -158,7 +158,7 @@ Now we need to place the `RoutedViewHost` XAML control to our main view. It will
 
 To disable the animations, simply set the `RoutedViewHost.PageTransition` property to `{x:Null}`, like so:
 
-```markup
+```xml
 <rxui:RoutedViewHost Grid.Row="0" Router="{Binding Router}" PageTransition="{x:Null}">
     <rxui:RoutedViewHost.DefaultContent>
         <TextBlock Text="Default content"

--- a/versioned_docs/version-0.10.x/guides/deep-dives/reactiveui/view-activation.md
+++ b/versioned_docs/version-0.10.x/guides/deep-dives/reactiveui/view-activation.md
@@ -34,7 +34,7 @@ public class ViewModel : ReactiveObject, IActivatableViewModel
 
 This is the UI for the view model you see above.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         Background="#f0f0f0" FontFamily="Ubuntu"

--- a/versioned_docs/version-0.10.x/guides/deep-dives/running-on-raspbian-lite-via-drm.md
+++ b/versioned_docs/version-0.10.x/guides/deep-dives/running-on-raspbian-lite-via-drm.md
@@ -91,7 +91,7 @@ When we work via FrameBuffer there are no windows, so we need a separate view (U
 counterpart to the normal window.
 
 `MainView` will be our app base in which we develop our UI:
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -113,7 +113,7 @@ counterpart to the normal window.
 ```
 
 Now create a new UserControl with name `MainSingleView` and host the `MainView`:
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -128,7 +128,7 @@ Now create a new UserControl with name `MainSingleView` and host the `MainView`:
 ```
 
 Also change the `MainWindow.axaml` to host the `MainView` inside:
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/input/hotkeys.md
+++ b/versioned_docs/version-0.10.x/input/hotkeys.md
@@ -5,7 +5,7 @@ title: Hotkeys
 
 Various Controls that implement `ICommandSource` have a `HotKey` property that you can set or bind to. Pressing the hotkey will execute the command [bound](../data-binding/binding-to-commands) to the Control.
 
-```markup
+```xml
 <Menu>
     <MenuItem Header="_File">
         <MenuItem x:Name="SaveMenuItem" Header="_Save" Command="{Binding SaveCommand}" HotKey="Ctrl+S"/>

--- a/versioned_docs/version-0.10.x/input/routed-events.md
+++ b/versioned_docs/version-0.10.x/input/routed-events.md
@@ -68,7 +68,7 @@ public class SampleControl: Control
 
 To add a handler for an event using XAML, you declare the event name as an attribute on the element that is an event listener. The value of the attribute is the name of your implemented handler method, which must exist in the class of the code-behind file.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -105,7 +105,7 @@ Each of the above considerations is discussed in a separate section of this topi
 
 To add an event handler in XAML, you simply add the event name to an element as an attribute and set the attribute value as the name of the event handler that implements an appropriate delegate, as in the following example.
 
-```markup
+```xml
 <Button Click="b1SetColor">button</Button>
 ```
 
@@ -202,7 +202,7 @@ The Avalonia input system uses attached events extensively. However, nearly all 
 
 Another syntax usage that resembles _typename_._eventname_ attached event syntax but is not strictly speaking an attached event usage is when you attach handlers for routed events that are raised by child elements. You attach the handlers to a common parent, to take advantage of event routing, even though the common parent might not have the relevant routed event as a member. Consider this example again:
 
-```markup
+```xml
 <Border Height="50" Width="300">
   <StackPanel Orientation="Horizontal" Button.Click="CommonClickHandler">
     <Button Name="YesButton">Yes</Button>

--- a/versioned_docs/version-0.10.x/layout/alignment-margins-and-padding.md
+++ b/versioned_docs/version-0.10.x/layout/alignment-margins-and-padding.md
@@ -23,7 +23,7 @@ At first glance, the `Button` elements in this illustration may appear to be pla
 
 The following example describes how to create the layout in the preceding illustration. A `Border` element encapsulates a parent `StackPanel`, with a `Padding` value of 15 device independent pixels. This accounts for the narrow `LightBlue` band that surrounds the child `StackPanel`. Child elements of the `StackPanel` are used to illustrate each of the various positioning properties that are detailed in this topic. Three `Button` elements are used to demonstrate both the `Margin` and `HorizontalAlignment` properties.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvaloniaApplication2.MainWindow"
@@ -72,7 +72,7 @@ The `HorizontalAlignment` property declares the horizontal alignment characteris
 
 The following example shows how to apply the `HorizontalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors.
 
-```markup
+```xml
 <Button HorizontalAlignment="Left">Button 1 (Left)</Button>
 <Button HorizontalAlignment="Right">Button 2 (Right)</Button>
 <Button HorizontalAlignment="Center">Button 3 (Center)</Button>
@@ -96,7 +96,7 @@ The `VerticalAlignment` property describes the vertical alignment characteristic
 
 The following example shows how to apply the `VerticalAlignment` property to `Button` elements. Each attribute value is shown, to better illustrate the various rendering behaviors. For purposes of this sample, a `Grid` element with visible gridlines is used as the parent, to better illustrate the layout behavior of each property value.
 
-```markup
+```xml
 <Border Background="LightBlue" BorderBrush="Black" BorderThickness="2" Padding="15">
     <Grid Background="White" ShowGridLines="True">
       <Grid.RowDefinitions>
@@ -131,7 +131,7 @@ A non-zero margin applies space outside the element's `Bounds`.
 
 The following example shows how to apply uniform margins around a group of `Button` elements. The `Button` elements are spaced evenly with a ten-pixel margin buffer in each direction.
 
-```markup
+```xml
 <Button Margin="10">Button 7</Button>
 <Button Margin="10">Button 8</Button>
 <Button Margin="10">Button 9</Button>
@@ -139,7 +139,7 @@ The following example shows how to apply uniform margins around a group of `Butt
 
 In many instances, a uniform margin is not appropriate. In these cases, non-uniform spacing can be applied. The following example shows how to apply non-uniform margin spacing to child elements. Margins are described in this order: left, top, right, bottom.
 
-```markup
+```xml
 <Button Margin="0,10,0,10">Button 1</Button>
 <Button Margin="0,10,0,10">Button 2</Button>
 <Button Margin="0,10,0,10">Button 3</Button>
@@ -151,7 +151,7 @@ Padding is similar to `Margin` in most respects. The Padding property is exposed
 
 The following example shows how to apply `Padding` to a parent `Border` element.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"
@@ -165,7 +165,7 @@ The following example shows how to apply `Padding` to a parent `Border` element.
 
 The following example demonstrates each of the concepts that are detailed in this topic. Building on the infrastructure found in the first sample in this topic, this example adds a`Grid` element as a child of the `Border` in the first sample. `Padding` is applied to the parent `Border` element. The`Grid` is used to partition space between three child `StackPanel` elements. `Button` elements are again used to show the various effects of `Margin` and `HorizontalAlignment`. `TextBlock` elements are added to each `ColumnDefinition` to better define the various properties applied to the `Button` elements in each column.
 
-```markup
+```xml
 <Border Background="LightBlue"
         BorderBrush="Black"
         BorderThickness="2"

--- a/versioned_docs/version-0.10.x/layout/panels-overview.md
+++ b/versioned_docs/version-0.10.x/layout/panels-overview.md
@@ -79,7 +79,7 @@ myParentCanvas.Children.Add(myCanvas3);
 
 XAML
 
-```markup
+```xml
 <Canvas Height="400" Width="400">
   <Canvas Height="100" Width="100" Top="0" Left="0" Background="Red"/>
   <Canvas Height="100" Width="100" Top="100" Left="100" Background="Green"/>
@@ -176,7 +176,7 @@ myDockPanel.Children.Add(myBorder5);
 
 XAML
 
-```markup
+```xml
 <DockPanel LastChildFill="True">
   <Border Height="25" Background="SkyBlue" BorderBrush="Black" BorderThickness="1" DockPanel.Dock="Top">
     <TextBlock Foreground="Black">Dock = "Top"</TextBlock>
@@ -378,7 +378,7 @@ myWrapPanel.Children.Add(btn4);
 
 XAML
 
-```markup
+```xml
 <Border HorizontalAlignment="Left" VerticalAlignment="Top" BorderBrush="Black" BorderThickness="2">
   <WrapPanel Background="LightBlue" Width="200" Height="100">
     <Button Width="200">Button 1</Button>

--- a/versioned_docs/version-0.10.x/styling/index.md
+++ b/versioned_docs/version-0.10.x/styling/index.md
@@ -4,7 +4,7 @@
 
 The following style selects any `TextBlock` in the `Window` with a `h1` _style class_ and sets its font size to 24 point and font weight to bold:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>

--- a/versioned_docs/version-0.10.x/styling/resources.md
+++ b/versioned_docs/version-0.10.x/styling/resources.md
@@ -9,7 +9,7 @@ Often, styles and controls will need to share resources such as \(but not limite
 
 If a resource is to be available to your entire application, you can define it in `App.xaml`/`App.axaml`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.App">
@@ -21,7 +21,7 @@ If a resource is to be available to your entire application, you can define it i
 
 Alternatively you can declare resources on a `Window` or `UserControl`: the resource will be available to the `Window`/`UserControl` and its children:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MyUserControl">
@@ -33,7 +33,7 @@ Alternatively you can declare resources on a `Window` or `UserControl`: the reso
 
 Or in fact any control at all:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MainWindow">
@@ -47,7 +47,7 @@ Or in fact any control at all:
 
 You can also declare resources on styles:
 
-```markup
+```xml
 <Style Selector="TextBlock.warn">
   <Style.Resources>
     <SolidColorBrush x:Key="Warning">Yellow</SolidColorBrush>
@@ -59,7 +59,7 @@ You can also declare resources on styles:
 
 You can references resources from controls using the `{DynamicResource}` markup extensions, e.g.:
 
-```markup
+```xml
 <Border Background="{DynamicResource Warning}">
   Look out!
 </Border>
@@ -76,7 +76,7 @@ In return, `StaticResource` doesn't need to add an event handler to listen for c
 
 Resources are resolved by walking up the logical tree from the point of the `DynamicResource` or `StaticResource` until a resource with the requested key is found. This means that resources can be "overridden" in sub-trees of the application, for example:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="MyApp.MyUserControl">
@@ -102,7 +102,7 @@ Here's the `Border`'s background will be `Orange` because its parent `StackPanel
 
 The `Resources` property on each control and style is of type `ResourceDictionary`. Resource dictionaries can also include other resource dictionaries by making use of the `MergedDictionaries` property. To include a resource dictionary in another you can use the `ResourceInclude` class, e.g.:
 
-```markup
+```xml
 <Window.Resources>
   <ResourceDictionary>
     <ResourceDictionary.MergedDictionaries>

--- a/versioned_docs/version-0.10.x/styling/selectors.md
+++ b/versioned_docs/version-0.10.x/styling/selectors.md
@@ -227,7 +227,7 @@ Matches any control which has the specified property set to the specified value.
 :::info
 **Note:** When using a `AttachedProperty` in selectors inside XAML, it has to be wrapped in parenthesis.
 
-```markup
+```xml
 <Style Selector="TextBlock[(Grid.Row)=0]">
 ```
 :::

--- a/versioned_docs/version-0.10.x/styling/styles.md
+++ b/versioned_docs/version-0.10.x/styling/styles.md
@@ -9,7 +9,7 @@ A style applies to the control that it is defined on and all descendent controls
 
 The following style selects any `TextBlock` with a `h1` _style class_ and sets its font size to 24 point and font weight to bold:
 
-```markup
+```xml
 <Style Selector="TextBlock.h1">
     <Setter Property="FontSize" Value="24"/>
     <Setter Property="FontWeight" Value="Bold"/>
@@ -18,7 +18,7 @@ The following style selects any `TextBlock` with a `h1` _style class_ and sets i
 
 Styles can be defined on any control or on the `Application` object by adding them to the [`Control.Styles`](http://reference.avaloniaui.net/api/Avalonia/StyledElement/0A46A84A) or [`Application.Styles`](http://reference.avaloniaui.net/api/Avalonia/Application/04017CAF) collections.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>
@@ -34,7 +34,7 @@ Styles can be defined on any control or on the `Application` object by adding th
 
 Styles can also be included from other files using the `StyleInclude` class, e.g.:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>
@@ -49,7 +49,7 @@ Where `CustomStyles.xaml` is a XAML file with a root of either `Style` or `Style
 
 CustomStyles.xaml
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="TextBlock.h1">
@@ -64,12 +64,12 @@ Note that unlike WPF/UWP, styles will have no effect if they're added to a contr
 
 As in CSS, controls can be given _style classes_ which can be used in selectors. Style classes can be assigned in XAML by setting the `Classes` property to a space-separated list of strings. The following example applies the `h1` and `blue` style classes to a `Button`:
 
-```markup
+```xml
 <Button Classes="h1 blue"/>
 ```
 
 If you need to add or remove class by condition, you can use the following special syntax:
-```markup
+```xml
 <Button Classes.blue="{Binding IsSpecial}" />
 ```
 
@@ -88,7 +88,7 @@ One example of a pseudoclass is the `:pointerover` \(similar to `:hover` in CSS\
 
 Pseudoclasses provide the functionality of `Triggers` in WPF and `VisualStateManager` in UWP:
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Border:pointerover">
@@ -103,7 +103,7 @@ Pseudoclasses provide the functionality of `Triggers` in WPF and `VisualStateMan
 
 Another example that involves changing properties inside of control [template](selectors.md#template):
 
-```markup
+```xml
 <StackPanel>
   <StackPanel.Styles>
     <Style Selector="Button:pressed /template/ ContentPresenter">
@@ -147,14 +147,14 @@ For more information see the [selectors documentation](selectors.md).
 
 A style's setters describe what will happen when the selector matches a control. They are simple property/value pairs written in the format:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="24"/>
 <Setter Property="Padding" Value="4 2 0 4"/>
 ```
 
 You can also use long-form syntax to declare more complex object values:
 
-```markup
+```xml
 <Setter Property="MyProperty">
    <MyObject Property1="My Value"/>
 </Setter>
@@ -162,7 +162,7 @@ You can also use long-form syntax to declare more complex object values:
 
 Bindings can also be applied using setters and can bind to the target control's `DataContext`:
 
-```markup
+```xml
 <Setter Property="FontSize" Value="{Binding SelectedFontSize}"/>
 ```
 
@@ -170,7 +170,7 @@ Whenever a style is matched with a control, all of the setters will be applied t
 
 Note that the `Setter` creates a single instance of `Value` which will be applied to all controls that the style matches: if the object is mutable then changes will be reflected on all controls. Following on from this, any bindings on an _object within the setter `Value`_ will not have access to the target control's `DataContext` as there may be multiple target controls:
 
-```markup
+```xml
 <Style Selector="local|MyControl">
   <Setter Property="MyProperty">
      <MyObject Property1="{Binding MyViewModelProperty}"/>
@@ -182,7 +182,7 @@ In the above example, the binding source will be `MyObject.DataContext`, not `My
 
 Note: at present, if you are using compiled bindings, you need to explicitly set the data type of the binding source in the `<Style>` element:
 
-```markup
+```xml
 <Style Selector="MyControl" x:DataType="MyViewModelClass">
   <Setter Property="ControlProperty" Value="{Binding MyViewModelProperty}" />
 </Style>
@@ -192,7 +192,7 @@ Note: at present, if you are using compiled bindings, you need to explicitly set
 
 As mentioned above, usually a single instance of a setter's `Value` is created and shared across all matching controls. Due to this, to use a control as a setter value, the control must be wrapped in a `<Template>`:
 
-```markup
+```xml
 <Style Selector="Border.empty">
   <Setter Property="Child">
     <Template>
@@ -206,7 +206,7 @@ As mentioned above, usually a single instance of a setter's `Value` is created a
 
 If multiple styles match a control, and they both attempt to set the same property then the style _closest to the control_ will win. Consider the following example:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Window.Styles>

--- a/versioned_docs/version-0.10.x/styling/troubleshooting.md
+++ b/versioned_docs/version-0.10.x/styling/troubleshooting.md
@@ -14,7 +14,7 @@ Avalonia selectors, like CSS selectors, do not raise any errors or warnings, whe
 
 Styles are applied in order of declaration. If there are **multiple** style files that target the same control property, one style can override the other:
 
-```markup title="Styles1.axaml"
+```xml title="Styles1.axaml"
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Blue" />
     <Style Property="FontSize" Value="16" />
@@ -22,13 +22,13 @@ Styles are applied in order of declaration. If there are **multiple** style file
 ```
 
 
-```markup title="Styles2.axaml"
+```xml title="Styles2.axaml"
 <Style Selector="TextBlock.header">
     <Style Property="Foreground" Value="Green" />
 </Style>
 ```
 
-```markup title="App.axaml"
+```xml title="App.axaml"
 <StyleInclude Source="Style1.axaml" />
 <StyleInclude Source="Style2.axaml" />
 ```
@@ -42,7 +42,7 @@ Similarly, to WPF, Avalonia properties can have multiple values, often of differ
 
 In this example you can see that local value (defined directly on the control) has higher priority than style value, so text block will have red foreground:
 
-```markup
+```xml
 <TextBlock Classes="header" Foreground="Red" />
 ...
 <Style Selector="TextBlock.header">
@@ -60,7 +60,7 @@ Some default Avalonia styles use local values in their templates instead of temp
 
 Let's imagine a situation in which you might expect a second style to override previous one, but it doesn't:
 
-```markup
+```xml
 <Style Selector="Border:pointerover">
     <Setter Property="Background" Value="Blue" />
 </Style>
@@ -81,7 +81,7 @@ Visit the Avalonia source code to find the [original templates](https://github.c
 
 The following code example of styles that can be expected to work on top of default styles:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="Red" />
 </Style>
@@ -94,7 +94,7 @@ You might expect the `Button` to be red by default and blue when pointer is over
 
 The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code (old [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) theme and new [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
 
-```markup
+```xml
 <Style Selector="Button">
     <Setter Property="Background" Value="{DynamicResource ButtonBackground}"/>
     <Setter Property="Template">
@@ -112,7 +112,7 @@ The reason is hidden in the Button's template. You can find the default template
 
 The actual background is rendered by a `ContentPresenter`, which in the default is bound to the Buttons `Background` property. However in the pointer-over state the selector is directly applying the background to the `ContentPresenter (Button:pointerover /template/ ContentPresenter#PART_ContentPresenter`) That's why when our setter was ignored in the previous code example. The corrected code should target content presenter directly as well:
 
-```markup
+```xml
 <!-- Here #PART_ContentPresenter name selector is not necessary, but was added to have more specific style -->
 <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Blue" />

--- a/versioned_docs/version-0.10.x/templates/creating-data-templates-in-code.md
+++ b/versioned_docs/version-0.10.x/templates/creating-data-templates-in-code.md
@@ -17,7 +17,7 @@ var template = new FuncDataTemplate<Student>((value, namescope) =>
 
 Is equivalent to:
 
-```markup
+```xml
 <DataTemplate DataType="{x:Type local:Student}">
     <TextBlock Text="{Binding FirstName}"/>
 </DataTemplate>

--- a/versioned_docs/version-0.10.x/templates/data-templates.md
+++ b/versioned_docs/version-0.10.x/templates/data-templates.md
@@ -10,7 +10,7 @@ import ControlContentStudentScreenshot from '/img/templates/data-templates/stude
 
 Many controls have a `Content` property, such as [`ContentControl.Content`](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756). `Window` inherits from [`ContentControl`](../controls/contentcontrol), so lets use that as an example. You're probably familiar with what happens when you put a control in the `Window.Content` property - the window displays the control:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Button HorizontalAlignment="Center"
@@ -24,7 +24,7 @@ Many controls have a `Content` property, such as [`ContentControl.Content`](http
 
 Similarly if you put a string as the window content, the window will display the string:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   Hello World!
@@ -52,7 +52,7 @@ namespace Example
 }
 ```
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -66,7 +66,7 @@ Not very helpful. That's because Avalonia doesn't know _how_ to display an objec
 
 The easiest way to do this on `Window` (and any control that inherits from `ContentControl`) is to set the [`ContentTemplate`](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/7AA9343E) property:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -97,7 +97,7 @@ The data template for the window content doesn't only come from the `ContentTemp
 
 Using the `DataTemplates` collection the previous example could be written as:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -139,7 +139,7 @@ namespace Example
 
 Now we can add a separate data template for the `Teacher` type and depending on the type of object in the `MainWindowViewModel.Content` property, the appropriate view will be displayed:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">

--- a/versioned_docs/version-0.10.x/templates/implement-idatatemplates.md
+++ b/versioned_docs/version-0.10.x/templates/implement-idatatemplates.md
@@ -37,7 +37,7 @@ public class MyDataTemplate : IDataTemplate
 
 You can now use the class `MyDataTemplate` in your view like this:
 
-```markup
+```xml
 <!-- remember to add the needed prefix in your view -->
 <!-- xmlns:dataTemplates="using:MyApp.DataTemplates" -->
 

--- a/versioned_docs/version-0.10.x/tutorials/music-store-app/add-and-layout-controls.md
+++ b/versioned_docs/version-0.10.x/tutorials/music-store-app/add-and-layout-controls.md
@@ -13,7 +13,7 @@ Let's start by adding a `Button` to the `MainWindow`. The button will allow the 
 
 In `MainWindow.axaml` change the code as follows, adding a Button inside the Panel.
 
-```markup
+```xml
 <Panel>
     <ExperimentalAcrylicBorder IsHitTestVisible="False">
         <ExperimentalAcrylicBorder.Material>
@@ -72,7 +72,7 @@ Place the `<Button>` element inside a simple `<Panel>` element.
 
 The simplest way to control the layout of a control is with the `HorizontalAlignment`and `VerticalAlignment` properties.
 
-```markup
+```xml
 <Panel>
   <Button Content="Buy Music" Margin="40" Command="{Binding BuyMusicCommand}" HorizontalAlignment="Right" VerticalAlignment="Top" />
 </Panel>
@@ -88,7 +88,7 @@ Find the name, in this case `store_microsoft_regular`.
 
 There should be some code similar to:
 
-```markup
+```xml
 <StreamGeometry x:Key="store_microsoft_regular">M11.5 9.5V13H8V9.5H11.5Z M11.5 17.5V14H8V17.5H11.5Z M16 9.5V13H12.5V9.5H16Z M16 17.5V14H12.5V17.5H16Z M8 6V3.75C8 2.7835 8.7835 2 9.75 2H14.25C15.2165 2 16 2.7835 16 3.75V6H21.25C21.6642 6 22 6.33579 22 6.75V18.25C22 19.7688 20.7688 21 19.25 21H4.75C3.23122 21 2 19.7688 2 18.25V6.75C2 6.33579 2.33579 6 2.75 6H8ZM9.5 3.75V6H14.5V3.75C14.5 3.61193 14.3881 3.5 14.25 3.5H9.75C9.61193 3.5 9.5 3.61193 9.5 3.75ZM3.5 18.25C3.5 18.9404 4.05964 19.5 4.75 19.5H19.25C19.9404 19.5 20.5 18.9404 20.5 18.25V7.5H3.5V18.25Z</StreamGeometry>
 ```
 
@@ -102,7 +102,7 @@ Enter the name `Icons` when prompted and press `Enter`.
 
 A new `xaml` file will be created that we can put styles or icons inside.
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -117,7 +117,7 @@ A new `xaml` file will be created that we can put styles or icons inside.
 
 Add your Icon code inside wrapped in a `Style` element as a resource like so.
 
-```markup
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -137,7 +137,7 @@ Add your Icon code inside wrapped in a `Style` element as a resource like so.
 
 Open `App.axaml` and add a `StyleInclude` so that the `Icons.axaml`can be loaded.
 
-```markup
+```xml
 <Application.Styles>
     <FluentTheme Mode="Dark"/>
     <StyleInclude Source="avares://Avalonia.MusicStore/Icons.axaml" />
@@ -148,7 +148,7 @@ Now build the application so that the Icons are available in the previewer.
 
 Return to `MainWindow.axaml`, we can add the Icon to the Button like so...
 
-```markup
+```xml
 <Button Margin="40" HorizontalAlignment="Right" VerticalAlignment="Top" Command="{Binding BuyMusicCommand}">
     <PathIcon Data="{StaticResource store_microsoft_regular}" />
 </Button>

--- a/versioned_docs/version-0.10.x/tutorials/music-store-app/add-content-to-dialog.md
+++ b/versioned_docs/version-0.10.x/tutorials/music-store-app/add-content-to-dialog.md
@@ -34,7 +34,7 @@ Build the project so that the previewer will work.
 
 Declare a `<DockPanel>`.
 
-```markup
+```xml
 <DockPanel>
 
 </DockPanel>
@@ -42,7 +42,7 @@ Declare a `<DockPanel>`.
 
 Inside the `DockPanel` add a `<StackPanel>`. Set `DockPanel.Dock="Top"` on the `StackPanel` so that it will be positioned at the top.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
 
@@ -52,7 +52,7 @@ Inside the `DockPanel` add a `<StackPanel>`. Set `DockPanel.Dock="Top"` on the `
 
 Inside the `StackPanel` add a `TextBox` and a `ProgressBar`.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
         <TextBox Text="{Binding SearchText}" Watermark="Search for Albums...." />
@@ -124,7 +124,7 @@ Back inside our DockPanel, add a `Button` and set it to Dock at the bottom. Set 
 
 Then bind its `Command` to `BuyMusicCommand` which we will create in the next chapter.
 
-```markup
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
         <TextBox Text="{Binding SearchText}" Watermark="Search for Albums...." />
@@ -138,7 +138,7 @@ Add a `ListBox` to the `DockPanel`. Since this is the last item in the Panel it 
 
 Bind the `Items` and `SelectedItem` properties as shown, set the `Background` to `Transparent`. Add a `Margin` of `0 20`. This means left and right sides have 0 and top and bottom have 20. This creates some space between the other controls.
 
-```markup
+```xml
 <ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" Background="Transparent" Margin="0 20" />
 ```
 
@@ -209,7 +209,7 @@ namespace Avalonia.MusicStore
 
 And then add that to `App.axaml`:
 
- ```markup
+ ```xml
 <Application.DataTemplates>
     <local:ViewLocator />
 </Application.DataTemplates>
@@ -240,13 +240,13 @@ xmlns:local="using:Avalonia.MusicStore.Views"
 
 Then inside the `<Panel>` add.
 
-```markup
+```xml
 <local:MusicStoreView />
 ```
 
 Your `MusicStoreWindow.axaml` should look like this.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -297,7 +297,7 @@ public class AlbumViewModel : ViewModelBase
 
 In your newly created `AlbumView` add the following code:
 
-```markup
+```xml
 <StackPanel Spacing="5" Width="200">
     <Border CornerRadius="10" ClipToBounds="True">
         <Panel Background="#7FFF22DD">
@@ -320,7 +320,7 @@ The border contains a `Panel` with a `Background` set, using a hexadecimal colou
 
 This `Panel` contains an `Image` and a `PathIcon` in front of it. Add the source for the Icon to `Icons.axaml`:
 
-```markup
+```xml
 <StreamGeometry x:Key="music_regular">M11.5,2.75 C11.5,2.22634895 12.0230228,1.86388952 12.5133347,2.04775015 L18.8913911,4.43943933 C20.1598961,4.91511241 21.0002742,6.1277638 21.0002742,7.48252202 L21.0002742,10.7513533 C21.0002742,11.2750044 20.4772513,11.6374638 19.9869395,11.4536032 L13,8.83332147 L13,17.5 C13,17.5545945 12.9941667,17.6078265 12.9830895,17.6591069 C12.9940859,17.7709636 13,17.884807 13,18 C13,20.2596863 10.7242052,22 8,22 C5.27579485,22 3,20.2596863 3,18 C3,15.7403137 5.27579485,14 8,14 C9.3521238,14 10.5937815,14.428727 11.5015337,15.1368931 L11.5,2.75 Z M8,15.5 C6.02978478,15.5 4.5,16.6698354 4.5,18 C4.5,19.3301646 6.02978478,20.5 8,20.5 C9.97021522,20.5 11.5,19.3301646 11.5,18 C11.5,16.6698354 9.97021522,15.5 8,15.5 Z M13,3.83223733 L13,7.23159672 L19.5002742,9.669116 L19.5002742,7.48252202 C19.5002742,6.75303682 19.0477629,6.10007069 18.3647217,5.84393903 L13,3.83223733 Z</StreamGeometry>
 ```
 
@@ -338,7 +338,7 @@ As can be seen the albums are displayed vertically. However it would be nice to 
 
 Luckily `ListBox` provides a solution to this with something called `ItemsPanelTemplate`. By default the `ListBox` has its `ItemPanel` property set to an `ItemsPanelTemplate` which contains a `StackPanel`, we can change this to a `WrapPanel` like so.
 
-```markup
+```xml
 <ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" Background="Transparent" Margin="0 20">
     <ListBox.ItemsPanel>
         <ItemsPanelTemplate>

--- a/versioned_docs/version-0.10.x/tutorials/music-store-app/add-items-to-users-collection.md
+++ b/versioned_docs/version-0.10.x/tutorials/music-store-app/add-items-to-users-collection.md
@@ -13,7 +13,7 @@ Modify the `MainWindow.axaml` so that it places the existing `Button` inside a p
 
 We can then use an `ItemsControl` instead of a `ListBox` as we did before. An `ItemsControl` is the exact same as a `ListBox` except it doesn't allow the user to select anything.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Avalonia.MusicStore.ViewModels"

--- a/versioned_docs/version-0.10.x/tutorials/music-store-app/creating-a-modern-looking-window.md
+++ b/versioned_docs/version-0.10.x/tutorials/music-store-app/creating-a-modern-looking-window.md
@@ -15,7 +15,7 @@ Let's try and make this look a little more modern by applying `Dark` mode and so
 
    Change the FluentTheme Mode from Default to Dark.
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Avolonia.MusicStore.App"
@@ -38,7 +38,7 @@ Let's try and make this look a little more modern by applying `Dark` mode and so
 
 1. After where it says `Title="Avalonia.MusicStore"` add the following code:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -57,7 +57,7 @@ This will make the Window Transparent and apply a Blur.
 
 To apply acrylic to the window, that we can tint and customize for a modern look, replace the `<TextBlock>` with the following code:
 
-```markup
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -102,7 +102,7 @@ Notice we have a nice acrylic window effect. Shame about the titlebar, though. L
 
    To enable this mode on the `Window` element set the `ExtendClientAreaToDecorationsHint` property to `True`.
 
-```markup
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"

--- a/versioned_docs/version-0.10.x/tutorials/music-store-app/opening-a-dialog.md
+++ b/versioned_docs/version-0.10.x/tutorials/music-store-app/opening-a-dialog.md
@@ -20,7 +20,7 @@ When prompted name this MusicStoreWindow and press the `Enter` key.
 
 This will add the following code:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -34,7 +34,7 @@ This will add the following code:
 
 Change this code as follows to enable the Acrylic and extended client area so the Window will look like our `MainWindow`.
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/tutorials/todo-list-app/adding-new-items.md
+++ b/versioned_docs/version-0.10.x/tutorials/todo-list-app/adding-new-items.md
@@ -15,7 +15,7 @@ We start by creating the view \(see [here](../todo-list-app/creating-a-view#crea
 
 Views/AddItemView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -104,7 +104,7 @@ We now want to bind our `Window.Content` property to this new `Content` property
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -119,7 +119,7 @@ And finally we need to make the "Add an item" button call `MainWindowViewModel.A
 
 Views/TodoListView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -146,7 +146,7 @@ Views/TodoListView.axaml
 
 The binding we've added to `<Button>` is:
 
-```markup
+```xml
 Command="{Binding $parent[Window].DataContext.AddItem}"
 ```
 
@@ -254,7 +254,7 @@ We can now bind the OK and Cancel buttons in the view to the `Ok` and `Cancel` c
 
 Views/AddItemView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/versioned_docs/version-0.10.x/tutorials/todo-list-app/creating-a-view.md
+++ b/versioned_docs/version-0.10.x/tutorials/todo-list-app/creating-a-view.md
@@ -37,7 +37,7 @@ dotnet new avalonia.usercontrol -o Views -n TodoListView  --namespace Todo.Views
 
 The template should create a XAML file with the following contents in the `Views` directory, alongside `MainWindow.axaml`
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -74,7 +74,7 @@ We're not going to touch the code-behind file for a little while, but notice tha
 
 Edit the contents of `Views/TodoListView.axaml` to contain the following:
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -102,7 +102,7 @@ If you're using the Visual Studio extension you should see the contents of the c
 
 Lets take a look at the code we just entered line-by-line.
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -131,7 +131,7 @@ This line tells the XAML engine where the class that accompanies the XAML can be
 
 Ok, that's the boilerplate out of the way! Now onto the meat of the code:
 
-```markup
+```xml
 <DockPanel>
 ```
 
@@ -139,13 +139,13 @@ First we add a `DockPanel` as the child of the `UserControl`. A `UserControl` ca
 
 `DockPanel` is a type of panel which lays out its controls at the top, bottom, left and right sides, with a single control filling the remaining space in the middle.
 
-```markup
+```xml
 <Button DockPanel.Dock="Bottom" HorizontalAlignment="Center">Add an item</Button>
 ```
 
 Now we declare the `Button` that appears at the bottom of the view. The `DockPanel.Dock` attribute tells the containing `DockPanel` that we want the button to appear at the bottom. `HorizontalAlignment` centers button in the middle of the parent. As the element content we set the button text: `"Add an item"`.
 
-```markup
+```xml
 <StackPanel>
 ```
 
@@ -153,7 +153,7 @@ Next we add another panel: a `StackPanel`. `StackPanel` lays out its child contr
 
 Because this is the last child in the `DockPanel` it will fill the remaining space in the center of the control.
 
-```markup
+```xml
 <CheckBox Margin="4">Walk the dog</CheckBox>
 <CheckBox Margin="4">Buy some milk</CheckBox>
 ```
@@ -166,7 +166,7 @@ To see the view we've just created, we need to add it to the application's main 
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Todo.Views"
@@ -186,7 +186,7 @@ xmlns:views="clr-namespace:Todo.Views"
 
 We want to display the `TodoListView` control we just created, which is in the `Todo.Views` C# namespace. Here we're mapping the `Todo.Views` namespace to the `views` XML namespace. Any control that is not a core Avalonia control will generally need this type of mapping in order for the XAML engine to find the control.
 
-```markup
+```xml
 <views:TodoListView/>
 ```
 

--- a/versioned_docs/version-0.10.x/tutorials/todo-list-app/locating-views.md
+++ b/versioned_docs/version-0.10.x/tutorials/todo-list-app/locating-views.md
@@ -7,7 +7,7 @@ Hold on, rewind a second. An observant reader will have noticed something strang
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -66,7 +66,7 @@ namespace Todo
 
 An instance of `ViewLocator` is present in `Application.DataTemplates`:
 
-```markup
+```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Todo"

--- a/versioned_docs/version-0.10.x/tutorials/todo-list-app/wiring-up-the-views.md
+++ b/versioned_docs/version-0.10.x/tutorials/todo-list-app/wiring-up-the-views.md
@@ -13,7 +13,7 @@ We're exposing the list in `MainWindowViewModel.List` so let's use that property
 
 Views/MainWindow.axaml
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Todo.Views.MainWindow"
@@ -34,13 +34,13 @@ Content="{Binding List}"
 
 The `Window.Content` property can either be set by placing a control as a child of the `Window` \([as we were doing previously](creating-a-view#display-the-view-in-the-window)\), or by assigning a value to the `Content` property. Both of these syntaxes are equivalent, meaning that writing:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui">Hello World!</Window>
 ```
 
 Is _exactly_ the same as writing:
 
-```markup
+```xml
 <Window xmlns="https://github.com/avaloniaui" Content="Hello World!"/>
 ```
 
@@ -50,7 +50,7 @@ Now we need to make `TodoListView` get the list of TODO items from the view mode
 
 Views/TodoListView.axaml
 
-```markup
+```xml
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -77,7 +77,7 @@ Views/TodoListView.axaml
 
 The first thing to notice here is that we've changed the `<StackPanel>` control to an `ItemsControl`:
 
-```markup
+```xml
 <ItemsControl Items="{Binding Items}">
 ```
 
@@ -85,7 +85,7 @@ The `ItemsControl` is a very simple control which displays each item in the coll
 
 How each item is displayed is controlled by the `ItemTemplate`. The `ItemTemplate` takes a [`DataTemplate`](https://avaloniaui.net/docs/templates/datatemplate) whose content is repeated for each item. In this case we display each item as a `CheckBox`, with the check state bound to the `IsChecked` property of the `TodoItemViewModel` and the content bound to the `Description`. We also set a `Margin` as before to space the items out a little:
 
-```markup
+```xml
 <ItemsControl.ItemTemplate>
   <DataTemplate>
     <CheckBox Margin="4"

--- a/versioned_docs/version-0.10.x/wpf-developer-tips/datatemplates.md
+++ b/versioned_docs/version-0.10.x/wpf-developer-tips/datatemplates.md
@@ -5,7 +5,7 @@ title: DataTemplates
 
 As styles aren't stored in `Resources`, neither are `DataTemplates`. Instead, `DataTemplates` are placed in a `DataTemplates` collection on each control \(and on `Application`\):
 
-```markup
+```xml
 <UserControl xmlns:viewmodels="clr-namespace:MyApp.ViewModels;assembly=MyApp">
     <UserControl.DataTemplates>
         <DataTemplate DataType="viewmodels:FooViewModel">

--- a/versioned_docs/version-0.10.x/wpf-developer-tips/grid.md
+++ b/versioned_docs/version-0.10.x/wpf-developer-tips/grid.md
@@ -5,7 +5,7 @@ title: Grid
 
 Column and row definitions can be specified in Avalonia using strings, avoiding the clunky syntax in WPF:
 
-```markup
+```xml
 <Grid ColumnDefinitions="Auto,*,32" RowDefinitions="*,Auto">
 ```
 

--- a/versioned_docs/version-0.10.x/wpf-developer-tips/styling.md
+++ b/versioned_docs/version-0.10.x/wpf-developer-tips/styling.md
@@ -5,7 +5,7 @@ title: Styling
 
 The most obvious difference from other XAML frameworks is that Avalonia uses a [CSS-like styling system](../styling/styles). Styles aren't stored in a `Resources` collection as in WPF, they are stored in a separate `Styles` collection:
 
-```markup
+```xml
 <UserControl>
     <UserControl.Styles>
         <!-- Make TextBlocks with the h1 style class have a font size of 24 points -->


### PR DESCRIPTION
After looking at #381, there are many, many instances of markup blocks being used instead of xml blocks. Not a problem for highlighting within the docs, but it does cause a lack of highlighting and error detection within Rider and possibly other editors. This helps docs be a bit more consistent, too.

Scope: Upgrades v11, v0.10.x, and localized versions.

I may have inadvertently upgraded a few XAML fragments (eg. a section consisting of only `Content="{Binding List}"`), but tried to avoid it. I went through replace manually, launched all 3 versions, used npm build, etc and all seems ok.