### PR TITLE
Update README.md

### DIFF
--- a/docs/reference/controls/treedatagrid/README.md
+++ b/docs/reference/controls/treedatagrid/README.md
@@ -92,11 +92,7 @@ You will use the `Source` property to bind to a view model that is defined in co
 ## More Information
 
 :::info
-For the complete API documentation about this control, see here.
-:::
-
-:::info
 View the source code on GitHub [TreeDataGrid.cs](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid)
 :::
 
-The next page shows an example of creating a hierarchical tree data grid with columns.
+The next page shows an example of creating a flat tree data grid with columns.


### PR DESCRIPTION
The notes at the bottom of this page referenced the complete API docs with no link. Since this is not part of the core Avalonia package, it is not referenced in the complete API docs. Additionally, the last line on the page referenced the next page as being a hierarchical grid while the next page was actually the flat grid example.