### PR TITLE
Fix minor typo in How to Use Included Styles docs

### DIFF
--- a/docs/guides/styles-and-resources/how-to-use-included-styles.md
+++ b/docs/guides/styles-and-resources/how-to-use-included-styles.md
@@ -60,7 +60,7 @@ However, it is more common to reference a styles file in the `App.axaml` file li
 
 This will allow you to use the styles from the separate file throughout your application.
 
-You can also include styles from a another assembly by using the `avares://` prefix:
+You can also include styles from another assembly by using the `avares://` prefix:
 
 ```xml
 <Application... > 


### PR DESCRIPTION
Original sentence:

> You can also include styles from a another assembly by using the `avares://` prefix:

Corrected:

> You can also include styles from another assembly by using the `avares://` prefix:

The 'a' article is unnecessary in this phrase.