### PR TITLE
Fix Microsoft.Toolkit mentions

### DIFF
--- a/docs/guides/data-binding/inotifypropertychanged.md
+++ b/docs/guides/data-binding/inotifypropertychanged.md
@@ -52,7 +52,7 @@ While implementing `INotifyPropertyChanged` isn't particularly complex, it can b
 Here's how you can achieve the same result as before, but using `ObservableObject`:
 
 ```csharp
-using Microsoft.Toolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 public partial class MyViewModel : ObservableObject
 {

--- a/docs/guides/development-guides/data-validation.md
+++ b/docs/guides/development-guides/data-validation.md
@@ -33,10 +33,10 @@ public string? EMail
 
 ### INotifyDataErrorInfo - ValidationPlugin
 
-Avalonia also supports validation of classes that implement [`INotifyDataErrorInfo`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifydataerrorinfo). Several `MVVM`-libraries are using this interface for their data validation, for example the [Microsoft.Toolkit.Mvvm](https://learn.microsoft.com/en-us/windows/communitytoolkit/mvvm/observablevalidator)-package and the [`ReactiveUI.Validation`](https://github.com/reactiveui/ReactiveUI.Validation#inotifydataerrorinfo-support)-package. For usage instructions please visit the documentation of the `MVVM`-package of your choice.
+Avalonia also supports validation of classes that implement [`INotifyDataErrorInfo`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifydataerrorinfo). Several `MVVM`-libraries are using this interface for their data validation, for example the [CommunityToolkit.Mvvm](https://learn.microsoft.com/en-us/windows/communitytoolkit/mvvm/observablevalidator)-package and the [`ReactiveUI.Validation`](https://github.com/reactiveui/ReactiveUI.Validation#inotifydataerrorinfo-support)-package. For usage instructions please visit the documentation of the `MVVM`-package of your choice.
 
 :::info
-Some libraries like the `Microsoft.Toolkit.Mvvm` use `DataAnnotations` for their validation. This may result in conflicts with the [DataAnnotations - ValidationPlugin](data-validation.md#dataannotations---validationplugin). Please see [Manage ValidationPlugins](data-validation.md#manage-validationplugins) how to solve this issue.
+Some libraries like the `CommunityToolkit.Mvvm` use `DataAnnotations` for their validation. This may result in conflicts with the [DataAnnotations - ValidationPlugin](data-validation.md#dataannotations---validationplugin). Please see [Manage ValidationPlugins](data-validation.md#manage-validationplugins) how to solve this issue.
 :::
 
 ### Exception - ValidationPlugin

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/inotifypropertychanged.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/data-binding/inotifypropertychanged.md
@@ -52,7 +52,7 @@ While implementing `INotifyPropertyChanged` isn't particularly complex, it can b
 Here's how you can achieve the same result as before, but using `ObservableObject`:
 
 ```csharp
