### PR TITLE
Rename LaunchFileAsync to LaunchDirectoryInfoAsync

### DIFF
--- a/docs/concepts/services/launcher.md
+++ b/docs/concepts/services/launcher.md
@@ -46,7 +46,7 @@ Starts the default app associated with the specified storage file.
 Task<bool> LaunchFileInfoAsync(FileInfo fileInfo)
 ```
 
-### LaunchFileAsync
+### LaunchDirectoryInfoAsync
 Starts the default app associated with the specified storage directory (folder).
 
 ```cs


### PR DESCRIPTION
Renamed LaunchFileAsync to LaunchDirectoryInfoAsync and updated description.

Fixes: https://github.com/AvaloniaUI/avalonia-docs/issues/777