### PR TITLE
Corrected the Avalonia.Templates version to 11.0.2

### DIFF
--- a/docs/get-started/install-avalonia.mdx
+++ b/docs/get-started/install-avalonia.mdx
@@ -72,7 +72,7 @@ dotnet new update
 This updates all installed template packages, including `Avalonia.Templates`. To install a specific template version (for example, to match a particular Avalonia release), specify the version explicitly:
 
 ```bash
-dotnet new install Avalonia.Templates::11.2.0
+dotnet new install Avalonia.Templates::11.0.2
 ```
 
 ### Uninstall templates


### PR DESCRIPTION
Updated the version of Avalonia.Templates from 11.2.0 to 11.0.2 in the installation instructions. Probably a type