### PR TITLE
Add docs for AOT support

### DIFF
--- a/docs/deployment/native-aot.md
+++ b/docs/deployment/native-aot.md
@@ -107,6 +107,10 @@ When using Native AOT with Avalonia, be aware of these limitations:
 
 For platform support, refer to [Platform/architecture restrictions](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/#platformarchitecture-restrictions).
 
+## Avalonia XPF
+
+If you are using [Avalonia XPF](/xpf), Native AOT is also supported. See [XPF: Native AOT](/xpf/deployment/native-aot) for XPF-specific setup and usage.
+
 ## See also
 
 - [Native AOT deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet9plus#platformarchitecture-restrictions): Microsoft documentation on Native AOT.

--- a/docs/deployment/native-aot.md
+++ b/docs/deployment/native-aot.md
@@ -51,48 +51,29 @@ When using Native AOT, XAML is compiled into the application at build time. Ensu
 
 ## Publishing Avalonia Native AOT applications
 
-### Windows
-```bash
-dotnet publish -r win-x64 -c Release
+To publish your app, run `dotnet publish` in the command line:
+
+```
+dotnet publish -r <current platform> -c Release
 ```
 
-### Linux
-```bash
-dotnet publish -r linux-x64 -c Release
-```
+As an example, `dotnet publish -r osx-arm64 -c Release` would publish the app for Apple Silicon devices.
 
-### macOS
-Intel based macOS 
-```bash
-dotnet publish -r osx-x64 -c Release
-```
-
-Apple silicon based macOS 
-```bash
-dotnet publish -r osx-arm64 -c Release
-```
+For more information, please see [Native AOT deployment on the .NET documentation site](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#publish-native-aot-using-the-cli).
 
 :::tip
 You can then use Apple's [lipo tool](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) to combine both Intel and Apple Silicon binaries, enabling you to ship  Universal binaries.
 :::
 
-## Troubleshooting common issues
+## Resolving reflection-related errors
 
-### 1. Reflection-related errors
-For view models or services using reflection:
-```xml
+Add a trimmer root descriptor to your `.csproj` file.
+
+```xml title=".csproj"
 <ItemGroup>
-    <TrimmerRootDescriptor Include="TrimmerRoots.xml" />
+    <ProjectReference Include="..\YourApp\YourApp.csproj" />
+    <TrimmerRootAssembly Include="YourAssembly" />
 </ItemGroup>
-```
-
-Create a `TrimmerRoots.xml`:
-```xml
-<linker>
-    <assembly fullname="YourApplication">
-        <type fullname="YourApplication.ViewModels*" preserve="all"/>
-    </assembly>
-</linker>
 ```
 
 ## Known limitations

--- a/docs/deployment/native-aot.md
+++ b/docs/deployment/native-aot.md
@@ -21,15 +21,22 @@ Native AOT compilation provides the following advantages for Avalonia applicatio
 
 ### Project configuration
 
-Add the following to your csproj file:
+Add the following to your `.csproj` file(s).
 
 ```xml
 <PropertyGroup>
+    <!-- Only needed for the main executable project -->
     <PublishAot>true</PublishAot>
+
+    <!-- Add to all projects/libraries in use, to ensure AOT compatibility -->
+    <IsAotCompatible>true</IsAotCompatible>
+
     <!-- Necessary before Avalonia 12.0, was used for accessiblity APIs -->
     <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
 </PropertyGroup>
 ```
+
+For information, please see [Native AOT deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) on the .NET documentation site.
 
 ## Avalonia-specific considerations
 
@@ -54,12 +61,12 @@ When using Native AOT, XAML is compiled into the application at build time. Ensu
 To publish your app, run `dotnet publish` in the command line:
 
 ```
-dotnet publish -r <current platform> -c Release
+dotnet publish -r <runtime> -c Release
 ```
 
 As an example, `dotnet publish -r osx-arm64 -c Release` would publish the app for Apple Silicon devices.
 
-For more information, please see [Native AOT deployment on the .NET documentation site](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#publish-native-aot-using-the-cli).
+For more information, please see [Native AOT deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#publish-native-aot-using-the-cli) and [dotnet publish](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish) on the .NET documentation site.
 
 :::tip
 You can then use Apple's [lipo tool](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) to combine both Intel and Apple Silicon binaries, enabling you to ship  Universal binaries.
@@ -71,10 +78,12 @@ Add a trimmer root descriptor to your `.csproj` file.
 
 ```xml title=".csproj"
 <ItemGroup>
-    <ProjectReference Include="..\YourApp\YourApp.csproj" />
+    <ProjectReference Include="..\YourAssembly\YourAssembly.csproj" />
     <TrimmerRootAssembly Include="YourAssembly" />
 </ItemGroup>
 ```
+
+For information, please see [Trimming](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#csproj-file) on the .NET documentation site.
 
 ## Known limitations
 

--- a/xpf-sidebar.ts
+++ b/xpf-sidebar.ts
@@ -68,6 +68,7 @@ const sidebars: SidebarsConfig = {
         'deployment/windows',
         'deployment/macos',
         'deployment/linux',
+        'deployment/native-aot',
       ]
     },
     'troubleshooting',

--- a/xpf/deployment/native-aot.md
+++ b/xpf/deployment/native-aot.md
@@ -57,11 +57,11 @@ For ARM64 devices:
 dotnet publish -r linux-arm64 -c Release
 ```
 
-## Trimming by NativeAOT linker
+## Trimming by the Native AOT linker
 
-To use AOT with XPF, trimming and linking must be conservative. `Xpf.Sdk` ships with an `rd.xml` root descriptor that force-includes runtime libraries. Any third-party WPF-consuming libraries your application references must have equivalent trimmer configurations. Otherwise, the NativeAOT linker may remove types that are only referenced from XAML, as it is unable to detect them as being in use.
+To use AOT with XPF, trimming and linking must be conservative. `Xpf.Sdk` ships with an `rd.xml` root descriptor that force-includes XPF runtime libraries. If your application references third-party WPF libraries, they must have equivalent trimming configurations. Otherwise, the Native AOT linker may remove types that are only referenced from XAML, because it cannot detect them as being in use.
 
-If you are experiencing runtime errors due to missing types, consider adding a trimmer root descriptor to your project to ensure they are preserved.
+If you are experiencing runtime errors due to missing types, add a trimmer root descriptor to your project so that application types, or third-party library types referenced only from XAML, are preserved.
 
 ```xml
 <ItemGroup>
@@ -80,7 +80,7 @@ If you are experiencing runtime errors due to missing types, consider adding a t
 </linker>
 ```
 
-Adjust the type patterns to match the namespaces your XAML references. Some third-party libraries may require similar entries to preserve their types.
+Adjust the type patterns to match the namespaces your XAML references. Some third-party libraries may require comprehensive entries if they do not ship with a root descriptor.
 
 ## See also
 

--- a/xpf/deployment/native-aot.md
+++ b/xpf/deployment/native-aot.md
@@ -1,0 +1,91 @@
+---
+id: native-aot
+title: Native AOT
+description: Publish XPF applications as native executables using ahead-of-time compilation, including trimming requirements and XAML type preservation.
+doc-type: how-to
+---
+
+Native AOT (Ahead-of-Time) compilation is supported in XPF. Unlike WPF, XPF does not use COM marshalling, which allows it to be compatible with AOT compilation. Large applications using third-party control libraries can be successfully compiled with Native AOT.
+
+## Project configuration
+
+Add `PublishAot` to your `.csproj`.
+
+```xml
+<PropertyGroup>
+    <PublishAot>true</PublishAot>
+</PropertyGroup>
+```
+
+## Publishing
+
+### Windows
+
+```bash
+dotnet publish -r win-x64 -c Release
+```
+
+For ARM64 Windows devices:
+
+```bash
+dotnet publish -r win-arm64 -c Release
+```
+
+### macOS
+
+Apple Silicon:
+
+```bash
+dotnet publish -r osx-arm64 -c Release
+```
+
+Intel:
+
+```bash
+dotnet publish -r osx-x64 -c Release
+```
+
+### Linux
+
+```bash
+dotnet publish -r linux-x64 -c Release
+```
+
+For ARM64 devices:
+
+```bash
+dotnet publish -r linux-arm64 -c Release
+```
+
+## Trimming by NativeAOT linker
+
+To use AOT with XPF, trimming and linking must be conservative. `Xpf.Sdk` ships with an `rd.xml` root descriptor that force-includes runtime libraries. Any third-party WPF-consuming libraries your application references must have equivalent trimmer configurations. Otherwise, the NativeAOT linker may remove types that are only referenced from XAML, as it is unable to detect them as being in use.
+
+If you are experiencing runtime errors due to missing types, consider adding a trimmer root descriptor to your project to ensure they are preserved.
+
+```xml
+<ItemGroup>
+    <TrimmerRootDescriptor Include="TrimmerRoots.xml" />
+</ItemGroup>
+```
+
+`TrimmerRoots.xml`:
+
+```xml
+<linker>
+    <assembly fullname="YourAssembly">
+        <type fullname="YourAssembly.ViewModels*" preserve="all"/>
+        <type fullname="YourAssembly.Views*" preserve="all"/>
+    </assembly>
+</linker>
+```
+
+Adjust the type patterns to match the namespaces your XAML references. Some third-party libraries may require similar entries to preserve their types.
+
+## See also
+
+- [Native AOT (Avalonia)](/docs/deployment/native-aot): AOT setup for standard Avalonia applications
+- [Windows Deployment](/xpf/deployment/windows)
+- [macOS Deployment](/xpf/deployment/macos)
+- [Linux Deployment](/xpf/deployment/linux)
+- [Performance Optimization](/xpf/configuration/performance)

--- a/xpf/deployment/native-aot.md
+++ b/xpf/deployment/native-aot.md
@@ -19,68 +19,34 @@ Add `PublishAot` to your `.csproj`.
 
 ## Publishing
 
-### Windows
+To publish your app, run `dotnet publish` in the command line:
 
-```bash
-dotnet publish -r win-x64 -c Release
+```
+dotnet publish -r <current platform> -c Release
 ```
 
-For ARM64 Windows devices:
+As an example, `dotnet publish -r osx-arm64 -c Release` would publish the app for Apple Silicon devices.
 
-```bash
-dotnet publish -r win-arm64 -c Release
-```
-
-### macOS
-
-Apple Silicon:
-
-```bash
-dotnet publish -r osx-arm64 -c Release
-```
-
-Intel:
-
-```bash
-dotnet publish -r osx-x64 -c Release
-```
-
-### Linux
-
-```bash
-dotnet publish -r linux-x64 -c Release
-```
-
-For ARM64 devices:
-
-```bash
-dotnet publish -r linux-arm64 -c Release
-```
+For more information, please see [Native AOT deployment on the .NET documentation site](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#publish-native-aot-using-the-cli).
 
 ## Trimming by the Native AOT linker
 
-To use AOT with XPF, trimming and linking must be conservative. `Xpf.Sdk` ships with an `rd.xml` root descriptor that force-includes XPF runtime libraries. If your application references third-party WPF libraries, they must have equivalent trimming configurations. Otherwise, the Native AOT linker may remove types that are only referenced from XAML, because it cannot detect them as being in use.
+To use AOT with XPF, trimming and linking must be conservative.
 
-If you are experiencing runtime errors due to missing types, add a trimmer root descriptor to your project so that application types, or third-party library types referenced only from XAML, are preserved.
+By default, the XPF SDK ships with an `rd.xml` root descriptor that force-includes XPF runtime libraries, including all built-in WPF assemblies and any user-executable assemblies on which `Xpf.Sdk` is set.
 
-```xml
+However, if your application references third-party WPF libraries, they must have equivalent trimming configurations. Otherwise, the Native AOT linker may remove types that are only referenced from XAML, which it cannot detect as being in use.
+
+If you are experiencing runtime errors due to missing types, add a trimmer root descriptor to your `.csproj` file. Some third-party libraries may require comprehensive entries if they do not ship with a root descriptor and reference types in XAML only.
+
+```xml title=".csproj"
 <ItemGroup>
-    <TrimmerRootDescriptor Include="TrimmerRoots.xml" />
+    <ProjectReference Include="..\YourApp\YourApp.csproj" />
+    <TrimmerRootAssembly Include="YourAssembly" />
 </ItemGroup>
 ```
 
-`TrimmerRoots.xml`:
-
-```xml
-<linker>
-    <assembly fullname="YourAssembly">
-        <type fullname="YourAssembly.ViewModels*" preserve="all"/>
-        <type fullname="YourAssembly.Views*" preserve="all"/>
-    </assembly>
-</linker>
-```
-
-Adjust the type patterns to match the namespaces your XAML references. Some third-party libraries may require comprehensive entries if they do not ship with a root descriptor.
+For information, please see [Trimming on the .NET documentation site](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#csproj-file).
 
 ## See also
 

--- a/xpf/deployment/native-aot.md
+++ b/xpf/deployment/native-aot.md
@@ -22,12 +22,12 @@ Add `PublishAot` to your `.csproj`.
 To publish your app, run `dotnet publish` in the command line:
 
 ```
-dotnet publish -r <current platform> -c Release
+dotnet publish -r <runtime> -c Release
 ```
 
 As an example, `dotnet publish -r osx-arm64 -c Release` would publish the app for Apple Silicon devices.
 
-For more information, please see [Native AOT deployment on the .NET documentation site](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#publish-native-aot-using-the-cli).
+For more information, please see [Native AOT deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#publish-native-aot-using-the-cli) and [dotnet publish](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish) on the .NET documentation site.
 
 ## Trimming by the Native AOT linker
 
@@ -41,12 +41,12 @@ If you are experiencing runtime errors due to missing types, add a trimmer root 
 
 ```xml title=".csproj"
 <ItemGroup>
-    <ProjectReference Include="..\YourApp\YourApp.csproj" />
+    <ProjectReference Include="..\YourAssembly\YourAssembly.csproj" />
     <TrimmerRootAssembly Include="YourAssembly" />
 </ItemGroup>
 ```
 
-For information, please see [Trimming on the .NET documentation site](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#csproj-file).
+For information, please see [Trimming](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#csproj-file) on the .NET documentation site.
 
 ## See also
 

--- a/xpf/deployment/native-aot.md
+++ b/xpf/deployment/native-aot.md
@@ -37,7 +37,7 @@ By default, the XPF SDK ships with an `rd.xml` root descriptor that force-includ
 
 However, if your application references third-party WPF libraries, they must have equivalent trimming configurations. Otherwise, the Native AOT linker may remove types that are only referenced from XAML, which it cannot detect as being in use.
 
-If you are experiencing runtime errors due to missing types, add a trimmer root descriptor to your `.csproj` file. Some third-party libraries may require comprehensive entries if they do not ship with a root descriptor and reference types in XAML only.
+If you are experiencing runtime errors due to missing types, check if you are using any third-party libraries that do not ship with a root descriptor. Add a root descriptor for these to your `.csproj` file.
 
 ```xml title=".csproj"
 <ItemGroup>

--- a/xpf/faq.md
+++ b/xpf/faq.md
@@ -86,6 +86,14 @@ All XPF licenses support Tier 1 Linux distributions (the latest versions of Ubun
 
 Yes. RHEL 8 and later are supported. Some additional setup is required compared to Ubuntu. See [Linux: Other Dependencies](/xpf/platforms/linux#other-dependencies) for RHEL-specific package installation instructions.
 
+## Native AOT
+
+**Does XPF support Native AOT?**
+
+Yes. Unlike WPF, which cannot be compiled with Native AOT due to its COM marshalling dependency, XPF includes support for AOT compilation.
+
+See the [Native AOT deployment guide](/xpf/deployment/native-aot) for setup and usage instructions.
+
 ## Common issues
 
 **My application works on Windows but crashes on macOS/Linux. Where do I start?**


### PR DESCRIPTION
- Add new doc for using AOT with XPF specifically.
- Add section to XPF FAQ page on AOT.
- Add crosslink from Avalonia AOT page.
- Update sidebar with link to new page.