### PR TITLE
Fix sidebar button from disappearing after collapsing

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -423,8 +423,6 @@ aside.theme-doc-sidebar-container {
 }
 
 .theme-doc-sidebar-container div[title='Expand sidebar'] {
-  position: sticky;
-  margin-left: 16px;
   background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.293 4.293a1 1 0 0 0 0 1.414L14.586 12l-6.293 6.293a1 1 0 1 0 1.414 1.414l7-7a1 1 0 0 0 0-1.414l-7-7a1 1 0 0 0-1.414 0Z' fill='%23181818'/%3E%3C/svg%3E");
 }
 


### PR DESCRIPTION
Removing some positional attributes fixes the sidebar. Tested on Firefox and Edge. Not sure what the root cause was.

Requesting review because I'm not sure if the CSS is handwritten or generated from something else.

Closes #369 