### PR TITLE
Add missing info about .UseReactiveUI() call inside BuildAvaloniaApp()

### DIFF
--- a/docs/tutorials/music-store-app/opening-a-dialog.md
+++ b/docs/tutorials/music-store-app/opening-a-dialog.md
@@ -126,6 +126,17 @@ At this point, the code for the interaction is still incomplete. If you attempt 
 
 Your next step is to make sure that the main window view knows how to start the interaction. This is implemented in the code-behind file for the main window view, and uses some features of the _ReactiveUI_ framework.  Follow this procedure:
 
+- Open **Program.cs** file. Add an additional call to `UseReactiveUI()` inside **BuildAvaloniaApp** method as follows:
+
+```csharp
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace()
+            .UseReactiveUI(); // add this line
+```
+
 - Locate and open the code-behind **MainWindow.axaml.cs** file. (You may need to expand the **MainWindow.axaml** file to find it.)
 - Alter the class so that it inherits from `ReactiveWindow<MainWindowViewModel>`.
 - Add the `DoShowDialogAsync` method as follows:


### PR DESCRIPTION
Includes the essential step of adding `.UseReactiveUI` when utilizing Reactive features, as outlined in the documentation. Omitting this call results in a runtime exception, which may cause confusion for new users.

Exception encountered: ```System.ArgumentException: Unable to detect activation/deactivation of Project1.Views.MainWindow; implementing IActivationForViewFetcher may be required."```