### PR TITLE
Add G tag

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -191,11 +191,13 @@ const config = {
         editLocalizedFiles: true,
       },
     ],
+    [
       '@docusaurus/plugin-google-gtag',
       {
         trackingID: 'G-999X9XX9XX',
         anonymizeIP: true,
       },
+    ],
 ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */


### PR DESCRIPTION
Added analytics tag to the docusaurus config according to https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag