### PR TITLE
Update WebView docs for WPEWebKit

### DIFF
--- a/controls/web/nativewebview.md
+++ b/controls/web/nativewebview.md
@@ -288,13 +288,13 @@ Asynchronously delays destruction of the native control during parent changes.
 
 ## Platform support
 
-| Feature                | Windows WebView2-Edge | macOS/iOS WKWebView | Linux | Android | Browser |
-|------------------------|-----------------------|-------|---------------------|---------|---------|
-| `NativeWebView`        | ✓                     | ✓                   | ✗     | ✓      | ✗*      |
-| `TryGetCommandManager` | ✓                    | ✓                   | ✗     | ✓       | ✗*       |
-| `TryGetCookieManager`  | ✓                    | ✓                   | ✗     | ✓      | ✗*       |
-| `ShowPrintUI` | ✓                    | ✓                   | ✗      | ✗*     | ✗*       |
-| `PrintToPdfStreamAsync`  | ✓                    |  ✓**                   | ✗     | ✗*      | ✗*       |
+| Feature                | Windows WebView2-Edge | macOS/iOS WKWebView | Linux WPE WebKit | Android | Browser |
+|------------------------|-----------------------|---------------------|------------------|---------|---------|
+| `NativeWebView`        | ✓                     | ✓                   | ✓                | ✓       | ✗*      |
+| `TryGetCommandManager` | ✓                     | ✓                   | ✗*               | ✓       | ✗*      |
+| `TryGetCookieManager`  | ✓                     | ✓                   | ✓                | ✓       | ✗*      |
+| `ShowPrintUI`          | ✓                     | ✓                   | ✗*               | ✗*      | ✗*      |
+| `PrintToPdfStreamAsync`| ✓                     | ✓**                 | ✗*               | ✗*      | ✗*      |
 
 \* Not yet implemented while possible. If this is a blocker for your project, please open an issue.
 
@@ -302,7 +302,7 @@ Asynchronously delays destruction of the native control during parent changes.
 
 :::note
 
-For Linux support, please use [NativeWebDialog](/controls/web/nativewebdialog)
+On Linux, `NativeWebView` is rendered through [WPE WebKit](https://wpewebkit.org) using offscreen (SHM) rendering. Install the `libwpewebkit-2.0`, `libwpe-1.0`, and `libWPEBackend-fdo-1.0` runtime libraries — see the [Linux prerequisites](/docs/app-development/embedding-web-content#linux). If WPE is unavailable, you can opt in to the WebKitGTK adapter via [`LinuxWpeWebViewEnvironmentRequestedEventArgs.PreferWebKitGtkInstead`](/controls/web/webview-environment#linux-wpe-webkit), or fall back to [`NativeWebDialog`](/controls/web/nativewebdialog).
 
 :::
 

--- a/controls/web/webview-environment.md
+++ b/controls/web/webview-environment.md
@@ -92,7 +92,33 @@ webView.EnvironmentRequested += (sender, args) =>
 };
 ```
 
+### Linux (WPE WebKit)
+
+The default Linux backend for `NativeWebView` is [WPE WebKit](https://wpewebkit.org), which renders offscreen and composites into the Avalonia visual tree.
+
+**Key Properties:**
+
+- `DataDirectory`: Directory used for persistent website data. When `null`, the default WPE data directory is used.
+- `CacheDirectory`: Directory used for the website cache. When `null`, the default WPE cache directory is used.
+- `RenderingMode`: Selects the WPE rendering backend (`WpeRenderingMode`). The default `Auto` currently maps to `Shm` (software rendering, no GPU required). `Egl` and `DmaBuf` are reserved for future use and will throw `NotImplementedException` if selected. The choice is process-global and affects all `NativeWebView` instances.
+- `PreferWebKitGtkInstead`: When `true`, falls back to the WebKitGTK adapter even if WPE is available.
+
+**Example:**
+
+```csharp
+webView.EnvironmentRequested += (sender, args) =>
+{
+    if (args is LinuxWpeWebViewEnvironmentRequestedEventArgs wpeArgs)
+    {
+        wpeArgs.DataDirectory = Path.Combine(AppContext.BaseDirectory, "wpe-data");
+        wpeArgs.CacheDirectory = Path.Combine(AppContext.BaseDirectory, "wpe-cache");
+    }
+};
+```
+
 ### Linux (GTK WebKit)
+
+Used by `NativeWebDialog`, and by `NativeWebView` when `PreferWebKitGtkInstead` is set or WPE is unavailable.
 
 **Key Properties:**
 

--- a/docs/app-development/embedding-web-content.md
+++ b/docs/app-development/embedding-web-content.md
@@ -315,18 +315,6 @@ public interface ILinuxWpePlatformHandle : IPlatformHandle
 }
 ```
 
