### PR TITLE
Three small XPF tweaks

### DIFF
--- a/xpf/getting-started.md
+++ b/xpf/getting-started.md
@@ -5,6 +5,10 @@ title: Getting started
 
 ## Step 1: Prepare your WPF project
 
+:::note
+This document uses .NET 7.0 as an example, but .NET 6.0 and above are supported by XPF
+:::
+
 Make sure that your project has been updated/ported to `net7.0-windows` and uses the new [SDK](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/overview) csproj format. 
 
 For more information see the Microsoft [How to upgrade a WPF desktop app to .NET 7](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/migration) guide.
@@ -21,10 +25,6 @@ If you are running on Linux, see the [linux](platforms/linux) guide **before** y
 
 :::tip
 See our [porting tips](porting-tips) for a more detailed run-through of this step.
-:::
-
-:::note
-This document specifies .NET 7.0, but `net6.0` should also work
 :::
 
 ## Step 2: Add a `NuGet.config`

--- a/xpf/missing-features.md
+++ b/xpf/missing-features.md
@@ -17,6 +17,7 @@ The following features are available, but with limitations:
 The following features will be available later but require significant engineering effort:
 
 - `Viewport3D` and related 3D APIs
+- `MediaElement` and `MediaPlayer`
 
 The following features are unlikely to be supported due to platform restrictions:
 

--- a/xpf/troubleshooting.md
+++ b/xpf/troubleshooting.md
@@ -16,11 +16,10 @@ Use the username `license` and your license key as the password when asked.
 :::
 
 - https://xpf-nuget-feed.avaloniaui.net/
-- https://nuget-feed-all.avaloniaui.net/
 - https://xpf-nuget-feed.avaloniaui.net/v3/index.json
 - https://nuget-feed-all.avaloniaui.net/v3/index.json
 
-The first two URLs should display a page similar to the package listing on [nuget.org](https://www.nuget.org/packages); the second two URLs should display some JSON.
+The first URL should display a page similar to the package listing on [nuget.org](https://www.nuget.org/packages); the second two URLs should display some JSON.
 
 If you are unable to view any of these URls, check your firewall settings.
 


### PR DESCRIPTION
- Make it clear that .NET 6+ is supported
- `MediaElement` and `MediaPlayer` are not yet supported
- Remove `nuget-feed-all` web URL as it has been restricted due to web crawlers