### PR TITLE
Update autocompletebox.md ItemsSource property name

### DIFF
--- a/docs/reference/controls/autocompletebox.md
+++ b/docs/reference/controls/autocompletebox.md
@@ -15,7 +15,7 @@ The way in which the text is matched to possible items in the items source is co
 
 You will probably use these properties most often:
 
-<table><thead><tr><th width="233">Property</th><th>Description</th></tr></thead><tbody><tr><td><code>Items</code></td><td>The list of items to match from. </td></tr><tr><td><code>FilterMode</code></td><td>Option for how the matching is to be done. See table below.</td></tr><tr><td><code>AsyncPopulator</code></td><td>An asynchronous function that can can provide the list of matches for a given (string) criteria. This </td></tr></tbody></table>
+<table><thead><tr><th width="233">Property</th><th>Description</th></tr></thead><tbody><tr><td><code>ItemsSource</code></td><td>The list of items to match from. </td></tr><tr><td><code>FilterMode</code></td><td>Option for how the matching is to be done. See table below.</td></tr><tr><td><code>AsyncPopulator</code></td><td>An asynchronous function that can can provide the list of matches for a given (string) criteria. This </td></tr></tbody></table>
 
 These are the options for the filter mode property:
 


### PR DESCRIPTION
The correct name of the items property is `ItemsSource`, as can be seen in the example at the end of the doc file.

Also other references shows the confrusion due to this: https://github.com/AvaloniaUI/Avalonia/discussions/13070#discussioncomment-7334717