### PR TITLE
971 clarify when its safe to touch logicalchildren

### DIFF
--- a/docs/custom-controls/control-trees.md
+++ b/docs/custom-controls/control-trees.md
@@ -94,7 +94,7 @@ protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e
 
 ### Where to mutate `LogicalChildren`
 
-When a custom container needs to add or remove logical children programmatically (for example, inserting separators between items), do this inside a structured lifecycle hook—e.g.,`OnApplyTemplate`, `OnAttachedToLogicalTree`, `OnAttachedToVisualTree`—rather than a property-change callback. The framework walks the tree to propagate inherited properties such as `DataContext`, and mutating `LogicalChildren` while a walk is in progress can result in binding errors.
+When a custom container needs to add or remove logical children programmatically (for example, inserting separators between items), do this inside a structured lifecycle hook—e.g.,`OnApplyTemplate`, `OnAttachedToLogicalTree`, `OnAttachedToVisualTree`—rather than a property-change callback like `DataContextChanged` or `OnPropertyChanged`. Mutating `LogicalChildren` while the logical tree is being walked can result in binding errors.
 
 See [Mutating the logical tree](/docs/fundamentals/visual-and-logical-trees#mutating-the-logical-tree) for more information on safe and unsafe contexts.
 

--- a/docs/custom-controls/control-trees.md
+++ b/docs/custom-controls/control-trees.md
@@ -94,7 +94,7 @@ protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e
 
 ### Where to mutate `LogicalChildren`
 
-When a custom container needs to add or remove logical children programmatically (for example, inserting separators between items), do this inside a structured lifecycle hook—e.g., `OnApplyTemplate`, `OnAttachedToLogicalTree`, `OnAttachedToVisualTree`—rather than a property-change callback like `DataContextChanged` or `OnPropertyChanged`. Mutating `LogicalChildren` while the logical tree is being walked can result in binding errors.
+When a custom container needs to add or remove logical children programmatically (for example, inserting separators between items), do this inside a structured lifecycle hook, e.g., `OnApplyTemplate`, rather than a property-change callback like `DataContextChanged` or `OnPropertyChanged`. Mutating `LogicalChildren` while the logical tree is being walked can result in binding errors.
 
 See [Mutating the logical tree](/docs/fundamentals/visual-and-logical-trees#mutating-the-logical-tree) for more information on safe and unsafe contexts.
 

--- a/docs/custom-controls/control-trees.md
+++ b/docs/custom-controls/control-trees.md
@@ -92,6 +92,12 @@ protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e
 }
 ```
 
+### Where to mutate `LogicalChildren`
+
+When a custom container needs to add or remove logical children programmatically (for example, inserting separators between items), do this inside a structured lifecycle hook—e.g.,`OnApplyTemplate`, `OnAttachedToLogicalTree`, `OnAttachedToVisualTree`—rather than a property-change callback. The framework walks the tree to propagate inherited properties such as `DataContext`, and mutating `LogicalChildren` while a walk is in progress can result in binding errors.
+
+See [Mutating the logical tree](/docs/fundamentals/visual-and-logical-trees#mutating-the-logical-tree) for more information on safe and unsafe contexts.
+
 ## See also
 
 - [Visual and Logical Trees](/docs/fundamentals/visual-and-logical-trees): Fundamental concepts.

--- a/docs/custom-controls/control-trees.md
+++ b/docs/custom-controls/control-trees.md
@@ -94,7 +94,7 @@ protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e
 
 ### Where to mutate `LogicalChildren`
 
-When a custom container needs to add or remove logical children programmatically (for example, inserting separators between items), do this inside a structured lifecycle hook—e.g.,`OnApplyTemplate`, `OnAttachedToLogicalTree`, `OnAttachedToVisualTree`—rather than a property-change callback like `DataContextChanged` or `OnPropertyChanged`. Mutating `LogicalChildren` while the logical tree is being walked can result in binding errors.
+When a custom container needs to add or remove logical children programmatically (for example, inserting separators between items), do this inside a structured lifecycle hook—e.g., `OnApplyTemplate`, `OnAttachedToLogicalTree`, `OnAttachedToVisualTree`—rather than a property-change callback like `DataContextChanged` or `OnPropertyChanged`. Mutating `LogicalChildren` while the logical tree is being walked can result in binding errors.
 
 See [Mutating the logical tree](/docs/fundamentals/visual-and-logical-trees#mutating-the-logical-tree) for more information on safe and unsafe contexts.
 

--- a/docs/events/lifecycle-events.md
+++ b/docs/events/lifecycle-events.md
@@ -142,6 +142,14 @@ This event fires when:
 - The inherited `DataContext` changes because a parent's `DataContext` changed.
 - The control moves to a different part of the visual tree with a different inherited `DataContext`.
 
+:::warning
+Do not mutate the logical tree from `DataContextChanged` or `OnPropertyChanged`!
+
+`DataContext` is an inherited property, so changes trigger a walk down the logical tree to propagate new values to descendants. If `LogicalChildren` are modified while the walk is in progress, binding errors can result.
+
+For more information, see [Mutating the logical tree](/docs/fundamentals/visual-and-logical-trees#mutating-the-logical-tree).
+:::
+
 ## Typical initialization patterns
 
 ### Loading data in a view

--- a/docs/events/lifecycle-events.md
+++ b/docs/events/lifecycle-events.md
@@ -143,7 +143,7 @@ For most scenarios, `Loaded` is the right choice. Use `AttachedToVisualTree` whe
 
 ## ApplyTemplate
 
-The event fires when applying the control template of a control.
+This method applies the control template of a control.
 
 ```csharp
 public class MyControl : Control
@@ -157,21 +157,21 @@ public class MyControl : Control
 
 ## MeasureOverride / ArrangeOverride
 
-These events fire whenever a control undergoes the [two-pass layout process](/docs/layout/#measuring-and-arranging-children) to size and position it within the layout.
+These override methods are called by the layout system whenever a control needs to undergo the [two-pass layout process](/docs/layout/#measuring-and-arranging-children) to size and position it within the layout.
 
 ```csharp
 public class MyControl : Control
 {
     protected override Size MeasureOverride(Size availableSize)
     {
-        return base.MeasureOverride(availableSize);
         // Calculates the desired size
+        return base.MeasureOverride(availableSize);
     }
 
     protected override Size ArrangeOverride(Size finalSize)
     {
-        return base.ArrangeOverride(finalSize);
         // Allocates the final size
+        return base.ArrangeOverride(finalSize);
     }
 }
 ```

--- a/docs/events/lifecycle-events.md
+++ b/docs/events/lifecycle-events.md
@@ -28,17 +28,17 @@ When a control is removed:
 | 1 | `Unloaded` | `Control` | The control is about to be removed from the visual tree. |
 | 2 | `DetachedFromVisualTree` | `Visual` | The control has been removed from the visual tree. |
 
-### Child control creation
+### Layout application
 
-In addition, when a layout control containing children controls adds them to the visual tree, the following events occur in the stated order.
+In addition to the events described above, layout controls can also participate in altering the visual tree through the following methods.
 
-These events happen after the control is added to the visual tree, and they must complete before the control can be fully attached, i.e., this sequence takes place between the `AttachedToVisualTree` and `Loaded` events [detailed above](#control-created).
+During the initial run (i.e., when the control is first attached to the visual tree), these events occur in the stated sequence between the `AttachedToVisualTree` and `Loaded` events [detailed above](#control-creation). However, `MeasureOverride` and `ArrangeOverride` can run multiple times during a control's lifetime, as they are triggered whenever the layout is updated, e.g., when the window size is adjusted.
 
 | Order | Event / Method | Defined On | Description |
 |---|---|---|---|
-| 1 | `ApplyTemplate` | `Control` | Applies values specified by the [control template](/docs/styling/control-template-walkthrough). |
-| 2 | `MeasureOverride` | `Control` | The [measure pass](/docs/layout/#measuring-and-arranging-children) of the layout system. Determines the desired size of each child control. |
-| 3 | `ArrangeOverride` | `Control` | The [arrange pass](/docs/layout/#measuring-and-arranging-children) of the layout system. Assigns the final size of each child control. |
+| 1 | `ApplyTemplate` | `Control` | Applies the [control template](/docs/styling/control-template-walkthrough) and creates the required templated visual parts. |
+| 2 | `MeasureOverride` | `Control` | Called during the [measure pass](/docs/layout/#measuring-and-arranging-children) of layout. Determines the desired size of a control. |
+| 3 | `ArrangeOverride` | `Control` | Called during the [arrange pass](/docs/layout/#measuring-and-arranging-children) of layout. Assigns the final size of a control. |
 
 ## Initialized
 
@@ -143,7 +143,7 @@ For most scenarios, `Loaded` is the right choice. Use `AttachedToVisualTree` whe
 
 ## ApplyTemplate
 
-The event fires when creating the visual children of a layout control.
+The event fires when applying the control template of a control.
 
 ```csharp
 public class MyControl : Control
@@ -157,7 +157,7 @@ public class MyControl : Control
 
 ## MeasureOverride / ArrangeOverride
 
-These events fire when a layout control performs the [two-pass layout process](/docs/layout/#measuring-and-arranging-children) to position children controls.
+These events fire whenever a control undergoes the [two-pass layout process](/docs/layout/#measuring-and-arranging-children) to size and position it within the layout.
 
 ```csharp
 public class MyControl : Control
@@ -165,13 +165,13 @@ public class MyControl : Control
     protected override Size MeasureOverride(Size availableSize)
     {
         return base.MeasureOverride(availableSize);
-        // Calculates the desired size of each child control
+        // Calculates the desired size
     }
 
     protected override Size ArrangeOverride(Size finalSize)
     {
         return base.ArrangeOverride(finalSize);
-        // Allocates the final size of each child control
+        // Allocates the final size
     }
 }
 ```

--- a/docs/events/lifecycle-events.md
+++ b/docs/events/lifecycle-events.md
@@ -9,6 +9,8 @@ Avalonia controls raise several events during their creation, attachment to the 
 
 ## Lifecycle event order
 
+### Control creation
+
 When a control is created and added to the visual tree, events fire in the following order:
 
 | Order | Event / Method | Defined On | Description |
@@ -17,12 +19,26 @@ When a control is created and added to the visual tree, events fire in the follo
 | 2 | `AttachedToVisualTree` | `Visual` | The control has been added to a rooted visual tree. Layout has not yet occurred. |
 | 3 | `Loaded` | `Control` | The control is fully attached and ready for interaction. This fires after the visual tree attachment is complete. |
 
+### Control removal
+
 When a control is removed:
 
 | Order | Event / Method | Defined On | Description |
 |---|---|---|---|
 | 1 | `Unloaded` | `Control` | The control is about to be removed from the visual tree. |
 | 2 | `DetachedFromVisualTree` | `Visual` | The control has been removed from the visual tree. |
+
+### Child control creation
+
+In addition, when a layout control containing children controls adds them to the visual tree, the following events occur in the stated order.
+
+These events happen after the control is added to the visual tree, and they must complete before the control can be fully attached, i.e., this sequence takes place between the `AttachedToVisualTree` and `Loaded` events [detailed above](#control-created).
+
+| Order | Event / Method | Defined On | Description |
+|---|---|---|---|
+| 1 | `ApplyTemplate` | `Control` | Applies values specified by the [control template](/docs/styling/control-template-walkthrough). |
+| 2 | `MeasureOverride` | `Control` | The [measure pass](/docs/layout/#measuring-and-arranging-children) of the layout system. Determines the desired size of each child control. |
+| 3 | `ArrangeOverride` | `Control` | The [arrange pass](/docs/layout/#measuring-and-arranging-children) of the layout system. Assigns the final size of each child control. |
 
 ## Initialized
 
@@ -124,6 +140,41 @@ Both events indicate the control is part of the visual tree. The key difference:
 - `Loaded` fires after the attachment is fully complete. It is a `RoutedEvent` on `Control`.
 
 For most scenarios, `Loaded` is the right choice. Use `AttachedToVisualTree` when you need access to the `Root` reference or when working with non-`Control` visuals.
+
+## ApplyTemplate
+
+The event fires when creating the visual children of a layout control.
+
+```csharp
+public class MyControl : Control
+{
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+    }
+}
+```
+
+## MeasureOverride / ArrangeOverride
+
+These events fire when a layout control performs the [two-pass layout process](/docs/layout/#measuring-and-arranging-children) to position children controls.
+
+```csharp
+public class MyControl : Control
+{
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        return base.MeasureOverride(availableSize);
+        // Calculates the desired size of each child control
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        return base.ArrangeOverride(finalSize);
+        // Allocates the final size of each child control
+    }
+}
+```
 
 ## DataContextChanged
 

--- a/docs/fundamentals/visual-and-logical-trees.md
+++ b/docs/fundamentals/visual-and-logical-trees.md
@@ -58,6 +58,23 @@ var window = myControl.FindLogicalAncestorOfType<Window>();
 var allTextBlocks = myPanel.GetLogicalDescendants().OfType<TextBlock>();
 ```
 
+### Mutating the logical tree
+
+It is only safe to add or remove `LogicalChildren` when the framework is not already walking the tree. Several common operations trigger such walks, most notably propagation of inherited properties (`DataContext`, `FontSize`, `FlowDirection`, etc). Mutating `LogicalChildren` while one of these walks is in flight can corrupt the iteration and surface as binding errors.
+
+**Safe places to add or remove logical children:**
+
+- The control's constructor, before it is attached to any tree.
+- `OnApplyTemplate`, after calling `base.OnApplyTemplate(e)`.
+- `OnAttachedToLogicalTree`, `OnDetachedFromLogicalTree`, and their visual-tree counterparts.
+- Routed input or command handlers (for example, a `Click` or `Tapped` handler).
+- The `Loaded` event handler.
+
+**Avoid mutating `LogicalChildren` from:**
+
+- `OnPropertyChanged` or `PropertyChanged` callbacks. The framework may be partway through propagating an inherited property to the children you are about to modify.
+- `DataContextChanged`, for the same reason.
+
 ## Visual tree
 
 The visual tree includes every visual element that participates in rendering, including the internal template parts of controls. A `Button` in the logical tree expands in the visual tree to include its `ContentPresenter`, `Border`, and other template elements.

--- a/docs/fundamentals/visual-and-logical-trees.md
+++ b/docs/fundamentals/visual-and-logical-trees.md
@@ -60,17 +60,17 @@ var allTextBlocks = myPanel.GetLogicalDescendants().OfType<TextBlock>();
 
 ### Mutating the logical tree
 
-It is only safe to add or remove `LogicalChildren` when the framework is not already walking the tree. Several common operations trigger such walks, most notably propagation of inherited properties (`DataContext`, `FontSize`, `FlowDirection`, etc). Mutating `LogicalChildren` while one of these walks is in flight can corrupt the iteration and surface as binding errors.
+It is only safe to add or remove `LogicalChildren` when the framework is not already walking the tree. Several common operations trigger such walks, most notably propagation of inherited properties such as `DataContext`. Mutating `LogicalChildren` while one of these walks is in progress can corrupt the iteration and surface as binding errors.
 
 **Safe places to add or remove logical children:**
 
 - The control's constructor, before it is attached to any tree.
 - `OnApplyTemplate`, after calling `base.OnApplyTemplate(e)`.
-- `OnAttachedToLogicalTree`, `OnDetachedFromLogicalTree`, and their visual-tree counterparts.
+- `OnAttachedToLogicalTree`, `OnDetachedFromLogicalTree`, and their visual tree counterparts.
 - Routed input or command handlers (for example, a `Click` or `Tapped` handler).
 - The `Loaded` event handler.
 
-**Avoid mutating `LogicalChildren` from:**
+**Avoid mutating logical children from:**
 
 - `OnPropertyChanged` or `PropertyChanged` callbacks. The framework may be partway through propagating an inherited property to the children you are about to modify.
 - `DataContextChanged`, for the same reason.

--- a/docs/fundamentals/visual-and-logical-trees.md
+++ b/docs/fundamentals/visual-and-logical-trees.md
@@ -66,7 +66,6 @@ It is only safe to add or remove `LogicalChildren` when the framework is not alr
 
 - The control's constructor, before it is attached to any tree.
 - `OnApplyTemplate`, after calling `base.OnApplyTemplate(e)`.
-- `OnAttachedToLogicalTree`, `OnDetachedFromLogicalTree`, and their visual tree counterparts.
 - Routed input or command handlers (for example, a `Click` or `Tapped` handler).
 - The `Loaded` event handler.
 


### PR DESCRIPTION
This PR aims to address feedback shared in https://github.com/AvaloniaUI/avalonia-docs/issues/971

- Add new section to visual-and-logical-trees.md to describe general principles around when it's safe to modify the logical tree.
- Add warnings to control-trees.md and lifecycle-events.md against changing logical children from `DataContextChanged`.
- Add new content to lifecycle-events.md to explicitly describe timing and significance of ApplyTemplate, MeasureOverride and ArrangeOverride within the lifecycle sequence.