### PR TITLE
Updated styles-and-resources/troubleshooting.md

### DIFF
--- a/docs/guides/styles-and-resources/troubleshooting.md
+++ b/docs/guides/styles-and-resources/troubleshooting.md
@@ -26,14 +26,14 @@ Styles are applied in order of declaration. If there are multiple style files in
 
 ```xml
 <Style Selector="TextBlock.header">
-    <Style Property="Foreground" Value="Green" />
+    <Setter Property="Foreground" Value="Green" />
 </Style>
 ```
 
 ```xml
 <Style Selector="TextBlock.header">
-    <Style Property="Foreground" Value="Blue" />
-    <Style Property="FontSize" Value="16" />
+    <Setter Property="Foreground" Value="Blue" />
+    <Setter Property="FontSize" Value="16" />
 </Style>
 ```
 
@@ -58,7 +58,14 @@ A local value defined directly on a control often has higher priority than any s
 
 You can see the full list of value priorities in the `BindingPriority` enum, where lower enum values have the higher priority.
 
-<table><thead><tr><th width="218">BindingPriority </th><th width="147.33333333333331">Value</th><th>Comment</th></tr></thead><tbody><tr><td><code>Animation</code></td><td>-1</td><td>The highest priority - even overrides a local value</td></tr><tr><td><code>LocalValue</code></td><td>0</td><td>A local value is set on the property of the control.</td></tr><tr><td><code>StyleTrigger</code></td><td>1</td><td>This is triggered when a pseudo class becomes active.</td></tr><tr><td><code>TemplatedParent</code></td><td>2</td><td></td></tr><tr><td><code>Style</code></td><td>3</td><td></td></tr><tr><td><code>Unset</code></td><td>2147483647</td><td></td></tr></tbody></table>
+| BindingPriority | Value      | Comment                                              |
+|-----------------|------------|------------------------------------------------------|
+| Animation       | -1         | The highest priority - even overrides a local value  |
+| LocalValue      | 0          | A local value is set on the property of the control. |
+| StyleTrigger    | 1          | This is triggered when a style becomes active.       |
+| Template        | 2          |                                                      |
+| Style           | 3          |                                                      |
+| Unset           | 2147483647 |                                                      |
 
 :::warning
 The exception is that `Animation` values have the highest priority and can even override local values.
@@ -104,7 +111,7 @@ The following code example of styles that can be expected to work on top of defa
 
 You might expect the `Button` to be red by default and blue when pointer is over it. In fact, only setter of first style will be applied, and second one will be ignored.
 
