### PR TITLE
Increased the line-height of search titles

### DIFF
--- a/src/styles/docsearch.scss
+++ b/src/styles/docsearch.scss
@@ -494,6 +494,10 @@ html[data-theme='dark'] .DocSearch-Hit-path {
   text-align: center;
 }
 
+.DocSearch-Title {
+  line-height: 2em;
+}
+
 .DocSearch-NoResults-Prefill-List {
   padding: 0;
   list-style: none;


### PR DESCRIPTION
If the search term is too long, it wraps to a new line, which has a line height that is too small, resulting in this horrible-looking result. 

<img width="3214" height="2200" alt="docs avaloniaui net_docs_welcome" src="https://github.com/user-attachments/assets/26b04ea9-f341-4d9b-8899-d83bc19d0555" />

I've confirmed it looks correct when searching with the long text. Might be worth a very quick sanity check that this doesn't break something else 👀 