### PR TITLE
Display MetaRow fields on each doc

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -108,7 +108,7 @@ const config: Config = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: "11.0.x",
+              label: "12.0.x",
               banner: "none"
             }
           }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -232,6 +232,8 @@ gtag('consent', 'default', {
         sidebarPath: './controls-sidebar.ts',
         editUrl: 'https://github.com/AvaloniaUI/avalonia-docs/tree/main',
         editLocalizedFiles: true,
+        showLastUpdateAuthor: true,
+        showLastUpdateTime: true,
       },
     ],
     [
@@ -243,6 +245,8 @@ gtag('consent', 'default', {
         sidebarPath: './xpf-sidebar.ts',
         editUrl: 'https://github.com/AvaloniaUI/avalonia-docs/tree/main',
         editLocalizedFiles: true,
+        showLastUpdateAuthor: true,
+        showLastUpdateTime: true,
       },
     ],
     [
@@ -254,6 +258,8 @@ gtag('consent', 'default', {
         sidebarPath: './tools-sidebar.ts',
         editUrl: 'https://github.com/AvaloniaUI/avalonia-docs/tree/main',
         editLocalizedFiles: true,
+        showLastUpdateAuthor: true,
+        showLastUpdateTime: true,
       },
     ],
     [
@@ -265,6 +271,8 @@ gtag('consent', 'default', {
         sidebarPath: './troubleshooting-sidebar.ts',
         editUrl: 'https://github.com/AvaloniaUI/avalonia-docs/tree/main',
         editLocalizedFiles: true,
+        showLastUpdateAuthor: true,
+        showLastUpdateTime: true,
       },
     ],
     [

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import TagsListInline from '@theme/TagsListInline';
+import EditMetaRow from '@theme/EditMetaRow';
 
 export default function DocItemFooter(): JSX.Element | null {
   const {metadata} = useDoc();
@@ -26,6 +27,17 @@ export default function DocItemFooter(): JSX.Element | null {
             <TagsListInline tags={tags} />
           </div>
         </div>
+      )}
+      {canDisplayEditMetaRow && (
+        <EditMetaRow
+          className={clsx(
+            'row margin-top--sm',
+            ThemeClassNames.docs.docFooterEditMetaRow,
+          )}
+          editUrl={editUrl}
+          lastUpdatedAt={lastUpdatedAt}
+          lastUpdatedBy={lastUpdatedBy}
+        />
       )}
     </footer>
   );


### PR DESCRIPTION
This PR enables display of "last updated time", "last updated author", and "edit this page" options at the bottom of each doc. These options were previously displayed in the v11 and earlier docs and should be restored to improve user experience, build authenticity and boost SEO.