### PR TITLE
Add helpful context to example in tray-icon.md

### DIFF
--- a/docs/reference/controls/detailed-reference/tray-icon.md
+++ b/docs/reference/controls/detailed-reference/tray-icon.md
@@ -28,25 +28,39 @@ You must use a **native menu** with the tray icon, and not the _Avalonia UI_ men
 This example defines a simple tray icon menu in the `App.xaml` file :
 
 ```xml
-<TrayIcon.Icons>
-  <TrayIcons>
-    <TrayIcon Icon="/Assets/avalonia-logo.ico" 
-              ToolTipText="Avalonia Tray Icon ToolTip">
-      <TrayIcon.Menu>
-        <NativeMenu>
-          <NativeMenuItem Header="Settings">
-            <NativeMenu>
-              <NativeMenuItem Header="Option 1"   />
-              <NativeMenuItem Header="Option 2"   />
-              <NativeMenuItemSeparator />
-              <NativeMenuItem Header="Option 3"  />
-            </NativeMenu>
-          </NativeMenuItem>
-        </NativeMenu>
-      </TrayIcon.Menu>
-    </TrayIcon>
-  </TrayIcons>
-</TrayIcon.Icons>
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="MyApplication.App">
+  <TrayIcon.Icons>
+    <TrayIcons>
+      <TrayIcon Icon="/Assets/avalonia-logo.ico" 
+                ToolTipText="Avalonia Tray Icon ToolTip">
+        <TrayIcon.Menu>
+          <NativeMenu>
+            <NativeMenuItem Header="Settings">
+              <NativeMenu>
+                <NativeMenuItem Header="Option 1"   />
+                <NativeMenuItem Header="Option 2"   />
+                <NativeMenuItemSeparator />
+                <NativeMenuItem Header="Option 3"  />
+              </NativeMenu>
+            </NativeMenuItem>
+          </NativeMenu>
+        </TrayIcon.Menu>
+      </TrayIcon>
+    </TrayIcons>
+  </TrayIcon.Icons>
+</Application>
+```
+
+Include the `.ico` file in the `.csproj` file using an `AvaloniaResource` item:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <AvaloniaResource Include="Assets/avalonia-logo.ico" />
+  </ItemGroup>
+</Project>
 ```
 
 <img src={TrayIconScreenshot} alt="" />


### PR DESCRIPTION
This PR updates the example in tray-icon.md in two ways:

1. The `<TrayIcon.Icons>` snippet is placed in context. When I tried to use this yesterday, I saw the snippet and thought, "Well, that's great but where do I _put_ that?" The page does say `App.xaml`, and yes, you do just drop it in there, but there was uncertainty there that a `<TrayIcon.Icons>` element could simply go directly in as a child of the root `<Application>`.

2. The sample references an icon as "/Assets/avalonia-logo.ico", but it doesn't say how you get that icon there. After some fiddling and searching and experimentation, I finally discovered that it works if I put an `<AvaloniaResource>` item into my `.csproj`. So, this PR adds a mention of this fact for future readers.
