### PR TITLE
Fix broken link to DataGrid source

### DIFF
--- a/docs/reference/controls/datagrid/README.md
+++ b/docs/reference/controls/datagrid/README.md
@@ -210,9 +210,9 @@ For more information about the different kinds of `DataGridColumn`, see the [nex
 :::
 
 :::info
-For the complete API documentation about this control, see [here](http://reference.avaloniaui.net/api/Avalonia.Controls/DataGrid/).
+For the complete API documentation about this control, see [here](https://reference.avaloniaui.net/api/Avalonia.Controls/DataGrid/).
 :::
 
 :::info
-View the source code on _GitHub_ [`DataGrid.cs`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls.DataGrid/DataGrid.cs)
+View the source code on _GitHub_ [`DataGrid.cs`](https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid/blob/master/src/Avalonia.Controls.DataGrid/DataGrid.cs)
 :::

--- a/docs/reference/controls/datagrid/data-grid-template-columns.md
+++ b/docs/reference/controls/datagrid/data-grid-template-columns.md
@@ -106,9 +106,9 @@ public class Person
 ## More Information
 
 :::info
-For the complete API documentation about this control, see [here](http://reference.avaloniaui.net/api/Avalonia.Controls/DataGridTemplateColumn/).
+For the complete API documentation about this control, see [here](https://reference.avaloniaui.net/api/Avalonia.Controls/DataGridTemplateColumn/).
 :::
 
 :::info
-View the source code on _GitHub_ [`DataGridTemplateColumn.cs`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs)
+View the source code on _GitHub_ [`DataGridTemplateColumn.cs`](https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid/blob/master/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs)
 :::

--- a/docs/reference/controls/datagrid/datagridcolumns.md
+++ b/docs/reference/controls/datagrid/datagridcolumns.md
@@ -118,17 +118,17 @@ It works in the preview pane because the `<Design.DataContext>` element creates 
 ## More Information
 
 :::info
-For the complete API documentation about the data grid text column, see [here](http://reference.avaloniaui.net/api/Avalonia.Controls/DataGridTextColumn/).
+For the complete API documentation about the data grid text column, see [here](https://reference.avaloniaui.net/api/Avalonia.Controls/DataGridTextColumn/).
 :::
 
 :::info
-For the complete API documentation about data grid check box column, see [here](http://reference.avaloniaui.net/api/Avalonia.Controls/DataGridCheckBoxColumn/).
+For the complete API documentation about data grid check box column, see [here](https://reference.avaloniaui.net/api/Avalonia.Controls/DataGridCheckBoxColumn/).
 :::
 
 :::info
-View the source code on _GitHub_ [`DataGridTextColumn.cs`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs)
+View the source code on _GitHub_ [`DataGridTextColumn.cs`](https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid/blob/master/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs)
 :::
 
 :::info
-View the source code on _GitHub_ [`DataGridCheckBoxColumn.cs`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls.DataGrid/DataGridCheckBoxColumn.cs)
+View the source code on _GitHub_ [`DataGridCheckBoxColumn.cs`](https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid/blob/master/src/Avalonia.Controls.DataGrid/DataGridCheckBoxColumn.cs)
 :::


### PR DESCRIPTION
DataGrid was removed from the main repository with this PR: https://github.com/AvaloniaUI/Avalonia/pull/18401

This PR updates the links from the docs to the new repository https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid
