### PR TITLE
Updated documentation for NativeMenuItem to include better documentation for macOS

### DIFF
--- a/docs/reference/controls/nativemenu.md
+++ b/docs/reference/controls/nativemenu.md
@@ -128,6 +128,10 @@ The `Gesture` attribute is a `+`-delimited list of key modifiers following by a 
 Note that the menu item will not be enabled without either a code-behind `Click` event handler or a function bound using the `Command` attribute.
 :::
 
+:::info
+Note that on macOS, a menu bar-level `NativeMenuItem` with the header `Edit` will include some additional macOS features by default.
+:::
+
 ## Example
 
 This example defines a native menu that can be attached to a tray icon:

--- a/docs/reference/controls/nativemenu.md
+++ b/docs/reference/controls/nativemenu.md
@@ -120,6 +120,10 @@ public void CopyCommand() { }
 public void PasteCommand() { }
 ```
 
+### Gesture Format
+
+The `Gesture` attribute is a `+`-delimited list of key modifiers following by a `+`, then followed by a single key character (which itself may be `+`). Permissible modifiers include `Alt`, `Control`, `Shift`, and `Meta`. If the `Gesture` attribute is the empty string or contains only a single key character, no exception will be thrown but the gesture will not activate the menu item. If a key modifier is provided without a key, or if the attribute value isn't formatted correctly, an `ArgumentException` will be thrown. For more details, see the source code for [`KeyGesture`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Base/Input/KeyGesture.cs), [`Key`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Base/Input/Key.cs), and [`KeyModifier`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Base/Input/IKeyboardDevice.cs).
+
 :::info
 Note that the menu item will not be enabled without either a code-behind `Click` event handler or a function bound using the `Command` attribute.
 :::

--- a/docs/reference/controls/nativemenu.md
+++ b/docs/reference/controls/nativemenu.md
@@ -34,7 +34,9 @@ You will probably use these properties most often:
 
 This example modifies the default application menu in macOS.
 
- > **_NOTE:_** Changing the application's `Name` property will cause the application menu header to change. In this example, it is set to *Sample Application*.
+:::info
+Changing the application's `Name` property will cause the application menu header to change. In this example, it is set to *Sample Application*.
+:::
 
 ```xml
 <Application xmlns="https://github.com/avaloniaui"
