### PR TITLE
Fix headings that have colons in them

### DIFF
--- a/docs/guides/implementation-guides/ide-support.md
+++ b/docs/guides/implementation-guides/ide-support.md
@@ -35,7 +35,7 @@ xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 
 With the namespace added, the following design-time properties become available:
 
-### d:DesignWidth and d:DesignHeight
+### d\:DesignWidth and d\:DesignHeight
 
 The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to the control being previewed.
 
@@ -49,7 +49,7 @@ The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to 
 </Window>
 ```
 
-### d:DataContext
+### d\:DataContext
 
 The `d:DataContext` property applies a `DataContext` only at design-time. It is recommended that you use this property in conjunction with the `{x:Static}` directive to reference a static property in one of your assemblies:
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/implementation-guides/ide-support.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/implementation-guides/ide-support.md
@@ -35,7 +35,7 @@ xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 
 With the namespace added, the following design-time properties become available:
 
-### d:DesignWidth and d:DesignHeight
+### d\:DesignWidth and d\:DesignHeight
 
 The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to the control being previewed.
 
@@ -49,7 +49,7 @@ The `d:DesignWidth` and `d:DesignHeight` properties apply a width and height to 
 </Window>
 ```
 
-### d:DataContext
+### d\:DataContext
 
 The `d:DataContext` property applies a `DataContext` only at design-time. It is recommended that you use this property in conjunction with the `{x:Static}` directive to reference a static property in one of your assemblies:
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/implementation-guides/ide-support.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/implementation-guides/ide-support.md
@@ -35,7 +35,7 @@ xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 
 添加了该命名空间后，以下设计时属性可用：
 
-### d:DesignWidth 和 d:DesignHeight
+### d\:DesignWidth 和 d\:DesignHeight
 
 `d:DesignWidth` 和 `d:DesignHeight` 属性为预览的控件应用宽度和高度。
 
@@ -49,7 +49,7 @@ xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 </Window>
 ```
 
-### d:DataContext
+### d\:DataContext
 
 `d:DataContext` 属性仅在设计时应用 `DataContext` 。建议您与 `{x:Static}` 指令结合使用此属性，以引用您的一个程序集中的静态属性：
 


### PR DESCRIPTION
Headings that contain a colon (and non-whitespace characters on each side) have awkward truncating in the sidebar. Escaping them fixes this. eg. `### d\:DesignWidth`. This does not affect headings with whitespace. eg. `### Example: Round Button`.

This only affected one doc as per ripgrep: `rg '^#+.*\S+:\S+.*'`

Localized versions were updated, so no localization work needed.

Behavior before fix:

![image](https://github.com/AvaloniaUI/avalonia-docs/assets/1782158/f9a05ec4-e47d-4763-9635-41b1d13f5e8c)
