### PR TITLE
TOC fixes

### DIFF
--- a/docs/get-started/install-avalonia.mdx
+++ b/docs/get-started/install-avalonia.mdx
@@ -72,7 +72,7 @@ dotnet new update
 This updates all installed template packages, including `Avalonia.Templates`. To install a specific template version (for example, to match a particular Avalonia release), specify the version explicitly:
 
 ```bash
-dotnet new install Avalonia.Templates::11.2.0
+dotnet new install Avalonia.Templates@12.0.2
 ```
 
 ### Uninstall templates

--- a/src/styles/components/_toc.scss
+++ b/src/styles/components/_toc.scss
@@ -19,13 +19,12 @@ html[data-theme='dark'] {
 
 //overrides
 #__docusaurus {
+  // Layout (sticky positioning, overflow, max-height) is owned by the
+  // swizzled TOC component's CSS module — see src/theme/TOC/styles.module.css.
+  // Only typographic/spacing tweaks belong here. Do NOT reintroduce
+  // `overflow` or `max-height`: this selector matches the component's inner
+  // scroll container (`tableOfContents_<hash>`) and would break its scrollbar.
   [class^='tableOfContents_'] {
-    position: static;
-    top: initial;
-    overflow: hidden;
-
-    max-height: initial;
-
     padding-block-end: 1.25rem;
 
     line-height: 1.4;

--- a/src/theme/TOC/index.tsx
+++ b/src/theme/TOC/index.tsx
@@ -77,7 +77,11 @@ export default function TOC({ className, ...props }: Props): ReactNode {
   const encodedPageUrl = encodeURIComponent(pageUrl);
 
   const editUrl = metadata?.editUrl;
-  const markdown = editUrl?.replace("github", "raw.githubusercontent").replace("/blob", "").replace("/tree", "");
+  // Derive the raw Markdown source URL from the document's source path rather
+  // than from editUrl. editUrl is absent for generated API pages (the `api`
+  // docs plugin has no editUrl configured), whereas `source` is always set.
+  const RAW_BASE = 'https://raw.githubusercontent.com/AvaloniaUI/avalonia-docs/main/';
+  const markdown = metadata?.source?.replace('@site/', RAW_BASE);
 
   const toggleDropdown = () => setIsOpen(!isOpen);
   const closeDropdown = () => setIsOpen(false);
@@ -117,16 +121,21 @@ export default function TOC({ className, ...props }: Props): ReactNode {
           onClose={closeDropdown}
         >
           <ul className="flex flex-col gap-1 list-none m-0 p-0">
-            <li>
-              <DropdownItem tag="div" onClick={getMDX}>
-                <MarkdownIcon />
-                Copy as Markdown
-              </DropdownItem>
-            </li>
-            {/* Divider */}
-            <li>
-              <span className="my-1.5 block h-px w-full bg-gray-200 dark:bg-white/[0.08]"></span>
-            </li>
+            {/* Copy as Markdown — only shown when a source file is resolvable */}
+            {markdown && (
+              <>
+                <li>
+                  <DropdownItem tag="div" onClick={getMDX}>
+                    <MarkdownIcon />
+                    Copy as Markdown
+                  </DropdownItem>
+                </li>
+                {/* Divider */}
+                <li>
+                  <span className="my-1.5 block h-px w-full bg-gray-200 dark:bg-white/[0.08]"></span>
+                </li>
+              </>
+            )}
             <li>
               <DropdownItem
                 tag="a"

--- a/src/theme/TOC/styles.module.css
+++ b/src/theme/TOC/styles.module.css
@@ -1,4 +1,6 @@
 .tableOfContentsWrapper {
+  display: flex;
+  flex-direction: column;
   max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
   position: sticky;
   top: calc(var(--ifm-navbar-height) + 1rem);
@@ -7,6 +9,12 @@
 }
 
 .tableOfContents {
+  /* As a flex child, min-height:0 lets this shrink below its content height
+     so overflow-y can engage; flex:1 caps its height at the space the
+     wrapper's max-height leaves after the header. Without both, the list
+     grows unbounded and the scrollbar never appears. */
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: visible;
 }


### PR DESCRIPTION
This PR fixes two issues in the TOC panel of the docs site.

1. "Copy as Markdown" didn't work on docs in the /api directory. This was due to the autogenerated docs not having an editUrl from which to generate a link to the raw content. Now adjusted to use metadata.source as the basis of the link instead. (This fixes https://github.com/AvaloniaUI/avalonia-docs/issues/973)
2. No scrollbar in the TOC. This has been fixed by removing a legacy SCSS override, and editing the TOC theme settings to allow the content block to shrink correctly.

In addition, the erroneous installation command in https://github.com/AvaloniaUI/avalonia-docs/pull/974 has been opportunistically fixed.

The above changes have been tested locally and confirmed to resolve the relevant issues.