@@ -116,7 +118,9 @@ public void CopyCommand() { }
 public void PasteCommand() { }
 ```
 
- > **_NOTE:_** Note that the menu item will not be enabled without either a code-behind `Click` event handler or a function bound using the `Command` attribute.
+:::info
+Note that the menu item will not be enabled without either a code-behind `Click` event handler or a function bound using the `Command` attribute.
+:::
 
 ## Example
 

--- a/docs/reference/controls/nativemenu.md
+++ b/docs/reference/controls/nativemenu.md
@@ -7,10 +7,6 @@ description: REFERENCE - Built-in Controls
 
 The `NativeMenu` can display a menu on _macOS_ and some Linux distributions.
 
-:::warning
-This control can only be used attached to a tray icon. For full details about the tray icon, see the reference [here](./tray-icon.md).
-:::
-
 You can create sub-menus by nesting `<MenuItem>` elements.
 
 You can add menu separator lines by including a `<NativeMenuItemSeparator>` element or by adding a menu item with its header set to the minus sign, like this:
@@ -23,7 +19,104 @@ You can add menu separator lines by including a `<NativeMenuItemSeparator>` elem
 
 You will probably use these properties most often:
 
-<table><thead><tr><th width="204">Property</th><th>Description</th></tr></thead><tbody><tr><td><code>Header</code></td><td>The menu caption.</td></tr><tr><td><code>Command</code></td><td>A command to execute when the user clicks the menu item.</td></tr></tbody></table>
+<table>
+  <thead>
+    <tr><th width="204">Property</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>Header</code></td><td>The menu caption.</td></tr>
+    <tr><td><code>Command</code></td><td>A command to execute when the user clicks the menu item.</td></tr>
+    <tr><td><code>Gesture</code></td><td>The keyboard shortcut to associated with the menu item.</td></tr>
+  </tbody>
+</table>
+
+## Example
+
+This example modifies the default application menu in macOS.
+
+ > **_NOTE:_** Changing the application's `Name` property will cause the application menu header to change. In this example, it is set to *Sample Application*.
+
+```xml
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="NativeMenuTest.App"
+             xmlns:local="using:NativeMenuTest"
+             RequestedThemeVariant="Default"
+             Name="Sample Application">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.DataTemplates>
+        <local:ViewLocator/>
+    </Application.DataTemplates>
+
+    <NativeMenu.Menu>
+        <NativeMenu>
+            <NativeMenuItem Header="About This Application…" Click="AppAbout_OnClick" />
+            <NativeMenuItem Header="Preferences…" Click="AppPreferences_OnClick" />
+        </NativeMenu>
+    </NativeMenu.Menu>
+  
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>
+```
+
+You will also have to add the appropriate event handlers in the code-behind.
+
+```C#
+private void AppAbout_OnClick(object? sender, System.EventArgs args) {
+
+}
+
+private void AppPreferences_OnClick(object? sender, System.EventArgs args) {
+    
+}
+```
+
+## Example
+
+This example adds a *File* menu and an *Edit* menu. For context regarding where in the XAML the `NativeMenu.Menu` element should go, other XML tags are included but are missing attributes necessary for the application to function for brevity.
+
+```Xml
+<Window>
+    <Design.DataContext />
+
+    <NativeMenu.Menu>
+        <NativeMenu>
+            <NativeMenuItem Header="File" IsVisible="true">
+                <NativeMenu>                    
+                    <NativeMenuItem Header="Open…" Click="FileOpen_OnClick" Gesture="Meta+O" />
+                    <NativeMenuItem Header="Save As…" Click="FileSaveAs_OnClick" Gesture="Meta+Shift+S" />
+                    <NativeMenuItem Header="Save As…" Click="FileSaveAs_OnClick" Gesture="Meta+A" />
+                </NativeMenu>
+            </NativeMenuItem>
+            <NativeMenuItem Header="Edit" IsEnabled="true">
+                <NativeMenu>                    
+                    <NativeMenuItem Header="Cut" Command="{Binding CutCommand}" Gesture="Meta-X" />
+                    <NativeMenuItem Header="Copy" Command="{Binding CopyCommand}" Gesture="Meta-C" />
+                    <NativeMenuItem Header="Past" Command="{Binding PasteCommand}" Gesture="Meta-V" />
+                </NativeMenu>
+            </NativeMenuItem>
+        </NativeMenu>
+    </NativeMenu.Menu>
+
+    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+
+</Window>
+```
+
+In the view-model, you would then add the command functions:
+
+```C#
+public void CutCommand() { }
+
+public void CopyCommand() { }
+
+public void PasteCommand() { }
+```
+
+ > **_NOTE:_** Note that the menu item will not be enabled without either a code-behind `Click` event handler or a function bound using the `Command` attribute.
 
 ## Example
 

--- a/docs/reference/controls/nativemenu.md
+++ b/docs/reference/controls/nativemenu.md
@@ -38,6 +38,8 @@ This example modifies the default application menu in macOS.
 Changing the application's `Name` property will cause the application menu header to change. In this example, it is set to *Sample Application*.
 :::
 
+![image](https://github.com/user-attachments/assets/d30bab47-f133-4f79-9bdb-d4fb4569ed61)
+
 ```xml
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/docs/reference/controls/nativemenu.md
+++ b/docs/reference/controls/nativemenu.md
@@ -94,10 +94,10 @@ This example adds a *File* menu and an *Edit* menu. For context regarding where 
                 </NativeMenu>
             </NativeMenuItem>
             <NativeMenuItem Header="Edit" IsEnabled="true">
-                <NativeMenu>                    
-                    <NativeMenuItem Header="Cut" Command="{Binding CutCommand}" Gesture="Meta-X" />
-                    <NativeMenuItem Header="Copy" Command="{Binding CopyCommand}" Gesture="Meta-C" />
-                    <NativeMenuItem Header="Past" Command="{Binding PasteCommand}" Gesture="Meta-V" />
+                <NativeMenu>
+                    <NativeMenuItem Header="Cut" Command="{Binding CutCommand}" Gesture="Meta+X" />
+                    <NativeMenuItem Header="Copy" Command="{Binding CopyCommand}" Gesture="Meta+C" />
+                    <NativeMenuItem Header="Past" Command="{Binding PasteCommand}" Gesture="Meta+V" />
                 </NativeMenu>
             </NativeMenuItem>
         </NativeMenu>


### PR DESCRIPTION
Updated documentation for `NativeMenuItem` to include better documentation for macOS with specific examples that can be copy-pasted into an existing application for:

1. The "application" menu.
2. Other menus.
3. Event handlers and bound commands.
4. Gestures.

The existing documentation was left in place.