### PR TITLE
Remove package mapping in Media Player quickstart doc

### DIFF
--- a/accelerate/components/media-player/quickstart.md
+++ b/accelerate/components/media-player/quickstart.md
@@ -34,14 +34,6 @@ Avalonia Accelerate packages are distributed through a dedicated NuGet feed that
       <add key="ClearTextPassword" value="YOUR_LICENSE_KEY" />
     </avalonia-accelerate>
   </packageSourceCredentials>
-  <packageSourceMapping>
-     <packageSource key="api.nuget.org">
-        <package pattern="*" />
-     </packageSource>
-     <packageSource key="avalonia-accelerate">
-        <package pattern="*" />
-     </packageSource>
-  </packageSourceMapping>
    // highlight-end
 </configuration>
 ```

--- a/accelerate/components/media-player/quickstart.md
+++ b/accelerate/components/media-player/quickstart.md
@@ -39,7 +39,7 @@ Avalonia Accelerate packages are distributed through a dedicated NuGet feed that
         <package pattern="*" />
      </packageSource>
      <packageSource key="avalonia-accelerate">
-        <package pattern="Avalonia.Controls.MediaPlayer" />
+        <package pattern="*" />
      </packageSource>
   </packageSourceMapping>
    // highlight-end


### PR DESCRIPTION
A customer encountered this issue, since the main package has dependencies on the feed and the filter only allowed for the main package's name. 

Remove package mapping altogether since it's not really necessary for the quick start doc.