### PR TITLE
Update in code sample for opening-a-dialog.md

### DIFF
--- a/docs/tutorials/music-store-app/opening-a-dialog.md
+++ b/docs/tutorials/music-store-app/opening-a-dialog.md
@@ -170,7 +170,7 @@ namespace Avalonia.MusicStore.Views
                 action(ViewModel!.ShowDialog.RegisterHandler(DoShowDialogAsync)));
         }
 
-        private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel, 
+        private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel, 
                                                 AlbumViewModel?> interaction)
         {
             var dialog = new MusicStoreWindow();


### PR DESCRIPTION
Object implementation generates error when copy pasting the code to sample, modified to use the interface that is the required type for ViewModel!.ShowDialog.RegisterHandler