### PR TITLE
docs(get-started): mismatch template name

### DIFF
--- a/docs/get-started/index.mdx
+++ b/docs/get-started/index.mdx
@@ -111,7 +111,7 @@ Check the output. You should see that these templates are installed:
 Template Name                                 Short Name                  Language    Tags
 --------------------------------------------  --------------------------  ----------  ---------------------------------------------------------
 Avalonia .NET App                             avalonia.app                [C#],F#     Desktop/Xaml/Avalonia/Windows/Linux/macOS
-Avalonia .NET MVVM App                        avalonia.app                [C#],F#     Desktop/Xaml/Avalonia/Windows/Linux/macOS
+Avalonia .NET MVVM App                        avalonia.mvvm                [C#],F#     Desktop/Xaml/Avalonia/Windows/Linux/macOS
 Avalonia Cross Platform Application           avalonia.xplat              [C#],F#     Desktop/Xaml/Avalonia/Web/Mobile
 Avalonia Resource Dictionary                  avalonia.resource                       Desktop/Xaml/Avalonia/Windows/Linux/macOS
 Avalonia Styles                               avalonia.styles                         Desktop/Xaml/Avalonia/Windows/Linux/macOS

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/get-started/index.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/get-started/index.mdx
@@ -111,7 +111,7 @@ dotnet new install Avalonia.Templates
 Template Name                                 Short Name                  Language    Tags
 --------------------------------------------  --------------------------  ----------  ---------------------------------------------------------
 Avalonia .NET App                             avalonia.app                [C#],F#     Desktop/Xaml/Avalonia/Windows/Linux/macOS
-Avalonia .NET MVVM App                        avalonia.app                [C#],F#     Desktop/Xaml/Avalonia/Windows/Linux/macOS
+Avalonia .NET MVVM App                        avalonia.mvvm                [C#],F#     Desktop/Xaml/Avalonia/Windows/Linux/macOS
 Avalonia Cross Platform Application           avalonia.xplat              [C#],F#     Desktop/Xaml/Avalonia/Web/Mobile
 Avalonia Resource Dictionary                  avalonia.resource                       Desktop/Xaml/Avalonia/Windows/Linux/macOS
 Avalonia Styles                               avalonia.styles                         Desktop/Xaml/Avalonia/Windows/Linux/macOS


### PR DESCRIPTION
The correct identifier should be avalonia.mvvm; here it was mistakenly written as avalonia.app.