### PR TITLE
Add packageSourceMapping examples to quickstart guides

### DIFF
--- a/accelerate/components/media-player/quickstart.md
+++ b/accelerate/components/media-player/quickstart.md
@@ -34,7 +34,15 @@ Avalonia Accelerate packages are distributed through a dedicated NuGet feed that
       <add key="ClearTextPassword" value="YOUR_LICENSE_KEY" />
     </avalonia-accelerate>
   </packageSourceCredentials>
-// highlight-end
+  <packageSourceMapping>
+     <packageSource key="api.nuget.org">
+        <package pattern="*" />
+     </packageSource>
+     <packageSource key="avalonia-accelerate">
+        <package pattern="Avalonia.Controls.MediaPlayer" />
+     </packageSource>
+  </packageSourceMapping>
+   // highlight-end
 </configuration>
 ```
 

--- a/accelerate/components/webview/quickstart.md
+++ b/accelerate/components/webview/quickstart.md
@@ -41,6 +41,14 @@ Avalonia Accelerate packages are distributed through a dedicated NuGet feed that
       <add key="ClearTextPassword" value="YOUR_LICENSE_KEY" />
     </avalonia-accelerate>
   </packageSourceCredentials>
+  <packageSourceMapping>
+     <packageSource key="api.nuget.org">
+        <package pattern="*" />
+     </packageSource>
+     <packageSource key="avalonia-accelerate">
+        <package pattern="Avalonia.Controls.WebView" />
+     </packageSource>
+  </packageSourceMapping> 
 // highlight-end
 </configuration>
 ```


### PR DESCRIPTION
Updated the media-player and webview quickstart documentation to include examples of packageSourceMapping.

Without the package source mapping, build tools can be confused about where to search for certain packages when central package management is used. Adding a package source mapping helps resolve any ambiguity and lets those tools build successfully.

I ran into this issue when using Cake to build using `dotnet cake`.

https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping#enabling-package-source-mapping