-using Microsoft.Toolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 public partial class MyViewModel : ObservableObject
 {

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/development-guides/data-validation.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/development-guides/data-validation.md
@@ -33,10 +33,10 @@ public string? EMail
 
 ### INotifyDataErrorInfo - ValidationPlugin
 
-Avalonia also supports validation of classes that implement [`INotifyDataErrorInfo`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifydataerrorinfo). Several `MVVM`-libraries are using this interface for their data validation, for example the [Microsoft.Toolkit.Mvvm](https://learn.microsoft.com/en-us/windows/communitytoolkit/mvvm/observablevalidator)-package and the [`ReactiveUI.Validation`](https://github.com/reactiveui/ReactiveUI.Validation#inotifydataerrorinfo-support)-package. For usage instructions please visit the documentation of the `MVVM`-package of your choice.
+Avalonia also supports validation of classes that implement [`INotifyDataErrorInfo`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifydataerrorinfo). Several `MVVM`-libraries are using this interface for their data validation, for example the [CommunityToolkit.Mvvm](https://learn.microsoft.com/en-us/windows/communitytoolkit/mvvm/observablevalidator)-package and the [`ReactiveUI.Validation`](https://github.com/reactiveui/ReactiveUI.Validation#inotifydataerrorinfo-support)-package. For usage instructions please visit the documentation of the `MVVM`-package of your choice.
 
 :::info
-Some libraries like the `Microsoft.Toolkit.Mvvm` use `DataAnnotations` for their validation. This may result in conflicts with the [DataAnnotations - ValidationPlugin](data-validation.md#dataannotations---validationplugin). Please see [Manage ValidationPlugins](data-validation.md#manage-validationplugins) how to solve this issue.
+Some libraries like the `CommunityToolkit.Mvvm` use `DataAnnotations` for their validation. This may result in conflicts with the [DataAnnotations - ValidationPlugin](data-validation.md#dataannotations---validationplugin). Please see [Manage ValidationPlugins](data-validation.md#manage-validationplugins) how to solve this issue.
 :::
 
 ### Exception - ValidationPlugin
@@ -99,7 +99,7 @@ To display the validation messages, Avalonia has a control called [`DataValidati
     </ControlTemplate>
   </Setter>
   <Setter Property="ErrorTemplate">
-    <DataTemplate>
+    <DataTemplate x:DataType="{x:Type x:Object}">
       <Canvas Width="14" Height="14" Margin="4 0 1 0" 
               Background="Transparent">
         <Canvas.Styles>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/inotifypropertychanged.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/data-binding/inotifypropertychanged.md
@@ -52,7 +52,7 @@ public class MyViewModel : INotifyPropertyChanged
 以下是如何使用 `ObservableObject` 实现相同结果的示例：
 
 ```csharp
-using Microsoft.Toolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 public partial class MyViewModel : ObservableObject
 {

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/development-guides/data-validation.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/development-guides/data-validation.md
@@ -33,10 +33,10 @@ public string? EMail
 
 ### INotifyDataErrorInfo - ValidationPlugin
 
-Avalonia 还支持实现 [`INotifyDataErrorInfo`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifydataerrorinfo) 接口的类的验证。一些 `MVVM`-库使用此接口进行数据验证，例如 [Microsoft.Toolkit.Mvvm](https://learn.microsoft.com/en-us/windows/communitytoolkit/mvvm/observablevalidator) 库和 [`ReactiveUI.Validation`](https://github.com/reactiveui/ReactiveUI.Validation#inotifydataerrorinfo-support) 库。有关使用说明，请参阅您选择的 `MVVM`-库的文档。
+Avalonia 还支持实现 [`INotifyDataErrorInfo`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifydataerrorinfo) 接口的类的验证。一些 `MVVM`-库使用此接口进行数据验证，例如 [CommunityToolkit.Mvvm](https://learn.microsoft.com/en-us/windows/communitytoolkit/mvvm/observablevalidator) 库和 [`ReactiveUI.Validation`](https://github.com/reactiveui/ReactiveUI.Validation#inotifydataerrorinfo-support) 库。有关使用说明，请参阅您选择的 `MVVM`-库的文档。
 
 :::info
-像 `Microsoft.Toolkit.Mvvm` 这样的库使用 `DataAnnotations` 进行验证。这可能会与 [DataAnnotations - ValidationPlugin](data-validation.md#dataannotations---validationplugin) 冲突。请参阅 [管理 ValidationPlugins](data-validation.md#manage-validationplugins) 来解决此问题。
+像 `CommunityToolkit.Mvvm` 这样的库使用 `DataAnnotations` 进行验证。这可能会与 [DataAnnotations - ValidationPlugin](data-validation.md#dataannotations---validationplugin) 冲突。请参阅 [管理 ValidationPlugins](data-validation.md#manage-validationplugins) 来解决此问题。
 :::
 
 ### Exception - ValidationPlugin


### PR DESCRIPTION
3 mentions of Microsoft.Toolkit were fixed to CommunityToolkit to reflect the new package name.

No localizer work required as I updated those docs, too.