### PR TITLE
Add example of using MultiBinding with Built-in converters

### DIFF
--- a/docs/reference/built-in-data-binding-converters.md
+++ b/docs/reference/built-in-data-binding-converters.md
@@ -58,12 +58,25 @@ This example binding will hide the text block if its bound text is null or empty
                        Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 ```
 
-And this example will hide the content control if the bound object is null or empty:
+This example will hide the content control if the bound object is null or empty:
 
 ```xml
 <ContentControl Content="{Binding MyContent}"
                 IsVisible="{Binding MyContent, 
                             Converter={x:Static ObjectConverters.IsNotNull}}"/>
+```
+
+And this example demonstrates binding to multiple bound parameters. It will show the text block if the `MyText` property of the bound object is not null or empty and the `IsMyNotEmptyTextVisible` property is set to `true`:
+
+```xml
+<TextBlock Text="{Binding MyText, StringFormat='My text: {0}'}">
+  <TextBlock.IsVisible>
+    <MultiBinding Converter="{x:Static BoolConverters.And}">
+        <Binding Path="MyText" Converter="{x:Static StringConverters.IsNotNullOrEmpty}"/>
+        <Binding Path="IsMyNotEmptyTextVisible"/>
+    </MultiBinding>
+  </TextBlock.IsVisible>
+</TextBlock>
 ```
 
 ## More Information


### PR DESCRIPTION
Add example of using MultiBinding with Built-in BoolConverter

Motivation: all examples in "Built-in Data Binding Converters" article show usage converters with only one parameter. I had to additionaly investigate the way how to use converters with MultiBinding, when I initily faced with this issue. To help another users - I added one example with MultiBinding and BoolConverter with 2 parameters