### PR TITLE
Compiled-Bindings: Replace the dead codeproject link

### DIFF
--- a/docs/basics/data/data-binding/compiled-bindings.md
+++ b/docs/basics/data/data-binding/compiled-bindings.md
@@ -7,7 +7,7 @@ description: CONCEPTS
 Bindings defined in the XAML are using reflection in order to find and access the requested property in your `ViewModel`. In Avalonia you can also use compiled bindings, which has some benefits:
 
 * If you use compiled bindings and the property you bind to is not found, you will get a compile-time error. Hence you get a much better debugging experience.
-* Reflection is known to be slow ([see this article on codeproject.com](https://www.codeproject.com/Articles/1161127/Why-is-reflection-slow)). Using compiled bindings can therefore improve the performance of your application.
+* Reflection is known to be slow ([see this article on codeproject.com](https://www.codeproject.com/articles/Why-is-Reflection-Slow)). Using compiled bindings can therefore improve the performance of your application.
 
 ## Enable and disable compiled bindings
 


### PR DESCRIPTION
Replaces the broken codeproject link with a working one.

Alternatively, we could link to an archive: https://web.archive.org/web/20240613021450/https://www.codeproject.com/Articles/1161127/Why-is-reflection-slow

It's a shame that they broke probably all of their links.