### PR TITLE
[ios docs] Updated ios docs to mention mention additional relevant info

### DIFF
--- a/docs/guides/platforms/ios/build-and-run-your-application-on-a-simulator.md
+++ b/docs/guides/platforms/ios/build-and-run-your-application-on-a-simulator.md
@@ -26,3 +26,11 @@ dotnet run
 <img src={IOSSimulatorScreenshot} alt='Application running on iPad simulator'/>
 
 If you use `JetBrains Rider` or `Visual Studio for Mac` you can open the solution and run, build and debug your program inside the simulator.
+
+:::info
+`Dependent on the .NET version and the iOS Simulator version it may require Rosetta 2 to be installed on Apple Slicon Macs. To install Rosetta 2, you can use the following command in the terminal:`
+
+```bash
+/usr/sbin/softwareupdate --install-rosetta
+```
+:::

--- a/docs/guides/platforms/ios/build-and-run-your-application-on-your-iphone-or-ipad.md
+++ b/docs/guides/platforms/ios/build-and-run-your-application-on-your-iphone-or-ipad.md
@@ -85,7 +85,3 @@ Set the value exactly as the bold text at the top of the window on your selected
 `Apple Development: dan@walms.co.uk (3L323F7VSS)` in this case.
 
 After this you can run and debug your application on the iPhone or iPad like any normal
-
-:::info
-`Note that this certificate is not bound to the Bundle ID. It basically is the certificate for the Mac user account. The very same certificate can be used in many different projects with different Bundle IDs`
-:::

--- a/docs/guides/platforms/ios/build-and-run-your-application-on-your-iphone-or-ipad.md
+++ b/docs/guides/platforms/ios/build-and-run-your-application-on-your-iphone-or-ipad.md
@@ -85,3 +85,7 @@ Set the value exactly as the bold text at the top of the window on your selected
 `Apple Development: dan@walms.co.uk (3L323F7VSS)` in this case.
 
 After this you can run and debug your application on the iPhone or iPad like any normal
+
+:::info
+`Note that this certificate is not bound to the Bundle ID. It basically is the certificate for the Mac user account. The very same certificate can be used in many different projects with different Bundle IDs`
+:::


### PR DESCRIPTION
Mentioned additional learnings from starting a new iOS project on a most up to date Apple Silicon Mac. 

I did not change the line where you mention to use the same bundle id but just explained in the bottom info box that the bundle Id may be changed in the actual Avalonia project