### PR TITLE
Fix: point dead link to new location

### DIFF
--- a/docs/basics/data/data-binding/index.md
+++ b/docs/basics/data/data-binding/index.md
@@ -37,7 +37,7 @@ Bindings can be unidirectional: where changes in the properties of a bound appli
 Binding is used with the MVVM architectural pattern, and this is one of the principle ways of programming with Avalonia UI.
 
 :::info
-For more information about how to use the MVVM Pattern with Avalonia, see the concept page [here](../../concepts/the-mvvm-pattern).
+For more information about how to use the MVVM Pattern with Avalonia, see the concept page [here](../../../concepts/the-mvvm-pattern).
 :::
 
 :::info


### PR DESCRIPTION
Link seemed to point to an old location, just points it to the current location