### PR TITLE
Update opening-a-dialog.md 

### DIFF
--- a/docs/tutorials/music-store-app/opening-a-dialog.md
+++ b/docs/tutorials/music-store-app/opening-a-dialog.md
@@ -131,7 +131,7 @@ Your next step is to make sure that the main window view knows how to start the 
 - Add the `DoShowDialogAsync` method as follows:
 
 ```csharp
-private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel,
+private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel,
                                         AlbumViewModel?> interaction)
 {
      var dialog = new MusicStoreWindow();
@@ -170,7 +170,7 @@ namespace Avalonia.MusicStore.Views
                 action(ViewModel!.ShowDialog.RegisterHandler(DoShowDialogAsync)));
         }
 
-        private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel, 
+        private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel, 
                                                 AlbumViewModel?> interaction)
         {
             var dialog = new MusicStoreWindow();

--- a/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
@@ -144,7 +144,7 @@ namespace Avalonia.MusicStore.ViewModels
 - Добавьте метод `DoShowDialogAsync`, как показано ниже:
 
 ```csharp
-private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel,
+private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel,
                                         AlbumViewModel?> interaction)
 {
      var dialog = new MusicStoreWindow();
@@ -185,7 +185,7 @@ namespace Avalonia.MusicStore.Views
                 action(ViewModel!.ShowDialog.RegisterHandler(DoShowDialogAsync)));
         }
 
-        private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel, 
+        private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel, 
                                                 AlbumViewModel?> interaction)
         {
             var dialog = new MusicStoreWindow();

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/music-store-app/opening-a-dialog.md
@@ -133,7 +133,7 @@ namespace Avalonia.MusicStore.ViewModels
 - 添加以下 `DoShowDialogAsync` 方法：
 
 ```csharp
-private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel,
+private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel,
                                         AlbumViewModel?> interaction)
 {
      var dialog = new MusicStoreWindow();
@@ -172,7 +172,7 @@ namespace Avalonia.MusicStore.Views
                 action(ViewModel!.ShowDialog.RegisterHandler(DoShowDialogAsync)));
         }
 
-        private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel, 
+        private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel, 
                                                 AlbumViewModel?> interaction)
         {
             var dialog = new MusicStoreWindow();


### PR DESCRIPTION
In the document for the music app store in version 11.0.x, the code fails to compile. 
InteractionContext should be replaced with IInteractionContext.