### PR TITLE
Remove IsScrollChainingEnabled section from 0.10.x docs

### DIFF
--- a/versioned_docs/version-0.10.x/controls/scrollviewer.md
+++ b/versioned_docs/version-0.10.x/controls/scrollviewer.md
@@ -5,16 +5,6 @@ title: ScrollViewer
 
 The `ScrollViewer` control scrolls its content if the content is bigger than the space available. A `ScrollViewer` cannot be contained in a control that has infinite height or width (depending on scrolling direction) such as a `StackPanel`. To avoid it, you can either set fixed Height/Width or MaxHeight/MaxWidth or choose another container panel.
 
-## ScrollChaining
-If you have one `ScrollViewer` nested inside another `ScrollViewer` and the user hits any limit of the inner `ScrollViewer`, you can specify if the parent `ScrollViewer` should continue with the scroll event or not. You can enable or disable this behavior with the attached property `ScrollViewer.IsScrollChainingEnabled=[true|false]`. The default value is `true`. 
-
-This property is available from these Controls: 
-- ScrollViewer
-- [DataGrid](./datagrid)
-- [ListBox](./listbox)
-- [TextBox](./textbox)
-- [TreeView](./treeview)
-
 ## Reference
 
 [ScrollViewer](http://reference.avaloniaui.net/api/Avalonia.Controls/ScrollViewer/)


### PR DESCRIPTION
Not sure if there's any substitute, but we should remove misleading 0.10.x doc sections even if there's no time to replace with accurate ones or workarounds.

Closes #211 