### PR TITLE
Change Advanced label to allow dependencies to upgrade

### DIFF
--- a/accelerate-sidebar.js
+++ b/accelerate-sidebar.js
@@ -35,7 +35,7 @@ const sidebars = {
         }, 
         {
           'type': 'category',
-          'label': 'Advanced',
+          'label': 'Advanced Markdown',
           'items': [
             'tools/dev-tools/advanced/options-reference', 
             'tools/dev-tools/advanced/attaching-browser-or-mobile',      


### PR DESCRIPTION
Changed the 'Advanced' label in the Accelerate sidebar to 'Advanced Markdown', as a workaround because Docusaurus v3.9 won't yet accept a key attribute on nonstandard sidebars.

This change should allow dependencies to be upgraded, per the original PR (https://github.com/AvaloniaUI/avalonia-docs/pull/729).