### PR TITLE
Remove redundant font-face declarations

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2,22 +2,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap');
 
 @font-face {
-  font-family: 'Outfit';
-  font-weight: 100 900;
-  font-display: swap;
-  font-style: normal;
-  src: url('https://fonts.gstatic.com/s/outfit/v11/QGYyz_MVcBeNP4NjuGObqx1XmO1I4TC1O4i0EwItq6fNIhnL.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: "Nunito", sans-serif;
-  font-weight: 100 900;
-  font-display: swap;
-  font-style: normal;
-  src: url('https://fonts.gstatic.com/s/nunito/v26/XRXV3I6Li01BKofINeaBTMnFcQ.woff2') format('woff2');
-}
-
-@font-face {
   font-family: 'Plus Jakarta Sans';
   font-style: normal;
   font-weight: 200 800;


### PR DESCRIPTION
The import url basically acts like C-style include. You can visit the URL to see what it will include. For Outfit fonts, it has two variants of the font-face included. one of them is overridden with the manual declaration just below, which causes trouble between font-faces.

### Before
![Screenshot_20241229_144110](https://github.com/user-attachments/assets/c2f10ce8-319d-4ae5-97b7-43f3c6fde0bc)

### After
![Screenshot_20241229_144152](https://github.com/user-attachments/assets/adf4809d-dec1-4408-8989-c4fafaf880c6)
