### PR TITLE
Update add-data-persistence.md

### DIFF
--- a/docs/tutorials/music-store-app/add-data-persistence.md
+++ b/docs/tutorials/music-store-app/add-data-persistence.md
@@ -53,7 +53,7 @@ public static async Task<IEnumerable<Album>> LoadCachedAsync()
 {
     if (!Directory.Exists("./Cache"))
     {
-        Directory.CreateDirectory("./Cache");
+        return Array.Empty<Album>();
     }
 
     var results = new List<Album>();


### PR DESCRIPTION
In a load method, if the directory does exist, we should return an empty collection not creating the directory and iterate over the files.