### PR TITLE
Fix Music Store App tutorial link

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -28,4 +28,4 @@ It uses the _JetBrains Rider_ IDE running on macOS, but the steps will be equiva
 
 The app features a highly graphical application using the MVVM pattern, and including how to display a dialog, present images and collections of data, and implement data persistence.
 
-Follow this demonstration [here](./music-store-app/).
+Follow this demonstration [here](https://github.com/AvaloniaUI/Avalonia.Samples/tree/main/src/Avalonia.Samples/CompleteApps/Avalonia.MusicStore).


### PR DESCRIPTION
Music Store App tutorial link returned a 404, replaced it with a link to the GitHub sample.

Old link: https://docs.avaloniaui.net/docs/tutorials/music-store-app/
New link: https://github.com/AvaloniaUI/Avalonia.Samples/tree/main/src/Avalonia.Samples/CompleteApps/Avalonia.MusicStore