### PR TITLE
Example code in 'Using XAML bindings from code' part missing 'Property' word

### DIFF
--- a/docs/guides/data-binding/binding-from-code.md
+++ b/docs/guides/data-binding/binding-from-code.md
@@ -110,7 +110,7 @@ Sometimes when you want the additional features that XAML bindings provide, it's
 
 ```csharp
 var textBlock = new TextBlock();
-var viewModelProperty = textBlock.GetObservable(TextBlock.DataContext)
+var viewModelProperty = textBlock.GetObservable(TextBlock.DataContextProperty)
     .OfType<MyViewModel>()
     .Select(x => x?.Name);
 textBlock.Bind(TextBlock.TextProperty, viewModelProperty);


### PR DESCRIPTION
TextBlock.DataContext -> TextBlock.DataContextProperty