### PR TITLE
Update opening-a-dialog.md

### DIFF
--- a/docs/tutorials/music-store-app/opening-a-dialog.md
+++ b/docs/tutorials/music-store-app/opening-a-dialog.md
@@ -131,7 +131,7 @@ Your next step is to make sure that the main window view knows how to start the 
 - Add the `DoShowDialogAsync` method as follows:
 
 ```csharp
-private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel,
+private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel,
                                         AlbumViewModel?> interaction)
 {
      var dialog = new MusicStoreWindow();
@@ -170,7 +170,7 @@ namespace Avalonia.MusicStore.Views
                 action(ViewModel!.ShowDialog.RegisterHandler(DoShowDialogAsync)));
         }
 
-        private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel, 
+        private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel, 
                                                 AlbumViewModel?> interaction)
         {
             var dialog = new MusicStoreWindow();


### PR DESCRIPTION
Fix build error 
 MainWindow.axaml.cs(14, 62): [CS1503] Argument 1: cannot convert from 'method group' to 'System.Action<ReactiveUI.IInteractionContext<Avalonia.MusicStore.ViewModels.MusicStoreViewModel, Avalonia.MusicStore.ViewModels.AlbumViewModel?>>'

by changing InteractionContext to IInteractionContext
