### PR TITLE
Change img path to include /static

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -28,6 +28,7 @@ jobs:
                 --base-url https://docs.avaloniaui.net
                 --exclude-path 'api'
                 --exclude-path '.claude'
+                --exclude-path 'README.md'
                 --exclude 'https://xpf-nuget-feed.avaloniaui.net/'
                 --exclude 'https://xpf-nuget-feed.avaloniaui.net/packages/xpf.sdk'
                 --exclude 'https://xpf-nuget-feed.avaloniaui.net/v3/index.json'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="Avalonia UI logo" src="/img/purple-border-gradient-icon.png" width="75px" />
+  <img alt="Avalonia UI logo" src="static/img/purple-border-gradient-icon.png" width="75px" />
   <h1 align="center">Avalonia UI Documentation</h1>
 </p>
 


### PR DESCRIPTION
This PR fixes the broken logo in README.md by replacing the src with a path relative to the repo instead of the website.