### PR TITLE
Set fetch-depth to 0 to get full history of doc updates

### DIFF
--- a/.github/workflows/azure-static-web-apps-zealous-desert-09e073403.yml
+++ b/.github/workflows/azure-static-web-apps-zealous-desert-09e073403.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -38,3 +39,4 @@ jobs:
           api_location: "" # Api source code path - optional
           output_location: "/" # Built app content directory - optional
           ###### End of 
+


### PR DESCRIPTION
Added fetch-depth option to checkout step for full history. This is intended to ensure last updated date and author display the correct information.