### PR TITLE
Fix WindowDecorationProperties.ElementRole mentions

### DIFF
--- a/controls/primitives/windowdrawndecorations.md
+++ b/controls/primitives/windowdrawndecorations.md
@@ -162,7 +162,7 @@ In the [example below](#example), an element role is marked for a `TextBlock` ac
                         <TextBlock Text="{Binding Title}"
                                    VerticalAlignment="Center"
                                    Margin="12,0"
-                                   chrome:WindowDecorations.ElementRole="TitleBar"/>
+                                   WindowDecorationProperties.ElementRole="TitleBar"/>
                     </DockPanel>
                 </WindowDrawnDecorationsContent.Overlay>
 

--- a/docs/app-development/window-management.md
+++ b/docs/app-development/window-management.md
@@ -193,7 +193,7 @@ protected override void OnClosing(WindowClosingEventArgs e)
 
 ## Custom title bar
 
-To create a custom title bar, extend the client area into the decorations and use `WindowDecorations.ElementRole` to mark a region as the title bar:
+To create a custom title bar, extend the client area into the decorations and use `WindowDecorationProperties.ElementRole` to mark a region as the title bar:
 
 ```xml
 <Window ExtendClientAreaToDecorationsHint="True"
@@ -201,7 +201,7 @@ To create a custom title bar, extend the client area into the decorations and us
     <Grid RowDefinitions="32,*">
         <!-- Custom title bar -->
         <Border Grid.Row="0" Background="#2D2D2D"
-                WindowDecorations.ElementRole="TitleBar">
+                WindowDecorationProperties.ElementRole="TitleBar">
             <TextBlock Text="My App" Foreground="White"
                        VerticalAlignment="Center" Margin="12,0" />
         </Border>
@@ -213,7 +213,7 @@ To create a custom title bar, extend the client area into the decorations and us
 </Window>
 ```
 
-Elements marked with `WindowDecorations.ElementRole="TitleBar"` support native window dragging and double-click-to-maximize. Interactive controls placed inside a title bar region (buttons, text boxes) receive input normally without triggering drag behavior.
+Elements marked with `WindowDecorationProperties.ElementRole="TitleBar"` support native window dragging and double-click-to-maximize. Interactive controls placed inside a title bar region (buttons, text boxes) receive input normally without triggering drag behavior.
 
 For more details on the `ElementRole` values, see the [custom title bar how-to](/docs/how-to/window-how-to#custom-title-bar-with-drag-region).
 

--- a/docs/how-to/window-how-to.md
+++ b/docs/how-to/window-how-to.md
@@ -141,13 +141,13 @@ Create a borderless window by disabling system decorations:
 
 ### Custom title bar with drag region
 
-Mark an element as a title bar drag region using the `WindowDecorations.ElementRole` attached property. The operating system handles drag and double-click-to-maximize behavior automatically:
+Mark an element as a title bar drag region using the `WindowDecorationProperties.ElementRole` attached property. The operating system handles drag and double-click-to-maximize behavior automatically:
 
 ```xml
 <Grid RowDefinitions="32,*">
     <!-- Custom title bar -->
     <Border Grid.Row="0" Background="#1E1E2E"
-            WindowDecorations.ElementRole="TitleBar">
+            WindowDecorationProperties.ElementRole="TitleBar">
         <DockPanel Margin="8,0">
             <TextBlock Text="My App" VerticalAlignment="Center" Foreground="White" />
             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal"

--- a/docs/platform-specific-guides/windows.md
+++ b/docs/platform-specific-guides/windows.md
@@ -45,14 +45,14 @@ For more details, see [Window Management](/docs/app-development/window-managemen
 
 ## Custom title bars
 
-Windows supports extending the client area into the title bar region for custom chrome. Set `ExtendClientAreaToDecorationsHint` to push your content into the title bar area, and use `WindowDecorations.ElementRole` to mark a region as the draggable title bar:
+Windows supports extending the client area into the title bar region for custom chrome. Set `ExtendClientAreaToDecorationsHint` to push your content into the title bar area, and use `WindowDecorationProperties.ElementRole` to mark a region as the draggable title bar:
 
 ```xml
 <Window ExtendClientAreaToDecorationsHint="True"
         WindowDecorations="None">
     <Grid RowDefinitions="32,*">
         <Border Grid.Row="0" Background="#2D2D2D"
-                WindowDecorations.ElementRole="TitleBar">
+                WindowDecorationProperties.ElementRole="TitleBar">
             <TextBlock Text="My App" Foreground="White"
                        VerticalAlignment="Center" Margin="12,0" />
         </Border>


### PR DESCRIPTION
This PR fixes several mentions of `WindowDecorations.ElementRole`, which does not exist. The correct property is `WindowDecorationProperties.ElementRole`.

Fixes https://github.com/AvaloniaUI/Avalonia/issues/21233