### PR TITLE
i18n: add zh translates

### DIFF
--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/faq.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/faq.md
@@ -4,7 +4,7 @@ title: 常见问题
 ---
 
 ## Avalonia是什么？
-Avalonia 是一个开源的跨平台 UI 框架。它是 [.NET 基金会](https://dotnetfoundation.org/) 的一部分，并被认为是其中最活跃的社区项目之一。它专为创建灵活且美观的用户界面而设计。Avalonia 支持多种应用程序开发平台，包括 Windows、Linux、macOS、iOS、Android 和 WebAssembly。
+Avalonia 是一个开源的跨平台 UI 框架。它是最受 .NET 开发人员欢迎的跨平台用户界面框架。它专为创建灵活美观的用户界面而设计。Avalonia 支持多种应用程序开发平台，包括 Windows、Linux、macOS、iOS、Android 和 WebAssembly。
 
 Avalonia 基于现代的 .NET 技术栈，允许开发人员使用 C# 或任何其他 .NET 语言编写代码，并使用 XAML 标记语言定义用户界面。类似于 WPF，Avalonia 使用基于 XAML 的样式系统，其布局系统和绑定基础设施模型为熟悉 XAML 框架的开发人员提供了一个熟悉的环境。
 
@@ -63,7 +63,9 @@ Avalonia的强大样式系统受到WPF和CSS的启发，使您能够打造美丽
 
 ## 是否有拖放式的可视化设计器？
 
-没有。Avalonia没有提供拖放式的设计器，而是支持实时预览功能。预览器会在您修改XAML时即时渲染UI。
+我们正在努力在2025年为Avalonia带来完整的拖放设计器体验。这个设计器将是[Avalonia Accelerate](https://github.com/AvaloniaUI/Avalonia/discussions/16997)的一部分，这是一个付费产品，旨在提高Avalonia生态系统中的开发者生产力。
+
+Avalonia Accelerate将通过可视化设计工具帮助开发者更高效地构建应用程序，这些工具将补充Avalonia所擅长的现有XAML优先方法。
 
 ---
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/overview/supported-platforms.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/overview/supported-platforms.md
@@ -1,0 +1,105 @@
+---
+id: supported-platforms
+title: 支持的平台
+---
+
+Avalonia 应用程序可以为以下平台编写：
+
+| 平台    | 支持情况 |
+|-------------|-----------|
+| `Windows`     | ✔️         |
+| `macOS `      | ✔️         |
+| `Linux`       | ✔️         |
+| `iOS`        | ✔️         |
+| `Android`     | ✔️         |
+| `WebAssembly` | ✔️         |
+
+## Windows
+
+* Windows 8.1
+* Windows 10
+* Windows 11
+
+虽然 Avalonia 应用程序可以在 Windows 7 上成功运行，但这个传统平台只获得有限的支持。我们不再为 Windows 7 特有的问题提供错误修复。
+
+## macOS
+
+* macOS 10.14 (Mojave)
+* macOS 10.15 (Catalina)
+* macOS 11 (Big Sur)
+* macOS 12 (Monterey)
+* macOS 13 (Ventura)
+* macOS 14 (Sonoma)
+* macOS 15 (Sequoia)
+
+Avalonia 也可以在 macOS 10.13 (High Sierra) 上运行，但我们正在迁移到 Metal GPU API，该 API 目前默认是禁用的。计划在某个小版本更新中启用它。
+
+:::important
+使用 Avalonia 可以在 Windows、macOS 和 Linux 上开发 macOS 应用程序。如果您计划签名和公证您的 macOS 应用程序以进行分发，您将需要一台安装了 XCode 的 Mac 设备。
+:::
+
+## Linux
+
+* Debian 9+
+* Ubuntu 16.04+
+* Fedora 30+
+
+Avalonia 在大多数支持 .NET SDK 并具有 X11 或帧缓冲功能的 Linux 发行版上运行良好。虽然我们官方支持 Debian 9+、Ubuntu 16.04+ 和 Fedora 30+，但许多其他发行版也可以无问题地运行 Avalonia 应用程序，我们积极努力确保广泛的 Linux 兼容性。
+
+对于拥有[支持协议](https://avaloniaui.net/support)的客户，我们提供扩展的 Linux 发行版覆盖范围，并可以协助满足特定的发行版需求。Wayland 支持目前处于私有预览阶段，并将在即将发布的版本中提供。
+
+WSL 2 发行版也受支持，但需要单独安装 `libice6`、`libsm6` 和 `libfontconfig1` 依赖项。
+
+:::info
+Skia 是基于 glibc 2.17 构建的。如果您的发行版使用其他版本，您需要在 [SkiaSharp](https://github.com/mono/SkiaSharp) 上自行构建 libSkiaSharp.so。您也可以访问 SkiaSharp 的主页以获取有关支持版本的更多信息。
+:::
+
+## iOS 
+
+* iOS 13
+* iOS 14
+* iOS 15
+* iOS 16
+* iOS 17
+* iOS 18
+
+:::note
+iOS 支持需要 .NET 7。
+:::
+
+## Android 
+
+| 名称                | 版本号 | API 级别 |
+|---------------------|---------|-----|
+| Android Lollipop    | 5.0     | 21  |
+| Android Lollipop    | 5.1     | 22  |
+| Android Marshmallow | 6.0     | 23  |
+| Android Nougat      | 7.0     | 24  |
+| Android Nougat      | 7.1     | 25  |
+| Android Oreo        | 8.0     | 26  |
+| Android Oreo        | 8.1     | 27  |
+| Android Pie         | 9       | 28  |
+| Android 10          | 10      | 29  |
+| Android 11          | 11      | 30  |
+| Android 12          | 12      | 31  |
+| Android 12L         | 12.1    | 32  |
+| Android 13          | 13      | 33  |
+| Android 14          | 14      | 34  |
+| Android 15          | 15      | 35  |
+| Android 16          | 16      | 36  |
+
+:::note
+Android 支持需要 .NET 7。
+:::
+
+## WebAssembly (浏览器)
+任何完全支持 WebAssembly 的浏览器都应该可以运行 - https://caniuse.com/wasm。
+
+为了获得最佳性能和支持，我们推荐使用最新版本的 Chrome 或 Safari。
+
+:::note
+浏览器支持需要 .NET 7。从 11.0.6 开始，我们推荐使用 .NET 8。
+:::
+
+## 其他平台支持
+Avalonia 还支持 Tizen 和 tvOS，但这是由社区提供的。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/overview/what-is-avalonia.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/overview/what-is-avalonia.md
@@ -1,0 +1,95 @@
+---
+id: what-is-avalonia
+title: 什么是 Avalonia?
+---
+
+import AvaloniaArchitecture from '/img/overview/Architecture.png';
+import MauiComparision from '/img/overview/MAUI-Comparision.png';
+
+Avalonia 是一个开源的跨平台 UI 框架，使开发者能够使用 .NET 为 Windows、macOS、Linux、iOS、Android 和 WebAssembly 创建应用程序。
+
+它使用自己的渲染引擎来绘制 UI 控件，确保在所有支持的平台上具有一致的外观和行为。这意味着开发者可以共享他们的 UI 代码，并且无论目标平台是什么，都能保持统一的外观和体验。
+
+<p><img className="image-zoom-medium" src={AvaloniaArchitecture} alt="" /></p>
+
+
+## Avalonia 适合谁？
+
+Avalonia 适合以下开发者：
+
+* 希望使用 XAML 和 C# 从单一共享代码库开发跨平台应用
+* 希望在多个平台上共享 UI、布局和设计
+* 希望跨平台共享代码、测试和业务逻辑
+
+
+## Avalonia 是如何工作的？
+Avalonia 通过一种独特的方法统一了桌面、移动和网页平台，这与传统的跨平台框架有所不同。Avalonia 并非包装原生 UI 控件，而是实现了自己的跨平台渲染引擎，确保在所有支持的平台上实现像素级的一致性。
+
+### 架构概述
+Avalonia 构建于 .NET Standard 2.0 之上，使其能够在任何支持 .NET 的平台上运行。该框架由几个关键层组成：
+
+#### 核心平台无关层
+Avalonia 的大部分功能都位于平台无关的核心层中，该层负责处理：
+
+* UI 控件和布局
+* 视觉树管理
+* 样式系统
+* 数据绑定
+* 输入处理
+* 动画框架
+
+这个核心层完全独立于平台，意味着无论在什么操作系统或设备上，它的行为都是相同的。
+
+#### 渲染引擎
+与依赖原生UI控件的框架不同，Avalonia使用自己的渲染引擎，由Skia或Direct2D提供支持。这种方法意味着：
+
+* 应用程序在所有平台上的外观和行为完全一致
+* 自定义控件和视觉效果只需实现一次，即可在所有平台上运行
+* 框架不受平台特定UI能力的限制
+
+#### 平台集成层
+Avalonia 只需少量特定于平台的代码即可与每个支持的平台集成。该层处理：
+
+* 窗口管理
+* 输入事件
+* 剪贴板操作
+* 原生对话框
+* 硬件加速
+* 平台特定功能
+
+#### 运行时环境
+Avalonia 应用程序运行在 .NET 运行时上，无论是 .NET Core 还是 Mono。
+
+#### 与原生方法的比较
+虽然像 .NET MAUI 这样的框架抽象了原生 UI 控件，但 Avalonia 采用了不同的方法：
+
+<p><img className="image-zoom-medium" src={MauiComparision} alt="" /></p>
+
+这种架构差异提供了几个优势：
+
+* 跨平台一致的行为
+* 像素级精确渲染
+* 对 UI 栈的完全控制
+* 简化的平台支持
+* 降低维护成本
+* 在资源受限设备上获得更好的性能
+
+### 与原生平台的集成
+
+虽然 Avalonia 使用自己的渲染引擎，但它仍然与原生平台功能无缝集成：
+
+* **Windows**：支持 Win32 API 和现代 Windows 功能
+* **Linux**：适用于 X11、Wayland 和帧缓冲区渲染
+* **macOS**：集成了 Cocoa 和平台服务
+* **移动设备**：提供原生生命周期管理和平台集成
+* **Web**：通过 WebAssembly 运行，完全集成浏览器功能
+
+### 平台支持要求
+本质上，Avalonia 只需要两项基本功能即可支持新平台：
+
+1. 能够在屏幕上绘制像素
+2. 能够接收输入事件
+
+这种最小需求集使 Avalonia 能够支持广泛的平台，从桌面操作系统到嵌入式设备，甚至是像 VNC 服务器这样的非常规平台。
+
+这种架构使 Avalonia 能够实现其“一份代码库，无限可能"的承诺，同时在最重要的地方保持高性能和原生平台集成。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/index.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/index.md
@@ -7,14 +7,14 @@ title: 示例和教程
 
 ## 待办事项列表应用
 
-这是一个简单的待办事项列表应用，使用了 Model-View-ViewModel (MVVM) 模式，并绑定到一个集合和 _Reactive UI_ 编程。您将会了解以下内容：
+一个使用模型-视图-视图模型（MVVM）模式的简单待办事项列表应用程序，通过绑定到集合，您将了解：
 
-* `RaiseAndSetIfChanged`
-* `ReactiveCommand`
-* `IObservable<>`
-* `Observable.Merge()` 与 `Select()`、`Take()` 和 `Subscribe()` 方法的使用。
+* 如何使用绑定(Bindings)
+* 如何使用命令(Commands)
+* 基本样式设置(Styling)
+* 一些非常基础的文件读写(I/O)操作
 
-这是一个非常好的 MVVM 和 _ReactiveUI_ 技术入门教程，特别适合用于 _Avalonia UI_ 编程。您可以在 [这里](https://github.com/AvaloniaUI/Avalonia.Samples/tree/main/src/Avalonia.Samples/CompleteApps/SimpleToDoList) 找到教程。
+这是一个推荐的很好的使用 MVVM 模式在 _Avalonia UI_ 下编程的教程。在[这里](https://github.com/AvaloniaUI/Avalonia.Samples/tree/main/src/Avalonia.Samples/CompleteApps/SimpleToDoList)查看教程。
 
 ## 音乐商店应用
 
@@ -28,4 +28,4 @@ title: 示例和教程
 
 该应用以 MVVM 模式呈现高度图形化的界面，并演示了如何显示对话框、展示图像和数据集合，并实现数据持久化。
 
-您可以在 [这里](music-store-app/) 查看这个演示。
+您可以在 [这里](./music-store-app/) 查看这个演示。


### PR DESCRIPTION
* Add the translations for `supported-platforms` and `what-is-avalonia`
* Updated translations for `faq` and `tutorials/index.md`