### PR TITLE
More differentiating labels

### DIFF
--- a/accelerate-sidebar.js
+++ b/accelerate-sidebar.js
@@ -36,7 +36,7 @@ const sidebars = {
         }, 
         {
           'type': 'category',
-          'label': 'Advanced Markdown',
+          'label': 'Advanced Tools',
           'items': [
             'tools/dev-tools/advanced/options-reference', 
             'tools/dev-tools/advanced/attaching-browser-or-mobile',      
@@ -165,7 +165,7 @@ const sidebars = {
         'components/markdown/markdown',
         {
           'type': 'category',
-          'label': 'Advanced',
+          'label': 'Advanced Markdown',
           'items': [
             'components/markdown/styling',
             'components/markdown/custom-image-loader'


### PR DESCRIPTION
Needed to differentiate the 'Advanced' labels further because I hadn't noticed there was a third one. Again, this is to ensure the build works on docusaurus 3.9.