### PR TITLE
Fix Avalonia Accelerate links in XPF/embeddeding/web-view.md

### DIFF
--- a/xpf/embedding/web-view.md
+++ b/xpf/embedding/web-view.md
@@ -177,6 +177,6 @@ NativeWebDialog also supports libwebkit2gtk-4.0 and soup-2.4 for older Ubuntu di
 
 For detailed API documentation, see:
 
-- [NativeWebView API](../../../accelerate/components/webview/nativewebview.md)
-- [NativeWebDialog API](../../../accelerate/components/webview/nativewebdialog.md)
-- [WebAuthenticationBroker API](../../../accelerate/components/webview/webauthenticationbroker.md)
+- [NativeWebView API](../../accelerate/components/webview/nativewebview)
+- [NativeWebDialog API](../../accelerate/components/webview/nativewebdialog)
+- [WebAuthenticationBroker API](../../accelerate/components/webview/webauthenticationbroker)


### PR DESCRIPTION
Docusaurus only supports resolving .md links to page links within the same plugin.

Broken links can be seen live at https://docs.avaloniaui.net/xpf/embedding/web-view#next-steps