### PR TITLE
Show last updated date and author

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,6 +101,8 @@ const config = {
           // Remove this to remove the "edit this page" links.
           editUrl: 'https://github.com/AvaloniaUI/avalonia-docs/tree/main',
           editLocalizedFiles: true,
+          showLastUpdateAuthor: true,
+          showLastUpdateTime: true,
           lastVersion: 'current',
           versions: {
             current: {


### PR DESCRIPTION
This change gets Docusaurus to display the last updated date and last updated author on each doc. It would make it easier for viewers to quickly tell how up-to-date the doc is, without needing to go into the repo to check the version history of the source file.