### PR TITLE
Fixed outdated font binding examples.

### DIFF
--- a/docs/reference/controls/combobox.md
+++ b/docs/reference/controls/combobox.md
@@ -89,28 +89,18 @@ This example uses a composed view for each item:
 This example binds the items in a combo box using a data template. The C# code-behind loads the installed font family names and binds them to the items property.
 
 ```xml
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="using:TmpAvaloniaApp"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        x:Class="TmpAvaloniaApp.MainWindow"
-        x:DataType="local:MainWindow"
-        Title="TmpAvaloniaApp">
-  <StackPanel Margin="20">
-    <ComboBox x:Name="fontComboBox" SelectedIndex="0"
-              Width="200" MaxDropDownHeight="300"
-              ItemsSource="{Binding FontFamilies}"
-              SelectedValue="{Binding SelectedFont}">
-      <ComboBox.ItemTemplate>
-        <DataTemplate>
-          <TextBlock Text="{Binding Name}" FontFamily="{Binding}" />
-        </DataTemplate>
-      </ComboBox.ItemTemplate>
-    </ComboBox>
-  </StackPanel>
-</Window>
+<StackPanel Margin="20">
+  <ComboBox x:Name="fontComboBox" SelectedIndex="0"
+            Width="200" MaxDropDownHeight="300"
+            ItemsSource="{Binding FontFamilies}"
+            SelectedValue="{Binding SelectedFont}">
+    <ComboBox.ItemTemplate>
+      <DataTemplate>
+        <TextBlock Text="{Binding Name}" FontFamily="{Binding}" />
+      </DataTemplate>
+    </ComboBox.ItemTemplate>
+  </ComboBox>
+</StackPanel>
 ```
 
 ```csharp title='C#'

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/combobox.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/controls/combobox.md
@@ -87,28 +87,18 @@ This example uses a composed view for each item:
 This example binds the items in a combo box using a data template. The C# code-behind loads the installed font family names and binds them to the items property.
 
 ```xml
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="using:TmpAvaloniaApp"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        x:Class="TmpAvaloniaApp.MainWindow"
-        x:DataType="local:MainWindow"
-        Title="TmpAvaloniaApp">
-  <StackPanel Margin="20">
-    <ComboBox x:Name="fontComboBox" SelectedIndex="0"
-              Width="200" MaxDropDownHeight="300"
-              ItemsSource="{Binding FontFamilies}"
-              SelectedValue="{Binding SelectedFont}">
-      <ComboBox.ItemTemplate>
-        <DataTemplate>
-          <TextBlock Text="{Binding Name}" FontFamily="{Binding}" />
-        </DataTemplate>
-      </ComboBox.ItemTemplate>
-    </ComboBox>
-  </StackPanel>
-</Window>
+<StackPanel Margin="20">
+  <ComboBox x:Name="fontComboBox" SelectedIndex="0"
+            Width="200" MaxDropDownHeight="300"
+            ItemsSource="{Binding FontFamilies}"
+            SelectedValue="{Binding SelectedFont}">
+    <ComboBox.ItemTemplate>
+      <DataTemplate>
+        <TextBlock Text="{Binding Name}" FontFamily="{Binding}" />
+      </DataTemplate>
+    </ComboBox.ItemTemplate>
+  </ComboBox>
+</StackPanel>
 ```
 
 ```csharp title='C#'

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/combobox.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/controls/combobox.md
@@ -88,28 +88,18 @@ import ComboBoxDataTemplateScreenshot from '/img/reference/controls/combobox/com
 这个示例使用数据模板绑定了组合框中的每一个元素。在 c# code-behind 代码中，我们将加载系统中安装的字体家族名称，并将它们绑定到 ComboBox 的 Items 属性。
 
 ```xml
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="using:TmpAvaloniaApp"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        x:Class="TmpAvaloniaApp.MainWindow"
-        x:DataType="local:MainWindow"
-        Title="TmpAvaloniaApp">
-  <StackPanel Margin="20">
-    <ComboBox x:Name="fontComboBox" SelectedIndex="0"
-              Width="200" MaxDropDownHeight="300"
-              ItemsSource="{Binding FontFamilies}"
-              SelectedValue="{Binding SelectedFont}">
-      <ComboBox.ItemTemplate>
-        <DataTemplate>
-          <TextBlock Text="{Binding Name}" FontFamily="{Binding}" />
-        </DataTemplate>
-      </ComboBox.ItemTemplate>
-    </ComboBox>
-  </StackPanel>
-</Window>
+<StackPanel Margin="20">
+  <ComboBox x:Name="fontComboBox" SelectedIndex="0"
+            Width="200" MaxDropDownHeight="300"
+            ItemsSource="{Binding FontFamilies}"
+            SelectedValue="{Binding SelectedFont}">
+    <ComboBox.ItemTemplate>
+      <DataTemplate>
+        <TextBlock Text="{Binding Name}" FontFamily="{Binding}" />
+      </DataTemplate>
+    </ComboBox.ItemTemplate>
+  </ComboBox>
+</StackPanel>
 ```
 
 ```csharp title='C#'


### PR DESCRIPTION
In the original example:
The `GetInstalledFontFamilyNames` method has been removed.
The `Items` property of `ComboBox` has been set to read-only and cannot be directly assigned.
Therefore, I have rewritten this example.