### PR TITLE
Typo fix

### DIFF
--- a/docs/tutorials/music-store-app/opening-a-dialog.md
+++ b/docs/tutorials/music-store-app/opening-a-dialog.md
@@ -155,7 +155,7 @@ Your whole file should now look like this:
 
 ```csharp
 using Avalonia.ReactiveUI;
-using AvaloniaApplication11.ViewModels;
+using Avalonia.MusicStore.ViewModels;
 using ReactiveUI;
 using System.Threading.Tasks;
 

--- a/docs/tutorials/music-store-app/return-from-dialog.md
+++ b/docs/tutorials/music-store-app/return-from-dialog.md
@@ -66,7 +66,7 @@ Your music store window code-behind should now look like this.
 
 ```csharp
 using Avalonia.ReactiveUI;
-using AvaloniaApplication11.ViewModels;
+using Avalonia.MusicStore.ViewModels;
 using ReactiveUI;
 using System;
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/button-command.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/button-command.md
@@ -26,7 +26,7 @@ description: TUTORIALS - Music Store App
 using ReactiveUI;
 using System.Windows.Input;
 
-namespace AvaloniaApplication11.ViewModels
+namespace Avalonia.MusicStore.ViewModels
 {
     public class MainWindowViewModel : ViewModelBase
     {

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/mock-search.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/mock-search.md
@@ -47,7 +47,7 @@ namespace Avalonia.MusicStore.ViewModels
 ```csharp
 using ReactiveUI;
 
-namespace AvaloniaApplication11.ViewModels
+namespace Avalonia.MusicStore.ViewModels
 {
     public class MusicStoreViewModel : ViewModelBase
     {

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
@@ -170,11 +170,11 @@ this.WhenActivated(action =>
 
 ```csharp
 using Avalonia.ReactiveUI;
-using AvaloniaApplication11.ViewModels;
+using Avalonia.MusicStore.ViewModels;
 using ReactiveUI;
 using System.Threading.Tasks;
 
-namespace AvaloniaApplication11.Views
+namespace Avalonia.MusicStore.Views
 {
     public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
     {

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/return-from-dialog.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/return-from-dialog.md
@@ -73,7 +73,7 @@ this.WhenActivated(action => action(ViewModel!.BuyMusicCommand.Subscribe(Close))
 
 ```csharp
 using Avalonia.ReactiveUI;
-using AvaloniaApplication11.ViewModels;
+using Avalonia.MusicStore.ViewModels;
 using ReactiveUI;
 using System;
 


### PR DESCRIPTION
When importing things the path should be `Avalonia.MusicStore` not `AvaloniaApplication11` as the solution name is `Avalonia.MusicStore` is the solution name entered [here](https://docs.avaloniaui.net/docs/tutorials/music-store-app/creating-the-project). 

I've done a find & replace all spots this affects.