### PR TITLE
Trying full html path

### DIFF
--- a/redirects/music-store-redirects.js
+++ b/redirects/music-store-redirects.js
@@ -1,5 +1,5 @@
 const redirects = [
-    { to: 'http://docs.avaloniaui.net/external-redirects/music-store-redirect.html',
+    { to: 'https://docs.avaloniaui.net/external-redirects/music-store-redirect.html',
       from: [
             '/docs/tutorials/music-store-app/',
             '/docs/tutorials/music-store-app/creating-the-project',


### PR DESCRIPTION
pathname:// SPA escape didn't work in production. Chrome DevTools showed it was attempting to go to the literal address starting pathname. Retrying a redirect to the full URL.