### PR TITLE
Schedule link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,12 +4,13 @@ on:
   schedule:
     - cron: '0 8 * * 1' # Runs every Monday at 8:00 AM UTC
   workflow_dispatch:
-  pull_request:
-    branches: [main]
+  repository_dispatch:
 
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
     steps:
         - uses: actions/checkout@v4
 
@@ -36,7 +37,15 @@ jobs:
                 './**/*.md'
                 './**/*.mdx'
             format: markdown
-            output: lychee/results.md
+            output: ./lychee/results.md
             token: ${{ secrets.GITHUB_TOKEN }}
-            fail: true
+            fail: false # so lychee doesn't abort the job
             jobSummary: true
+      
+        - name: Create issue from link checker results
+          if: steps.lychee.outputs.exit_code != 0
+          uses: peter-evans/create-issue-from-file@v6
+          with:
+            title: Link checker found broken links
+            content-filepath: ./lychee/results.md
+            labels: 'link-checker'

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -10,6 +10,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     permissions:
+      contents: read # required for actions/checkout
       issues: write # required for peter-evans/create-issue-from-file
     steps:
         - uses: actions/checkout@v4

--- a/controls-sidebar.ts
+++ b/controls-sidebar.ts
@@ -386,6 +386,16 @@ const sidebars: SidebarsConfig = {
                   'input/text-input/richtexteditor/thread-safety',
                 ],
               },
+              {
+                type: 'category',
+                label: 'Virtual keyboard',
+                collapsed: true,
+                items: [
+                  'input/text-input/virtualkeyboard/index',
+                  'input/text-input/virtualkeyboard/virtualkeyboard-control',
+                  'input/text-input/virtualkeyboard/virtualkeyboardscope',
+                ],
+              },
           ],
         },
       ],
@@ -408,16 +418,6 @@ const sidebars: SidebarsConfig = {
               'layout/containers/scrollviewer',
               'layout/containers/splitview',
               'layout/containers/viewbox',
-              {
-                type: 'category',
-                label: 'Virtual keyboard',
-                collapsed: true,
-                items: [
-                  'input/text-input/virtualkeyboard/index',
-                  'input/text-input/virtualkeyboard/virtualkeyboard-control',
-                  'input/text-input/virtualkeyboard/virtualkeyboardscope',
-                ],
-              },
           ],
         },
         'layout/decorator',

--- a/controls/input/text-input/virtualkeyboard/index.md
+++ b/controls/input/text-input/virtualkeyboard/index.md
@@ -141,7 +141,7 @@ See the [virtual keyboard control](/controls/input/text-input/virtualkeyboard/vi
 
 The virtual keyboard supports the [RIME](https://rime.im/) input method engine for Chinese text input. RIME support is provided as a separate plugin package.
 
-See the [`VirtualKeyboard` control reference](/controls/input/text-input/virtualkeyboad/virtualkeyboard-control#rime-input-method-engine) for installation and configuration instructions.
+See the [`VirtualKeyboard` control reference](/controls/input/text-input/virtualkeyboard/virtualkeyboard-control#rime-input-method-engine) for installation and configuration instructions.
 
 ## Text input options
 
@@ -171,4 +171,4 @@ Available `ReturnKeyType` values:
 ## See also
 
 - [VirtualKeyboard control](/controls/input/text-input/virtualkeyboard)
-- [VirtualKeyboardScope control](/controls/layout/containers/virtualkeyboardscope)
+- [VirtualKeyboardScope control](/controls/input/text-input/virtualkeyboard/virtualkeyboardscope)


### PR DESCRIPTION
Due to the high volume of false positives, change link-checker to run as a scheduled weekly process instead of during each PR.

This PR amends link-checker.yml to make it run the check weekly on Mondays, then output any errors as an issue.

Broken links identified during the work have also been opportunistically fixed.