### PR TITLE
Update compiled-bindings.md to rewrite section about type casting

### DIFF
--- a/docs/basics/data/data-binding/compiled-bindings.md
+++ b/docs/basics/data/data-binding/compiled-bindings.md
@@ -86,7 +86,6 @@ If you are using an earlier version of Avalonia, or if the compiler fails to inf
 
 We do not generally recommend explicit type casting.
 
-
 ```xml
 <Window x:Name="MyWindow"
         xmlns:vm="using:MyApp.ViewModels"


### PR DESCRIPTION
Type casting was no longer needed as of 11.3.0. The docs continued to describe type casting, which caused user confusion, not helped by Rider highlighting the inference as an error. This rewrite aims to clarify how DataContext inference works, which version it was introduced in, and when users need to resort to explicit type casting.