### PR TITLE
Enhance documentation on design-time attributes and window size

### DIFF
--- a/docs/get-started/test-drive/the-design-preview.mdx
+++ b/docs/get-started/test-drive/the-design-preview.mdx
@@ -24,7 +24,7 @@ Examine the XAML for the `<Window>` tag. It will look like this:
 
 The `Window` tag starts by defining some of the XML namespaces that Avalonia uses. The aliases 'x', 'd' and 'mc' are used.
 
-The design namespace 'd' allows the design-time attributes `d:DesignWidth` and `d:DesignHeight`to be set. In the above 
+The design namespace 'd' allows the design-time attributes `d:DesignWidth` and `d:DesignHeight` to be set. In the above 
 code sample, these have been set to make the preview look more like a mobile (portrait orientation) display. 
 
 
@@ -53,5 +53,22 @@ With these attributes set, the preview of the window now looks like this:
                 dark: useBaseUrl('/img/get-started/test-drive/temperature-design-preview-dark.png'),
             }}
             />
+
+Note that `d:DesignWidth` and `d:DesignHeight` only affect the size of the preview pane and do not change the size of the window at runtime.
+If you want the running application's window to start with a specific size, then add the `Width` and `Height` properties on the `Window` element as follows:
+
+```xml
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:GetStartedApp.ViewModels"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
+        x:Class="GetStartedApp.Views.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
+        Icon="/Assets/avalonia-logo.ico"
+        Title="GetStartedApp"
+        Width="400" Height="450">
+```
 
 On the next page, you will learn how to add some action to the app by responding to the `Button` `Click` event. 


### PR DESCRIPTION
Clarified the purpose of design-time attributes and added information on setting runtime window size. This confusion will save many first-time users a google search on why their running application was not affected by the design width and height.