-**Important**: All WPE/GLib calls must be made on the GLib main thread. Use [`GtkInteropHelper.RunOnGlibThread`](https://api-docs.avaloniaui.net/docs/M_Avalonia_X11_Interop_GtkInteropHelper_RunOnGlibThread__1) from the `Avalonia.X11` assembly (included with `Avalonia.Desktop`) to marshal calls onto it.
-
-```csharp
-if (myWebView.TryGetPlatformHandle() is ILinuxWpePlatformHandle handle)
-{
-    GtkInteropHelper.RunOnGlibThread(() =>
-    {
-        // Your WPE WebKit P/Invoke calls here using handle.WebKitWebView
-    });
-}
-```
-
 #### Linux (WebKitGTK)
 
 `NativeWebDialog` (and `NativeWebView` when configured to prefer WebKitGTK) exposes a WebKitGTK handle. The provided `WebKitWebView` IntPtr can be used directly with WebKit P/Invokes from the [official WebKitGTK reference](https://webkitgtk.org/reference/webkit2gtk/stable/index.html).
@@ -337,8 +325,6 @@ public interface IGtkWebViewPlatformHandle : IPlatformHandle
     IntPtr WebKitWebView { get; }
 }
 ```
-
-The same threading rule applies — wrap calls in `GtkInteropHelper.RunOnGlibThread`.
 
 #### Android
 

--- a/docs/app-development/embedding-web-content.md
+++ b/docs/app-development/embedding-web-content.md
@@ -32,7 +32,7 @@ dotnet add package Avalonia.Controls.WebView
 ### NativeWebView
 
 :::note
-Embeddable `NativeWebView` is not supported on Linux. Please use `NativeWebDialog` instead.
+On Linux, `NativeWebView` uses [WPE WebKit](https://wpewebkit.org) and renders offscreen. Make sure the WPE runtime libraries are installed — see [Linux prerequisites](#linux). If WPE is not available on the target system, use [`NativeWebDialog`](/controls/web/nativewebdialog) instead.
 :::
 
 ```xml
@@ -129,11 +129,11 @@ The WebView component relies on native web rendering implementations that must b
 
 | Component | Windows | macOS | Linux | iOS | Android | Browser |
 |-----------|---------|-------|-------|-----|---------|---------|
-| NativeWebView | ✓ | ✓ | ✗* | ✓ | ✓ | ✗ |
+| NativeWebView | ✓ | ✓ | ✓* | ✓ | ✓ | ✗ |
 | NativeWebDialog | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | WebAuthenticationBroker | ✓** | ✓ | ✓** | ✓ | ✓*** | ✓**** |
 
-\* For Linux, use NativeWebDialog instead of NativeWebView
+\* On Linux, `NativeWebView` uses WPE WebKit. If WPE is unavailable on the target system, fall back to `NativeWebDialog` (which uses WebKitGTK).
 \** Uses NativeWebDialog implementation
 \*** Android support is experimental
 \**** Requires CORS configuration for the redirect page. .NET 10 is also necessary to run this library in browser.
@@ -159,7 +159,34 @@ Uses `WKWebView` which is pre-installed on all modern macOS/iOS devices.
 
 #### Linux
 
-Requires GTK 3.0 and WebKitGTK 4.1:
+Linux uses two different backends depending on the API you use:
+
+- **`NativeWebView`** is rendered with [WPE WebKit](https://wpewebkit.org) using offscreen (SHM) rendering. WPE has no hard dependency on GTK, so the embedded control works on both X11 and Wayland sessions and can be composed inside the Avalonia visual tree. 
+- **`NativeWebDialog`** uses WebKitGTK in a dedicated GTK window. Use it as a fallback when WPE is not available, or when you prefer a separate browser window.
+
+For `NativeWebView`, install the WPE runtime libraries:
+
+Debian/Ubuntu (24.04+):
+
+```bash
+sudo apt install libwpewebkit-2.0-1
+```
+
+Fedora:
+
+```bash
+sudo dnf install dnf-plugins-core
+sudo dnf copr enable philn/wpewebkit
+sudo dnf install wpewebkit
+```
+
+Arch:
+
+```bash
+sudo pacman -S wpewebkit
+```
+
+For `NativeWebDialog`, install GTK 3.0 and WebKitGTK 4.1:
 
 Debian/Ubuntu:
 
@@ -174,7 +201,11 @@ dnf install gtk3 webkit2gtk4.1
 ```
 
 :::note
-NativeWebDialog also supports libwebkit2gtk-4.0 and soup-2.4 for older Ubuntu distributives. But it is recommended to use libwebkit2gtk-4.1.
+`NativeWebDialog` also supports `libwebkit2gtk-4.0` and `soup-2.4` for older Ubuntu distributions. `libwebkit2gtk-4.1` is recommended.
+:::
+
+:::note
+On systems where WPE is not packaged, use `NativeWebDialog` instead, or set [`LinuxWpeWebViewEnvironmentRequestedEventArgs.PreferWebKitGtkInstead`](/controls/web/webview-environment#linux-wpe-webkit) to fall back to the WebKitGTK adapter.
 :::
 
 #### Android
@@ -269,13 +300,36 @@ public interface IAppleWKWebViewPlatformHandle : IPlatformHandle
 }
 ```
 
-#### GTK Linux
+#### Linux (WPE WebKit)
 
-GTK interop provides direct access to WebKitWebView but requires careful thread synchronization.
+On Linux, `NativeWebView` is backed by WPE WebKit. The platform handle exposes both the `WebKitWebView` GObject and the underlying `wpe_view_backend` struct, allowing direct P/Invoke against the [WPE WebKit API](https://webkitgtk.org/reference/wpe-webkit/stable/index.html).
 
-**Important**: All GTK calls must be executed on the GTK thread. Use [`GtkInteropHelper.RunOnGlibThread`](https://api-docs.avaloniaui.net/docs/M_Avalonia_X11_Interop_GtkInteropHelper_RunOnGlibThread__1) from the `Avalonia.X11` assembly (included with `Avalonia.Desktop`).
+```csharp
+public interface ILinuxWpePlatformHandle : IPlatformHandle
+{
+    /// Pointer to the WebKitWebView GObject instance.
+    IntPtr WebKitWebView { get; }
 
-The provided `WebKitWebView` IntPtr can be used directly with WebKit P/Invokes from the [official WebKit reference](https://webkitgtk.org/reference/webkit2gtk/2.5.1/WebKitWebView.html).
+    /// Pointer to the wpe_view_backend native struct.
+    IntPtr WpeViewBackend { get; }
+}
+```
+
+**Important**: All WPE/GLib calls must be made on the GLib main thread. Use [`GtkInteropHelper.RunOnGlibThread`](https://api-docs.avaloniaui.net/docs/M_Avalonia_X11_Interop_GtkInteropHelper_RunOnGlibThread__1) from the `Avalonia.X11` assembly (included with `Avalonia.Desktop`) to marshal calls onto it.
+
+```csharp
+if (myWebView.TryGetPlatformHandle() is ILinuxWpePlatformHandle handle)
+{
+    GtkInteropHelper.RunOnGlibThread(() =>
+    {
+        // Your WPE WebKit P/Invoke calls here using handle.WebKitWebView
+    });
+}
+```
+
+#### Linux (WebKitGTK)
+
+`NativeWebDialog` (and `NativeWebView` when configured to prefer WebKitGTK) exposes a WebKitGTK handle. The provided `WebKitWebView` IntPtr can be used directly with WebKit P/Invokes from the [official WebKitGTK reference](https://webkitgtk.org/reference/webkit2gtk/stable/index.html).
 
 ```csharp
 public interface IGtkWebViewPlatformHandle : IPlatformHandle
@@ -284,14 +338,7 @@ public interface IGtkWebViewPlatformHandle : IPlatformHandle
 }
 ```
 
-**Example Usage**:
-
-```csharp
-GtkInteropHelper.RunOnGlibThread(() =>
-{
-    // Your WebKit P/Invoke calls here
-});
-```
+The same threading rule applies — wrap calls in `GtkInteropHelper.RunOnGlibThread`.
 
 #### Android
 

--- a/docs/app-development/embedding-web-content.md
+++ b/docs/app-development/embedding-web-content.md
@@ -302,7 +302,7 @@ public interface IAppleWKWebViewPlatformHandle : IPlatformHandle
 
 #### Linux (WPE WebKit)
 
-On Linux, `NativeWebView` is backed by WPE WebKit. The platform handle exposes both the `WebKitWebView` GObject and the underlying `wpe_view_backend` struct, allowing direct P/Invoke against the [WPE WebKit API](https://webkitgtk.org/reference/wpe-webkit/stable/index.html).
+On Linux, `NativeWebView` is backed by WPE WebKit. The platform handle exposes both the `WebKitWebView` GObject and the underlying `wpe_view_backend` struct, allowing direct P/Invoke against the [WPEWebKit API](https://github.com/WebPlatformForEmbedded/WPEWebKit).
 
 ```csharp
 public interface ILinuxWpePlatformHandle : IPlatformHandle

--- a/reference/webview/webview-environment.md
+++ b/reference/webview/webview-environment.md
@@ -1,7 +1,7 @@
 ---
 id: webview-environment
 title: WebView environment
-description: Configure WebView browser engine settings in Avalonia, including developer tools, private browsing, user data directories, and platform-specific options for WebView2, WKWebView, and GTK WebKit.
+description: Configure WebView browser engine settings in Avalonia, including developer tools, private browsing, user data directories, and platform-specific options for WebView2, WKWebView, WPE WebKit, and GTK WebKit.
 doc-type: reference
 tags:
 ---
@@ -95,7 +95,33 @@ webView.EnvironmentRequested += (sender, args) =>
 };
 ```
 
+### Linux (WPE WebKit)
+
+The default Linux backend for `NativeWebView` is [WPE WebKit](https://wpewebkit.org), which renders offscreen and composites into the Avalonia visual tree.
+
+**Key Properties:**
+
+- `DataDirectory`: Directory used for persistent website data. When `null`, the default WPE data directory is used.
+- `CacheDirectory`: Directory used for the website cache. When `null`, the default WPE cache directory is used.
+- `RenderingMode`: Selects the WPE rendering backend (`WpeRenderingMode`). The default `Auto` currently maps to `Shm` (software rendering, no GPU required). `Egl` and `DmaBuf` are reserved for future use and will throw `NotImplementedException` if selected. The choice is process-global and affects all `NativeWebView` instances.
+- `PreferWebKitGtkInstead`: When `true`, falls back to the WebKitGTK adapter even if WPE is available. Useful on systems without WPE backend libraries.
+
+**Example:**
+
+```csharp
+webView.EnvironmentRequested += (sender, args) =>
+{
+    if (args is LinuxWpeWebViewEnvironmentRequestedEventArgs wpeArgs)
+    {
+        wpeArgs.DataDirectory = Path.Combine(AppContext.BaseDirectory, "wpe-data");
+        wpeArgs.CacheDirectory = Path.Combine(AppContext.BaseDirectory, "wpe-cache");
+    }
+};
+```
+
 ### Linux (GTK WebKit)
+
+Used by `NativeWebDialog`, and by `NativeWebView` when `PreferWebKitGtkInstead` is set or WPE is unavailable.
 
 **Key Properties:**
 

--- a/tools/faq.md
+++ b/tools/faq.md
@@ -198,11 +198,14 @@ new TextColumn<Person, string>(
 
 No, offscreen rendering is not currently supported. Offscreen rendering is being tracked as a potential future feature.
 
-#### Why is NativeWebView control not supported on Linux?
+#### Is NativeWebView supported on Linux?
 
-`NativeWebView` requires a system browser that can be embedded into Avalonia. Unlike Windows and macOS, Linux has more complex native control embedding, which doesn't work reliably on Wayland-based desktop environments.
+Yes. `NativeWebView` on Linux uses [WPE WebKit](https://wpewebkit.org) and renders offscreen using SHM (software rendering), so it does not depend on native window embedding and works on both X11 and Wayland sessions. See the [Linux prerequisites](/docs/app-development/embedding-web-content#linux) for the runtime libraries you need to install (`libwpewebkit-2.0`, `libwpe-1.0`, `libWPEBackend-fdo-1.0`).
 
-**Recommended Solution:** Design your app with `NativeWebDialog` as a fallback. This component provides a similar API to `NativeWebView` but operates in a dedicated window.
+If WPE is not available on the target distribution, you have two fallbacks:
+
+- Set [`LinuxWpeWebViewEnvironmentRequestedEventArgs.PreferWebKitGtkInstead`](/controls/web/webview-environment#linux-wpe-webkit) to use the WebKitGTK adapter instead.
+- Use [`NativeWebDialog`](/controls/web/nativewebdialog), which renders WebKitGTK in a dedicated window.
 
 #### Can I use WebAuthenticationBroker for Google Auth or Microsoft.Identity Auth?
 


### PR DESCRIPTION
For https://github.com/AvaloniaUI/Avalonia.Controls.Maui/issues/192

I didn't update the docs for this when I landed it in Avalonia.Controls.Webview. 100% on me. This updates the docs to note that we do support Linux Webviews, and that you should use WPEWebKit first when available.

I tested the install guides on Ubuntu, Fedora, and Arch, and they worked for me. 