### PR TITLE
Add back "if you don't need to convert back"

### DIFF
--- a/docs/guides/data-binding/how-to-create-a-custom-data-binding-converter.md
+++ b/docs/guides/data-binding/how-to-create-a-custom-data-binding-converter.md
@@ -146,7 +146,7 @@ public class AnimalConverter : IValueConverter
 
 ## FuncValueConverter and FuncMultiConverter
 
-You can also implement a `FuncValueConverter`. The FuncValueConverter has two or three generic parameters:
+You can also implement a `FuncValueConverter` if you don't need to convert back. The FuncValueConverter has two or three generic parameters:
 
 * **TIn**: This parameter defines the expected input type. This can also be an array in case you want to use this converter in a MultiBinding.
 


### PR DESCRIPTION
This is a partial rollback of #746 to restore the description in line 149 about "if you don't need to convert back".

This is because FuncValueConverter is not yet able to convert back. However, the remaining changes added in #746 are true and should be retained.