### PR TITLE
Add documentation for `WinFormsAvaloniaControlHost`

### DIFF
--- a/docs/guides/platforms/windows/host-avalonia-controls-in-winforms.md
+++ b/docs/guides/platforms/windows/host-avalonia-controls-in-winforms.md
@@ -1,0 +1,49 @@
+---
+id: host-avalonia-controls-in-winforms
+title: Host Avalonia controls in Windows Forms
+---
+
+# Host Avalonia controls in Windows Forms
+
+Avalonia controls can be hosted in Windows Forms applications. This enables a step-by-step migration of existing Windows Forms applications to Avalonia.
+
+## Overview
+
+An exemplary Windows Forms application with Avalonia controls requires at least three projects:
+
+1. `YourApp` Cross platform library where you put your Avalonia controls 
+2. `YourApp.Desktop` Executable Avalonia application, required for the Visual Studio Avalonia designer
+3. `YourApp.WinForms` Your existing Windows Forms application
+
+## Prerequisites
+
+- Visual Studio 2022
+- Avalonia extension for Visual Studio 2022
+- A solution with a Windows Forms project
+
+## Step-by-step instructions
+
+1. Create both Avalonia projects
+   - In Visual Studio add a new project to your solution
+   - Choose _Avalonia C# Project_
+   - Select at least _Desktop_ as target platforms
+   - Click _Create_
+   - You should now have a `YourApp` and a `YourApp.Desktop` project in your solution
+2. Add references to your existing Windows Forms project
+   - A package reference to `Avalonia.Skia`
+   - A package reference to `Avalonia.Win32.Interoperability`
+   - A project reference to `YourApp.csproj`
+3. Add the following lines in your `Program.cs` before you call `Application.Run()`
+```cs
+AppBuilder.Configure<App>()
+    .UseWin32()
+    .UseSkia()
+    .SetupWithoutStarting();
+```
+4. Add an `WinFormsAvaloniaControlHost` control from the Toolbox
+5. Add the following line to your form's constructor after `InitializeComponent()`
+```cs
+winFormsAvaloniaControlHost1.Content = new MainView { DataContext = new MainViewModel() };
+```
+
+Now you should see Avalonia's default main view _Welcome to Avalonia_ in your Windows Forms application.

--- a/docs/guides/platforms/windows/host-avalonia-controls-in-winforms.md
+++ b/docs/guides/platforms/windows/host-avalonia-controls-in-winforms.md
@@ -47,3 +47,10 @@ winFormsAvaloniaControlHost1.Content = new MainView { DataContext = new MainView
 ```
 
 Now you should see Avalonia's default main view _Welcome to Avalonia_ in your Windows Forms application.
+
+:::info
+You cannot use ReactiveUI for your Windows Forms and Avalonia controls at the same time.
+
+If you want to use it for Avalonia you must register ReactiveUI at the `AppBuilder` with `.UseReactiveUI()` in `Program.cs`.
+Do not include a reference to `ReactiveUI.WinForms` otherwise interactions will not work (see [#16478](https://github.com/AvaloniaUI/Avalonia/discussions/16478)).
+:::

--- a/docs/guides/platforms/windows/host-avalonia-controls-in-winforms.md
+++ b/docs/guides/platforms/windows/host-avalonia-controls-in-winforms.md
@@ -9,19 +9,18 @@ Avalonia controls can be hosted in Windows Forms applications. This enables a st
 
 ## Overview
 
-An exemplary Windows Forms application with Avalonia controls requires at least three projects:
+An exemplary Windows Forms application with Avalonia controls requires at least two projects:
 
 1. `YourApp` Cross platform library where you put your Avalonia controls 
-2. `YourApp.Desktop` Executable Avalonia application, required for the Visual Studio Avalonia designer
-3. `YourApp.WinForms` Your existing Windows Forms application
+2. `YourApp.WinForms` Your existing Windows Forms application
+3. `YourApp.Desktop` (optional) Executable Avalonia application, required only for the Visual Studio Avalonia designer
 
-## Prerequisites
-
-- Visual Studio 2022
-- Avalonia extension for Visual Studio 2022
-- A solution with a Windows Forms project
+As Windows Forms is only supported on Microsoft Windows, adding Avalonia controls to your app will not make it cross platform.
 
 ## Step-by-step instructions
+
+These instruction assume that you use Visual Studio 2022 with the Avalonia extension.
+You can adjust the steps and leave out the `YourApp.Desktop` project if you are using VS Code or Rider.
 
 1. Create both Avalonia projects
    - In Visual Studio add a new project to your solution
@@ -30,14 +29,13 @@ An exemplary Windows Forms application with Avalonia controls requires at least 
    - Click _Create_
    - You should now have a `YourApp` and a `YourApp.Desktop` project in your solution
 2. Add references to your existing Windows Forms project
-   - A package reference to `Avalonia.Skia`
+   - A package reference to `Avalonia.Desktop`
    - A package reference to `Avalonia.Win32.Interoperability`
    - A project reference to `YourApp.csproj`
 3. Add the following lines in your `Program.cs` before you call `Application.Run()`
 ```cs
 AppBuilder.Configure<App>()
-    .UseWin32()
-    .UseSkia()
+    .UsePlatformDetect()
     .SetupWithoutStarting();
 ```
 4. Add an `WinFormsAvaloniaControlHost` control from the Toolbox

--- a/sidebars.js
+++ b/sidebars.js
@@ -382,6 +382,13 @@ const sidebars = {
             },
             {
               'type': 'category',
+              'label': 'Windows',
+              'items': [
+                'guides/platforms/windows/host-avalonia-controls-in-winforms',
+              ],
+            },
+            {
+              'type': 'category',
               'label': 'Raspberry PI',
               'items': [
                 'guides/platforms/rpi/running-your-app-on-a-raspberry-pi',


### PR DESCRIPTION
This pull request adds a new documentation page _How-To Guides > Platforms > Windows > Host Avalonia controls in Windows Forms_ which explains the usage of `WinFormsAvaloniaControlHost` (resolves #522)