-The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code (old [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) theme and new [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
+The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code ([Simple](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Simple/Controls/Button.xaml) theme and [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
 
 ```xml
 <Style Selector="Button">
@@ -132,7 +139,7 @@ The actual background is rendered by a `ContentPresenter`, which in the default 
 ```
 
 :::info
-You can see this behavior for all controls in the default themes (both old Default and the new Fluent), not just Button. And not just for Background, but also other state-dependent properties.
+You can see this behavior for all controls in the default themes (both Simple and Fluent), not just Button. And not just for Background, but also other state-dependent properties.
 :::
 
 :::info

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/styles-and-resources/troubleshooting.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/styles-and-resources/troubleshooting.md
@@ -26,14 +26,14 @@ Styles are applied in order of declaration. If there are multiple style files in
 
 ```xml
 <Style Selector="TextBlock.header">
-    <Style Property="Foreground" Value="Green" />
+    <Setter Property="Foreground" Value="Green" />
 </Style>
 ```
 
 ```xml
 <Style Selector="TextBlock.header">
-    <Style Property="Foreground" Value="Blue" />
-    <Style Property="FontSize" Value="16" />
+    <Setter Property="Foreground" Value="Blue" />
+    <Setter Property="FontSize" Value="16" />
 </Style>
 ```
 
@@ -58,7 +58,14 @@ A local value defined directly on a control often has higher priority than any s
 
 You can see the full list of value priorities in the `BindingPriority` enum, where lower enum values have the higher priority.
 
-<table><thead><tr><th width="218">BindingPriority </th><th width="147.33333333333331">Value</th><th>Comment</th></tr></thead><tbody><tr><td><code>Animation</code></td><td>-1</td><td>The highest priority - even overrides a local value</td></tr><tr><td><code>LocalValue</code></td><td>0</td><td>A local value is set on the property of the control.</td></tr><tr><td><code>StyleTrigger</code></td><td>1</td><td>This is triggered when a pseudo class becomes active.</td></tr><tr><td><code>TemplatedParent</code></td><td>2</td><td></td></tr><tr><td><code>Style</code></td><td>3</td><td></td></tr><tr><td><code>Unset</code></td><td>2147483647</td><td></td></tr></tbody></table>
+| BindingPriority | Value      | Comment                                              |
+|-----------------|------------|------------------------------------------------------|
+| Animation       | -1         | The highest priority - even overrides a local value  |
+| LocalValue      | 0          | A local value is set on the property of the control. |
+| StyleTrigger    | 1          | This is triggered when a style becomes active.       |
+| Template        | 2          |                                                      |
+| Style           | 3          |                                                      |
+| Unset           | 2147483647 |                                                      |
 
 :::warning
 The exception is that `Animation` values have the highest priority and can even override local values.
@@ -104,7 +111,7 @@ The following code example of styles that can be expected to work on top of defa
 
 You might expect the `Button` to be red by default and blue when pointer is over it. In fact, only setter of first style will be applied, and second one will be ignored.
 
-The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code (old [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) theme and new [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
+The reason is hidden in the Button's template. You can find the default templates in the Avalonia source code ([Simple](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Simple/Controls/Button.xaml) theme and [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) theme), but for convenience here we have simplified one from the Fluent theme:
 
 ```xml
 <Style Selector="Button">
@@ -132,7 +139,7 @@ The actual background is rendered by a `ContentPresenter`, which in the default 
 ```
 
 :::info
-You can see this behavior for all controls in the default themes (both old Default and the new Fluent), not just Button. And not just for Background, but also other state-dependent properties.
+You can see this behavior for all controls in the default themes (both Simple and Fluent), not just Button. And not just for Background, but also other state-dependent properties.
 :::
 
 :::info

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/styles-and-resources/troubleshooting.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/styles-and-resources/troubleshooting.md
@@ -1,39 +1,39 @@
 ---
 id: troubleshooting
-title: 如何解决样式问题
+title: 如何排查样式问题
 ---
 
 
-# 👉 如何解决样式问题
+# 👉 如何排查样式问题
 
-大部分 _Avalonia UI_ 的样式系统与 CSS 样式方法相对应。如果您对这项技术不了解，您可能会发现以下提示有所帮助。
+Avalonia UI 的样式系统在很多方面与 CSS 样式类似。如果您不熟悉相关技术，以下提示可能会对您有所帮助。
 
-## 选择器没有目标
+## 选择器没有匹配目标
 
-_Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控件时不会引发错误或警告。样式将静默失败。
+Avalonia UI 的选择器与 CSS 选择器类似，当没有控件被匹配时，不会报错或警告，样式会默认失效。
 
 :::info
-检查是否使用了不存在的名称或类。
+请检查是否使用了不存在的名称或类。
 :::
 
 :::info
-检查是否使用了子选择器，而没有匹配的子控件。
+请检查是否使用了子选择器，但没有对应的子控件可匹配。
 :::
 
-## 包含文件的顺序
+## 声明文件的顺序
 
-样式按照声明的顺序应用。如果有多个包含了针对相同控件属性的样式文件，则最后一个包含的样式将覆盖之前的样式。例如：
+样式会按照声明顺序应用。如果有多个样式匹配到同一控件属性，最后声明的样式会覆盖之前的。例如：
 
 ```xml
 <Style Selector="TextBlock.header">
-    <Style Property="Foreground" Value="Green" />
+    <Setter Property="Foreground" Value="Green" />
 </Style>
 ```
 
 ```xml
 <Style Selector="TextBlock.header">
-    <Style Property="Foreground" Value="Blue" />
-    <Style Property="FontSize" Value="16" />
+    <Setter Property="Foreground" Value="Blue" />
+    <Setter Property="FontSize" Value="16" />
 </Style>
 ```
 
@@ -42,11 +42,11 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 <StyleInclude Source="Style2.axaml" />
 ```
 
-在这个例子中，首先应用了来自文件 **Styles1.axaml** 的样式，所以文件 **Styles2.axaml** 中的样式设置会覆盖之前的样式。最终的 TextBlock 将具有 FontSize="16" 和 Foreground="Green"。在样式文件内部也会发生相同的优先级排序。
+在此例中，**Style1.axaml** 的样式会先应用，**Style2.axaml** 的样式会覆盖前者。最终 TextBlock 生效的是 FontSize="16" 和 Foreground="Blue"。在样式文件内部也是同样的优先级规则。
 
-## 本地设置的属性具有优先级
+## 本地设置的属性值优先级更高
 
-直接在控件上定义的本地值通常比任何样式值具有更高的优先级。因此，在这个例子中，文本块的前景色将是红色的：
+直接在控件上设置的本地值通常优先于样式值。例如，以下代码中 TextBlock 的前景色为红色：
 
 ```xml
 <Style Selector="TextBlock.header">
@@ -56,21 +56,28 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 <TextBlock Classes="header" Foreground="Red" />
 ```
 
-您可以在 `BindingPriority` 枚举中看到完整的值优先级列表，较低的枚举值具有较高的优先级。
+完整的优先级表可以参考 `BindingPriority` 枚举，枚举值越小，优先级越高：
 
-<table><thead><tr><th width="218">绑定优先级 </th><th width="147.33333333333331">值</th><th>说明</th></tr></thead><tbody><tr><td><code>Animation</code></td><td>-1</td><td>最高优先级——甚至可以覆盖本地值</td></tr><tr><td><code>LocalValue</code></td><td>0</td><td>在控件的属性上设置了本地值。</td></tr><tr><td><code>StyleTrigger</code></td><td>1</td><td>当伪类变为活动状态时触发。</td></tr><tr><td><code>TemplatedParent</code></td><td>2</td><td></td></tr><tr><td><code>Style</code></td><td>3</td><td></td></tr><tr><td><code>Unset</code></td><td>2147483647</td><td></td></tr></tbody></table>
+| BindingPriority | 值          | 说明                |
+|-----------------|------------|-------------------|
+| Animation       | -1         | 最高优先级 - 可覆盖本地值 |
+| LocalValue      | 0          | 控件属性上的本地值       |
+| StyleTrigger    | 1          | 样式激活时触发      |
+| Template        | 2          |                   |
+| Style           | 3          |                   |
+| Unset           | 2147483647 |                   |
 
 :::warning
-例外情况是 `Animation` 值具有最高优先级，甚至可以覆盖本地值。
+例外情况：`Animation` 优先级最高，甚至可以覆盖本地值。
 :::
 
 :::info
-一些默认的 _Avalonia UI_ 样式在其模板中使用本地值而不是模板绑定或样式设置。这使得在不替换整个模板的情况下无法更新模板属性。
+部分默认 Avalonia UI 样式在模板中使用本地值而非模板绑定或样式设置，这会导致无法仅通过样式更新模板属性，需替换整个模板。
 :::
 
-### 缺失的样式伪类（触发器）选择器
+### 缺少伪类（激活）选择器
 
-假设有一种情况，您希望第二个样式覆盖前一个样式，但实际上并没有覆盖：
+假设您希望第二个样式覆盖第一个样式，但实际并未生效：
 
 ```xml
 <Style Selector="Border:pointerover">
@@ -83,15 +90,15 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 <Border Width="100" Height="100" Margin="100" />
 ```
 
-在这个代码示例中，`Border` 正常情况下具有红色背景，当鼠标指针悬停在上面时具有蓝色背景。这是因为与 CSS 一样，更具体的选择器具有优先权。当您希望使用一个单独的样式覆盖任何状态（例如 pointerover、pressed 或其他状态）的默认样式时，这可能会成为问题。为了实现这一点，您需要为这些状态创建新的样式。
+在此示例中，Border 背景色默认是红色，悬停时是蓝色。原因是和CSS一样，更具体的选择器优先级更高。如果想用单一样式覆盖所有状态（如 pointerover、pressed 等），需要为这些状态分别创建样式。
 
 :::info
-访问 Avalonia 源代码以找到当出现这种情况时的[原始模板](https://github.com/AvaloniaUI/Avalonia/tree/master/src/Avalonia.Themes.Fluent/Controls)，并将带有伪类的样式复制粘贴到您的代码中。
+可以访问 Avalonia 源码，查找[原始模板](https://github.com/AvaloniaUI/Avalonia/tree/master/src/Avalonia.Themes.Fluent/Controls)，并将带伪类的样式复制到您的代码中。
 :::
 
-### 具有伪类的选择器不覆盖默认样式
+### 伪类选择器无法覆盖默认样式
 
-以下代码示例中的样式应该在默认样式之上起作用：
+下面的样式代码示例，按理说应该可以在默认样式的基础上生效：
 
 ```xml
 <Style Selector="Button">
@@ -102,9 +109,9 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 </Style>
 ```
 
-您可能期望 `Button` 在默认情况下是红色的，当鼠标指针悬停在上面时是蓝色的。实际上，只有第一个样式的 setter 将被应用，第二个将被忽略。
+您可能认为 Button 的背景色默认是红色，悬停时是蓝色。实际上，只有第一个样式的 setter 会生效，第二个会被忽略。
 
-原因在于 Button 的模板中。您可以在 Avalonia 源代码中找到默认模板（旧版 [Default](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Default/Button.xaml) 主题和新版 [Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) 主题），但为了方便起见，我们在此处简化了来自 Fluent 主题的模板：
+原因藏在 Button 的模板中。您可以在 Avalonia 源代码中找到默认模板（[Simple](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Simple/Controls/Button.xaml) 主题和（[Fluent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/Button.xaml) 主题）。但是为了便利，这里提供了一个简化的 Fluent 主题示例：
 
 ```xml
 <Style Selector="Button">
@@ -122,27 +129,27 @@ _Avalonia UI_ 的选择器，就像 CSS 选择器一样，当没有匹配的控�
 </Style>
 ```
 
-实际背景是由 `ContentPresenter` 渲染的，在默认情况下它与按钮的 `Background` 属性绑定。然而，在 pointerover 状态下，选择器直接将背景应用于 `ContentPresenter (Button:pointerover /template/ ContentPresenter#PART_ContentPresenter)`。这就是为什么在前一个代码示例中我们的 setter 被忽略的原因。修正后的代码应该直接针对 content presenter：
+实际的背景是由 ContentPresenter 渲染的，默认情况下它绑定到 Button 的 Background 属性。然而在 pointerover 状态时，选择器会直接将背景应用到 ContentPresenter（即 Button:pointerover /template/ ContentPresenter#PART_ContentPresenter）。这就是为什么前面示例中的 setter 被忽略了。正确的做法是直接针对 ContentPresenter 设置样式。
 
 ```xml
-<!-- 这里的 #PART_ContentPresenter 名称选择器不是必需的，但为了具有更具体的样式而添加 -->
+<!-- 这里的 #PART_ContentPresenter 名称选择器其实不是必须的，但添加它可以让样式选择器更具体、优先级更高。 -->
 <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Blue" />
 </Style>
 ```
 
 :::info
-您可以在默认主题（包括旧版 Default 和新版 Fluent）中看到所有控件的这种行为，不仅限于 Button。而且不仅限于 Background，还包括其他依赖于状态的属性。
+你可以在所有控件的默认主题（包括 Simple 和 Fluent）中看到这种写法，不仅仅是 Button，也不仅限于 Background 属性，其他依赖状态的属性同样如此。
 :::
 
 :::info
-为什么默认样式直接更改 `ContentPresenter` 的 `Background` 属性而不是更改 `Button.Background` 属性？
+为什么默认样式会直接修改 ContentPresenter 的 `Background` 属性，而不是修改 `Button.Background` 属性？
 
-这是因为如果用户在按钮上设置了本地值，它将覆盖所有样式，并使按钮始终具有相同的颜色。有关更多详情，请参见 [撤销的 PR](https://github.com/AvaloniaUI/Avalonia/pull/2662#issuecomment-515764732).
+这是因为如果用户在按钮上设置了本地值，这个本地值会覆盖所有样式，使按钮始终显示为同一种颜色。更多详情请浏览这个[回退的 PR](https://github.com/AvaloniaUI/Avalonia/pull/2662#issuecomment-515764732)。
 :::
 
-### 当样式不再应用时，特定属性的先前值不会恢复
+### 样式失效时属性值不会恢复
 
-在 Avalonia 中，我们有多种类型的属性，其中之一是直接属性（Direct Property），它根本不支持样式。这些属性以简化的方式工作，以实现较低的开销和更高的性能，并且不存储多个依赖于优先级的值。而是只保存最新的值，无法恢复之前的值。您可以在 [此处](../custom-controls/defining-properties) 找到有关属性的更多详情。
+Avalonia 有多种属性类型，其中 DirectProperty（直接属性）不支持样式。此类属性为了提升性能，仅保存最新值，不会根据优先级存储多个值，因此无法恢复之前的值。更多属性详情见[此处](../custom-controls/defining-properties)。
 
-典型的例子是 [CommandProperty](https://api-docs.avaloniaui.net/docs/P_Avalonia_Controls_Button_Command)。它被定义为直接属性，因此它永远不会正常工作。将来，尝试为直接属性设置样式将导致编译时错误，详见 [#6837](https://github.com/AvaloniaUI/Avalonia/issues/6837)。
+典型例子如 [CommandProperty](https://api-docs.avaloniaui.net/docs/P_Avalonia_Controls_Button_Command)，它是直接属性，无法通过样式正常工作。在未来，为直接属性设置样式会导致编译错误，详见 [#6837](https://github.com/AvaloniaUI/Avalonia/issues/6837)。


### PR DESCRIPTION
This pull request updates troubleshooting documentation for Avalonia UI styles in English, Russian, and Simplified Chinese. The main changes clarify style application, update terminology, improve code samples, and enhance explanations of style priority and theme references.

**Documentation improvements:**

* Updated all XML style examples to use the correct `Setter` syntax instead of `Style Property` for consistency and clarity in both English and Russian docs.
* Replaced legacy HTML tables with markdown tables for the `BindingPriority` enum, corrected terminology (e.g., "Template" instead of "TemplatedParent"), and clarified comments in all languages. [[1]](diffhunk://#diff-fbd4f840aa90cb30d7b38a2dde99caec64fd2174a6f488f868ea3d4ba22d026eL61-R68) [[2]](diffhunk://#diff-15f3cd6adbd6c0e7b82e884b53af20df1dbc47193fda0b58cd8450fa8e7306dcL59-R80)

**Explanations and terminology:**

* Improved descriptions and terminology in the Simplified Chinese guide, making explanations more accurate and easier to understand (e.g., clarifying style precedence, selector matching, and priority rules). [[1]](diffhunk://#diff-15f3cd6adbd6c0e7b82e884b53af20df1dbc47193fda0b58cd8450fa8e7306dcL3-R36) [[2]](diffhunk://#diff-15f3cd6adbd6c0e7b82e884b53af20df1dbc47193fda0b58cd8450fa8e7306dcL45-R49)
* Updated theme references from "Default" to "Simple" where appropriate, and clarified which themes the examples refer to in English, Russian, and Chinese docs. [[1]](diffhunk://#diff-fbd4f840aa90cb30d7b38a2dde99caec64fd2174a6f488f868ea3d4ba22d026eL107-R114) [[2]](diffhunk://#diff-fbd4f840aa90cb30d7b38a2dde99caec64fd2174a6f488f868ea3d4ba22d026eL135-R142) [[3]](diffhunk://#diff-15f3cd6adbd6c0e7b82e884b53af20df1dbc47193fda0b58cd8450fa8e7306dcL105-R114) [[4]](diffhunk://#diff-15f3cd6adbd6c0e7b82e884b53af20df1dbc47193fda0b58cd8450fa8e7306dcL125-R155)

**Clarifications on style application:**

* Enhanced explanations about why certain style setters may be ignored due to template behavior, and how to correctly target elements like `ContentPresenter` for state-dependent styling. [[1]](diffhunk://#diff-15f3cd6adbd6c0e7b82e884b53af20df1dbc47193fda0b58cd8450fa8e7306dcL86-R101) [[2]](diffhunk://#diff-15f3cd6adbd6c0e7b82e884b53af20df1dbc47193fda0b58cd8450fa8e7306dcL105-R114) [[3]](diffhunk://#diff-15f3cd6adbd6c0e7b82e884b53af20df1dbc47193fda0b58cd8450fa8e7306dcL125-R155)

These changes improve clarity, consistency, and accuracy in the troubleshooting guides for Avalonia UI styles.