### PR TITLE
docs: add missing EnumToBoolConverter resource registration to RadioButton example

### DIFF
--- a/controls/input/buttons/radiobutton.md
+++ b/controls/input/buttons/radiobutton.md
@@ -102,15 +102,19 @@ public partial class OrderViewModel : ObservableObject
 }
 ```
 
-Avalonia includes a built-in [`EnumToBoolConverter`](/api/avalonia/controls/converters/enumtoboolconverter) for this purpose. Before using it in a binding, register it as an application resource in `App.axaml` so it's available throughout your app. You'll also need to declare the converter namespace in the `<Application>` tag:
+Avalonia includes a built-in [`EnumToBoolConverter`](/api/avalonia/controls/converters/enumtoboolconverter) for this purpose. Before using it in a binding, register it as an application resource in `App.axaml` so it's available throughout your app:
 
 ```xml
-<!-- In App.axaml -->
-<!-- Add to Application tag: xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls" -->
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
+             x:Class="YourApp.App">
 
-<Application.Resources>
-    <converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
-</Application.Resources>
+    <Application.Resources>
+        <converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
+    </Application.Resources>
+
+</Application>
 ```
 
 Then reference the converter in your radio button bindings:

--- a/controls/input/buttons/radiobutton.md
+++ b/controls/input/buttons/radiobutton.md
@@ -102,6 +102,16 @@ public partial class OrderViewModel : ObservableObject
 }
 ```
 
+Avalonia includes a built-in [`EnumToBoolConverter`](/api/avalonia/controls/converters/enumtoboolconverter) for this purpose. Before using it in a binding, register it as a resource in your window or application:
+
+```xml
+<Window.Resources>
+    <EnumToBoolConverter x:Key="EnumToBoolConverter"/>
+</Window.Resources>
+```
+
+Then reference the converter in your radio button bindings:
+
 ```xml
 <StackPanel Spacing="4">
     <RadioButton Content="Standard (5-7 days)"

--- a/controls/input/buttons/radiobutton.md
+++ b/controls/input/buttons/radiobutton.md
@@ -102,12 +102,15 @@ public partial class OrderViewModel : ObservableObject
 }
 ```
 
-Avalonia includes a built-in [`EnumToBoolConverter`](/api/avalonia/controls/converters/enumtoboolconverter) for this purpose. Before using it in a binding, register it as a resource in your window or application:
+Avalonia includes a built-in [`EnumToBoolConverter`](/api/avalonia/controls/converters/enumtoboolconverter) for this purpose. Before using it in a binding, register it as an application resource in `App.axaml` so it's available throughout your app. You'll also need to declare the converter namespace in the `<Application>` tag:
 
 ```xml
-<Window.Resources>
-    <EnumToBoolConverter x:Key="EnumToBoolConverter"/>
-</Window.Resources>
+<!-- In App.axaml -->
+<!-- Add to Application tag: xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls" -->
+
+<Application.Resources>
+    <converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
+</Application.Resources>
 ```
 
 Then reference the converter in your radio button bindings:


### PR DESCRIPTION
## Summary

The **Binding to an enum** section of the RadioButton documentation references \\EnumToBoolConverter\\ via \\{StaticResource EnumToBoolConverter}\\ but never shows how to register it as a resource. This causes confusion for developers who follow the example and get a runtime error because the resource is not found.

## Changes

Added a short explanation and code sample showing the \\<Window.Resources>\\ declaration before the existing RadioButton binding example. Also linked to the [\\EnumToBoolConverter\\ API reference](/api/avalonia/controls/converters/enumtoboolconverter).