### PR TITLE
Platform options

### DIFF
--- a/docs/platform-specific-guides/android/android.md
+++ b/docs/platform-specific-guides/android/android.md
@@ -2,7 +2,7 @@
 id: android
 title: Developing with Avalonia for Android
 description: Setting up the Android development environment for building Avalonia applications, including SDK and workload installation.
-doc-type: guide
+doc-type: overview
 ---
 
 ## Setting up your developer environment
@@ -72,6 +72,37 @@ maui-check
 ```
 
 With the above _Android_ development environment setup, you will be able to build _Android_ applications, and run them in a simulator on your platform.
+
+## Configuring Android platform options
+
+`AndroidPlatformOptions` controls how Avalonia renders on Android. Apply it by overriding `CustomizeAppBuilder` in your `AvaloniaAndroidApplication` subclass:
+
+```csharp
+protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
+{
+    return base.CustomizeAppBuilder(builder)
+        .With(new AndroidPlatformOptions
+        {
+            RenderingMode = new[]
+            {
+                AndroidRenderingMode.Egl,
+                AndroidRenderingMode.Software
+            }
+        });
+}
+```
+
+### Rendering mode
+
+`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is `Egl`, then `Software`.
+
+| Mode | Description |
+|---|---|
+| `Egl` | GPU rendering through EGL (OpenGL ES). The default GPU backend. |
+| `Vulkan` | GPU rendering through Vulkan. |
+| `Software` | CPU rendering into a framebuffer. |
+
+To support the widest range of devices, include `Software` as a fallback. If `RenderingMode` is empty, or none of the listed modes initialize, Avalonia throws an `InvalidOperationException`.
 
 ## See also
 

--- a/docs/platform-specific-guides/android/android.md
+++ b/docs/platform-specific-guides/android/android.md
@@ -102,7 +102,9 @@ protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
 | `Vulkan` | GPU rendering through Vulkan. |
 | `Software` | CPU rendering into a framebuffer. |
 
-To support the widest range of devices, include `Software` as a fallback. If `RenderingMode` is empty, or none of the listed modes initialize, Avalonia throws an `InvalidOperationException`.
+To support the widest range of devices, include `Software` as a fallback.
+
+`RenderingMode` must contain at least one mode. If it is empty, or none of the listed modes initialize, Avalonia throws an `InvalidOperationException`.
 
 ## See also
 

--- a/docs/platform-specific-guides/android/android.md
+++ b/docs/platform-specific-guides/android/android.md
@@ -94,7 +94,7 @@ protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
 
 ### Rendering mode
 
-`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is `Egl`, then `Software`.
+`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is a two-item list of `Egl` first, `Software` second.
 
 | Mode | Description |
 |---|---|

--- a/docs/platform-specific-guides/ios.md
+++ b/docs/platform-specific-guides/ios.md
@@ -1,6 +1,8 @@
 ---
 id: ios
 title: iOS
+description: How to set up, provision, and configure Avalonia apps for iOS, including rendering options, Mac Catalyst, and deep linking.
+doc-type: overview
 ---
 
 import IOSOpenXcodeScreenshot from '/img/guides/platform-specific-guides/ios/ios-open-xcode.png';
@@ -83,6 +85,36 @@ If successful, your device is now provisioned for development. To find your code
 <Image light={IOSCertScreenshot} alt="" position="center" maxWidth={400} cornerRadius="true"/>
 
 The bold text at the top of the window on your selected development certificate is your signing key value (e.g., `Apple Development: dan@walms.co.uk (3L323F7VSS)`).
+
+## Configuring iOS platform options
+
+`iOSPlatformOptions` controls how Avalonia renders on iOS. Apply it by overriding `CustomizeAppBuilder` in your `AppDelegate`, which inherits from `AvaloniaAppDelegate`:
+
+```csharp
+protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
+{
+    return base.CustomizeAppBuilder(builder)
+        .With(new iOSPlatformOptions
+        {
+            RenderingMode = new[]
+            {
+                iOSRenderingMode.Metal,
+                iOSRenderingMode.OpenGl
+            }
+        });
+}
+```
+
+### Rendering mode
+
+`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is `Metal`, then `OpenGl`.
+
+| Mode | Description |
+|---|---|
+| `Metal` | GPU rendering through Metal. Currently works only on iOS, and is not yet stable. |
+| `OpenGl` | GPU rendering through EAGL on iOS and tvOS. Not supported on Mac Catalyst. |
+
+`RenderingMode` must contain at least one mode. If it is empty, or none of the listed modes initialize, Avalonia throws an `InvalidOperationException`.
 
 ## Mac Catalyst
 

--- a/docs/platform-specific-guides/ios.md
+++ b/docs/platform-specific-guides/ios.md
@@ -107,7 +107,7 @@ protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
 
 ### Rendering mode
 
-`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is `Metal`, then `OpenGl`.
+`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is a two-item list of `Metal` first, `OpenGl` second.
 
 | Mode | Description |
 |---|---|

--- a/docs/platform-specific-guides/linux.md
+++ b/docs/platform-specific-guides/linux.md
@@ -1,8 +1,8 @@
 ---
 id: linux
 title: Desktop Linux
-description: How Avalonia runs on desktop Linux, including WSL 2 setup and accessibility support with AT-SPI2.
-doc-type: guide
+description: How Avalonia runs on desktop Linux, including X11 platform options, WSL 2 setup, and accessibility support with AT-SPI2.
+doc-type: overview
 ---
 
 ## How Avalonia runs on Linux
@@ -11,6 +11,78 @@ Avalonia uses the Win32 API on Windows, its own native Objective-C++ backend on 
 
 :::note
 Wayland support is coming in Avalonia 12.0.
+:::
+
+## Configuring X11 platform options
+
+`X11PlatformOptions` controls how Avalonia renders and integrates with the desktop on Linux. Pass an instance to `.With()` when you build the application in `Program.cs`:
+
+```csharp
+AppBuilder.Configure<App>()
+    .UsePlatformDetect()
+    .With(new X11PlatformOptions
+    {
+        RenderingMode = new[]
+        {
+            X11RenderingMode.Glx,
+            X11RenderingMode.Software
+        },
+        UseDBusMenu = true
+    });
+```
+
+Every option has a default, so set only the ones you need to change.
+
+### Rendering mode
+
+`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is `Glx`, then `Software`.
+
+| Mode | Description |
+|---|---|
+| `Glx` | GPU rendering through GLX (OpenGL on X11). The default GPU backend. |
+| `Egl` | GPU rendering through native Linux EGL. |
+| `Vulkan` | GPU rendering through Vulkan. |
+| `Software` | CPU rendering into a framebuffer. |
+
+To support the widest range of devices, including remote sessions and virtual machines without GPU acceleration, include `Software` as a fallback. If none of the listed modes initialize, Avalonia throws an `InvalidOperationException`.
+
+### Rendering options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `RenderingMode` | `IReadOnlyList<X11RenderingMode>` | `Glx`, `Software` | Ordered list of graphics backends with fallback, described above. |
+| `GlProfiles` | `IList<GlVersion>` | OpenGL 4.0, 3.2, 3.0; OpenGL ES 3.2, 3.0, 2.0 | OpenGL and OpenGL ES profiles tried when using `Glx` or `Egl` rendering, in priority order. |
+| `GlxRendererBlacklist` | `IList<string>` | `llvmpipe`, `SVGA3D` | GLX renderer names that force a fallback away from `Glx`. The defaults skip the `llvmpipe` software rasterizer and the `SVGA3D` VMware driver. |
+| `ShouldRenderOnUIThread` | `bool` | `false` | Renders on the UI thread instead of a dedicated render thread. Useful on single-core devices. |
+| `UseRetainedFramebuffer` | `bool?` | `null` | When using software rendering, keeps an offscreen bitmap of the previous frame for each window. Saves a blit at the cost of higher memory use with many windows. |
+
+### Desktop integration options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `UseDBusMenu` | `bool` | `true` | Exports the application menu over D-Bus for global menu bars on desktop environments that support them, such as KDE, and XFCE or MATE with the appropriate plugin. |
+| `UseDBusFilePicker` | `bool` | `true` | Uses the D-Bus portal [file picker](/docs/services/storage/file-picker-options) instead of GTK. |
+| `EnableSessionManagement` | `bool` | `true` | Enables the X Session Management Protocol, letting the application respond to session shutdown requests. Set the `AVALONIA_X11_USE_SESSION_MANAGEMENT` environment variable to `0` to disable it by default. |
+| `WmClass` | `string?` | entry assembly name | Sets the X11 `WM_CLASS` window property. Window managers use it to group windows and match the application to its `.desktop` entry and icon. |
+| `OverlayPopups` | `bool` | `false` | Embeds popups inside the window instead of creating separate top-level popup windows. |
+
+### Input options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `EnableIme` | `bool?` | `true` | Enables the input method editor for composing characters that are not on the keyboard. Used automatically for Mandarin, Japanese, Vietnamese, and Korean input. |
+| `EnableMultiTouch` | `bool?` | `true` | Recognizes more than one simultaneous point of contact on a touchpad or touchscreen. |
+| `EnableInputFocusProxy` | `bool` | `false` | Enables the X11 input focus proxy. |
+
+### Event loop options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `UseGLibMainLoop` | `bool` | `false` | Uses a `GMainLoop`-based dispatcher instead of the default epoll-based one. Enable it to use GLib-based libraries on the main thread. |
+| `ExternalGLibMainLoopExceptionLogger` | `Action<Exception>?` | `null` | Callback to inspect managed exceptions raised on a GLib main loop that Avalonia does not control. Relevant only when `UseGLibMainLoop` is `true`. |
+
+:::caution
+`EnableDrawnDecorations` and `ForceDrawnDecorations` enable client-side window decorations (titlebar, borders, and resize grips drawn by Avalonia rather than the window manager). Both are experimental, used mainly for testing, and may change or be removed in a future release.
 :::
 
 ## WSL 2 (Windows Subsystem for Linux)

--- a/docs/platform-specific-guides/linux.md
+++ b/docs/platform-specific-guides/linux.md
@@ -31,7 +31,13 @@ AppBuilder.Configure<App>()
     });
 ```
 
-Every option has a default, so set only the ones you need to change.
+The following options are available.
+
+- [Rendering mode](#rendering-mode)
+- [Rendering options](#rendering-options)
+- [Desktop integration options](#desktop-integration-options)
+- [Input options](#input-options)
+- [Event loop options](#event-loop-options)
 
 ### Rendering mode
 

--- a/docs/platform-specific-guides/linux.md
+++ b/docs/platform-specific-guides/linux.md
@@ -15,7 +15,7 @@ Wayland support is coming in Avalonia 12.0.
 
 ## Configuring X11 platform options
 
-`X11PlatformOptions` controls how Avalonia renders and integrates with the desktop on Linux. Pass an instance to `.With()` when you build the application in `Program.cs`:
+`X11PlatformOptions` controls how Avalonia renders and integrates with the desktop on Linux. Apply it by passing to `.With()` in the `AppBuilder` in `Program.cs`:
 
 ```csharp
 AppBuilder.Configure<App>()

--- a/docs/platform-specific-guides/macos.md
+++ b/docs/platform-specific-guides/macos.md
@@ -1,6 +1,8 @@
 ---
 id: macos
 title: macOS
+description: macOS-specific Avalonia features: the native backend, app identity, Dock and menu bar integration, native view embedding, and platform options.
+doc-type: overview
 ---
 
 ## How Avalonia runs on macOS
@@ -22,6 +24,67 @@ If your app needs macOS APIs beyond what Avalonia exposes, change your target fr
 ```
 
 This gives you access to the complete set of APIs provided by the .NET macOS workload, but it comes with a constraint: **builds targeting a macOS TFM must be performed on macOS**. You lose the ability to cross-compile from Windows or Linux.
+
+## Configuring macOS platform options
+
+macOS configuration is split across two option classes, both passed to `.With()` when you build the application in `Program.cs`:
+
+- `AvaloniaNativePlatformOptions` controls the rendering backend and window behavior.
+- `MacOSPlatformOptions` controls how the application integrates with the macOS shell (Dock, menu bar, and process identity).
+
+```csharp
+AppBuilder.Configure<App>()
+    .UsePlatformDetect()
+    .With(new AvaloniaNativePlatformOptions
+    {
+        RenderingMode = new[]
+        {
+            AvaloniaNativeRenderingMode.Metal,
+            AvaloniaNativeRenderingMode.Software
+        }
+    })
+    .With(new MacOSPlatformOptions
+    {
+        ShowInDock = true
+    });
+```
+
+Every option has a default, so set only the ones you need to change.
+
+### Rendering mode
+
+`AvaloniaNativePlatformOptions.RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is `Metal`, then `OpenGl`, then `Software`.
+
+| Mode | Description |
+|---|---|
+| `Metal` | GPU rendering through Apple's Metal API. The default GPU backend. |
+| `OpenGl` | GPU rendering through native OpenGL. |
+| `Software` | CPU rendering into a framebuffer. |
+
+To support the widest range of devices, include `Software` as a fallback. If none of the listed modes initialize, Avalonia throws an `InvalidOperationException`.
+
+### Backend options
+
+`AvaloniaNativePlatformOptions` covers the rendering backend and window-level behavior.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `RenderingMode` | `IReadOnlyList<AvaloniaNativeRenderingMode>` | `Metal`, `OpenGl`, `Software` | Ordered list of graphics backends with fallback, described above. |
+| `OverlayPopups` | `bool` | `false` | Embeds popups inside the window instead of creating separate top-level popup windows. |
+| `AppSandboxEnabled` | `bool` | `true` | Wraps storage calls in a secure context and enables `IStorageItem.SaveBookmarkAsync` and related APIs. App Store distribution requires the sandbox to be enabled. |
+| `AvaloniaNativeLibraryPath` | `string?` | `null` | Path to a custom-built `libAvaloniaNative.dylib`. See [Native code](#native-code) for the build workflow. |
+
+### Shell integration options
+
+`MacOSPlatformOptions` controls how the application appears in the macOS Dock and menu bar.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `ShowInDock` | `bool` | `true` | Shows the application icon in the Dock while it runs. Set to `false` for background or agent apps. |
+| `DisableDefaultApplicationMenuItems` | `bool` | `false` | Prevents Avalonia from adding default items such as Quit and Hide to the [application menu](#application-menu). |
+| `DisableNativeMenus` | `bool` | `false` | Disables the [native macOS menu bar](#native-menu-bar) for the application. |
+| `DisableSetProcessName` | `bool` | `false` | Prevents Avalonia from setting the process name through `NSProcessInfo` at runtime. |
+| `DisableAvaloniaAppDelegate` | `bool` | `false` | Prevents Avalonia from installing its own `AppDelegate`. Useful when [running as a plugin inside an existing macOS application](#embedding-avalonia-in-a-native-macos-app). |
 
 ## Application name and identity
 

--- a/docs/platform-specific-guides/webassembly.md
+++ b/docs/platform-specific-guides/webassembly.md
@@ -1,6 +1,8 @@
 ---
 id: webassembly
 title: WebAssembly
+description: How to run Avalonia in the browser with WebAssembly, including project setup, platform options, and JavaScript interop.
+doc-type: overview
 ---
 
 Avalonia applications can run in the browser using WebAssembly (WASM). This page explains how to set up a project for browser deployment and how to use JavaScript interop.
@@ -50,6 +52,56 @@ dotnet run
 # Debug at url: http://127.0.0.1:53576/_framework/debug
 # Debug at url: https://127.0.0.1:53577/_framework/debug
 ```
+
+## Configuring browser platform options
+
+`BrowserPlatformOptions` controls how Avalonia renders and behaves in the browser. Pass an instance to `StartBrowserAppAsync` in your Browser project's `Program.cs`:
+
+```csharp
+internal sealed partial class Program
+{
+    private static Task Main(string[] args) => BuildAvaloniaApp()
+        .StartBrowserAppAsync("out", new BrowserPlatformOptions
+        {
+            RenderingMode = new[]
+            {
+                BrowserRenderingMode.WebGL2,
+                BrowserRenderingMode.Software2D
+            }
+        });
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>();
+}
+```
+
+The first argument to `StartBrowserAppAsync` is the `id` of the HTML element where Avalonia renders. Every option has a default, so set only the ones you need to change.
+
+### Rendering mode
+
+`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is `WebGL2`, then `WebGL1`, then `Software2D`.
+
+| Mode | Description |
+|---|---|
+| `WebGL2` | GPU rendering through WebGL 2. The default GPU backend. |
+| `WebGL1` | GPU rendering through WebGL 1. |
+| `Software2D` | CPU rendering using the HTML 2D canvas. |
+
+If none of the listed modes initialize, Avalonia throws an `InvalidOperationException`.
+
+### Other options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `RenderingMode` | `IReadOnlyList<BrowserRenderingMode>` | `WebGL2`, `WebGL1`, `Software2D` | Ordered list of graphics backends with fallback, described above. |
+| `PreferManagedThreadDispatcher` | `bool?` | `true` | Creates a controlled dispatcher loop on the web worker thread. Used only when `WasmEnableThreads` is `true`. |
+| `PreferFileDialogPolyfill` | `bool` | `false` | Forces the `native-file-system-adapter` polyfill for file dialogs instead of the browser's native implementation. |
+| `FrameworkAssetPathResolver` | `Func<string, string>?` | `null` | Customizes the paths where Avalonia modules and the service locator are resolved. The default path depends on the backend (browser or Blazor). |
+| `AvaloniaServiceWorkerScope` | `string?` | `null` | Sets the scope for the Avalonia service worker. Defaults to the current domain root. Used only when `RegisterAvaloniaServiceWorker` is enabled. |
+
+:::caution
+`RegisterAvaloniaServiceWorker` registers a service worker that can act as a save file picker fallback on browsers without native support. It is marked unstable and might not work reliably.
+:::
 
 ## Deployment
 

--- a/docs/platform-specific-guides/windows.md
+++ b/docs/platform-specific-guides/windows.md
@@ -9,9 +9,87 @@ doc-type: overview
 
 Avalonia uses the Win32 API directly on Windows. No additional workloads or dependencies are needed beyond the .NET SDK. Your target framework is simply `net9.0` or `net10.0`, not a platform-specific one.
 
-Rendering uses Skia backed by Direct3D, with an automatic software fallback when GPU acceleration is unavailable (for example, in remote desktop sessions or virtual machines without GPU passthrough). Input, windowing, clipboard, file dialogs, drag-and-drop, and accessibility are all provided through standard Win32 APIs.
+Rendering uses Skia on top of Direct3D 11, reached through the ANGLE translation layer (the default `AngleEgl` mode described in [Configuring Win32 platform options](#configuring-win32-platform-options)), with an automatic software fallback when GPU acceleration is unavailable (for example, in remote desktop sessions or virtual machines without GPU passthrough). Input, windowing, clipboard, file dialogs, drag-and-drop, and accessibility are all provided through standard Win32 APIs.
 
 Because there is no dependency on a Windows-specific .NET workload, you can cross-compile Windows builds from macOS or Linux. The resulting binary runs on any supported version of Windows with the .NET runtime installed.
+
+## Configuring Win32 platform options
+
+`Win32PlatformOptions` controls how Avalonia renders, composites, and scales on Windows. Pass an instance to `.With()` when you build the application in `Program.cs`:
+
+```csharp
+AppBuilder.Configure<App>()
+    .UsePlatformDetect()
+    .With(new Win32PlatformOptions
+    {
+        RenderingMode = new[]
+        {
+            Win32RenderingMode.AngleEgl,
+            Win32RenderingMode.Software
+        },
+        CompositionMode = new[]
+        {
+            Win32CompositionMode.WinUIComposition,
+            Win32CompositionMode.RedirectionSurface
+        },
+        DpiAwareness = Win32DpiAwareness.PerMonitorDpiAware
+    });
+```
+
+Every option has a default, so set only the ones you need to change.
+
+### Rendering mode
+
+`RenderingMode` is an ordered list of graphics backends. Avalonia tries each one in turn and uses the first that initializes successfully, so the first entry has the highest priority. The default is `AngleEgl`, then `Software`.
+
+| Mode | Description |
+|---|---|
+| `AngleEgl` | GPU rendering through ANGLE EGL. The default GPU backend. |
+| `Wgl` | GPU rendering through native Windows OpenGL. |
+| `Vulkan` | GPU rendering through native Windows Vulkan. |
+| `Software` | CPU rendering into a framebuffer. |
+
+ANGLE (Almost Native Graphics Layer Engine) translates the OpenGL ES calls that Skia produces into Direct3D 11 on Windows. This is why `AngleEgl` is the default GPU backend, and why it is the mode the `WinUIComposition` and `DirectComposition` modes below depend on.
+
+To support the widest range of devices, including remote desktop sessions and virtual machines without a GPU, include `Software` as a fallback. If none of the listed modes initialize, Avalonia throws an `InvalidOperationException`.
+
+### Composition mode
+
+`CompositionMode` is an ordered list of window composition backends, tried in priority order like `RenderingMode`. The default is `WinUIComposition`, `DirectComposition`, then `RedirectionSurface`.
+
+| Mode | Requirements and behavior |
+|---|---|
+| `WinUIComposition` | Windows 10 build 17134 and above. Supports acrylic effects and high refresh rate rendering. Requires `RenderingMode` to include `AngleEgl`. |
+| `DirectComposition` | Windows 8 and above. Requires `RenderingMode` to include `AngleEgl`. |
+| `LowLatencyDxgiSwapChain` | Feature Level 11_3, Windows 8.1 and above. Renders through a low-latency DXGI swap chain for reduced input latency, without the transparency and blur of `WinUIComposition`. Requires `RenderingMode` to include `AngleEgl`. |
+| `RedirectionSurface` | Compatibility fallback for older systems. Some Avalonia features may not work. |
+
+Include `RedirectionSurface` as a fallback to support the widest range of devices. If none of the listed modes apply, Avalonia throws an `InvalidOperationException`.
+
+For how rendering and composition fit together, see [Application Architecture](/docs/fundamentals/architecture#the-rendering-pipeline).
+
+### DPI awareness
+
+`DpiAwareness` sets how the application responds to display scaling. The default is `PerMonitorDpiAware`.
+
+| Value | Behavior |
+|---|---|
+| `PerMonitorDpiAware` | Adjusts the scale factor whenever DPI changes, such as when a window moves between monitors. |
+| `SystemDpiAware` | Queries DPI once at startup and does not adjust to later changes. |
+| `Unaware` | The application is DPI unaware, and the system bitmap-scales it. |
+
+See [High DPI and per-monitor scaling](#high-dpi-and-per-monitor-scaling) for how scaling affects layout and assets.
+
+### Other options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `OverlayPopups` | `bool` | `false` | Embeds popups inside the window instead of creating separate top-level popup windows. |
+| `WinUICompositionBackdropCornerRadius` | `float?` | `null` | When `CompositionMode` is `WinUIComposition`, creates rounded-corner blur brushes. Leave `null` for sharp corners. Use it for a rounded, blurred Windows 10 app or a borderless Windows 11 app. |
+| `ShouldRenderOnUIThread` | `bool` | `false` | Renders on the UI thread instead of a dedicated render thread. Applies only when `CompositionMode` is `RedirectionSurface`. Intended for interop with systems that must render on the UI thread, such as WPF. |
+| `WglProfiles` | `IList<GlVersion>` | `4.0`, `3.2` | OpenGL profiles used when `RenderingMode` is `Wgl`. |
+| `CustomPlatformGraphics` | `IPlatformGraphics?` | `null` | Supplies a custom graphics context such as a custom `ISkiaGpu`. When set, `RenderingMode` is ignored and `CompositionMode` accepts only `null` or `RedirectionSurface`. |
+| `GraphicsAdapterSelectionCallback` | `Func<...>` | `null` | Callback invoked when the compositor creates a platform graphics device, letting you select the adapter. Currently called only for `AngleEgl` rendering mode when DirectX 11 is used. |
 
 ## Window transparency and Mica
 
@@ -105,7 +183,7 @@ For more details, see [Platform Settings](/docs/services/platform-settings).
 
 ## High DPI and per-monitor scaling
 
-Avalonia is per-monitor DPI-aware by default on Windows. Each monitor reports its own scaling factor, and Avalonia adjusts layout and rendering automatically as windows move between displays.
+Avalonia is per-monitor DPI-aware by default on Windows. Each monitor reports its own scaling factor, and Avalonia adjusts layout and rendering automatically as windows move between displays. To change this behavior, set the [`DpiAwareness` option](#dpi-awareness).
 
 The `Screen.Scaling` property reports the DPI scale factor for each display:
 

--- a/docs/testing/setting-up-the-headless-platform.md
+++ b/docs/testing/setting-up-the-headless-platform.md
@@ -1,6 +1,8 @@
 ---
 id: setting-up-the-headless-platform
 title: Headless Testing Platform
+description: Run Avalonia without a window for automated testing: simulate input, flush async operations, and capture rendered frames for visual regression.
+doc-type: how-to
 ---
 
 The headless platform runs Avalonia without a visible window, making it ideal for automated testing in CI/CD environments and on machines without a display. It provides the full Avalonia control tree, layout, styling, and data binding, but replaces the real windowing and rendering backends with in-memory implementations.
@@ -194,6 +196,15 @@ public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<TestApplicat
         UseHeadlessDrawing = false
     });
 ```
+
+### Headless platform options
+
+`AvaloniaHeadlessPlatformOptions` is passed to `.UseHeadless()` and has two properties:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `UseHeadlessDrawing` | `bool` | `true` | Uses the fake drawing backend that produces no pixels. Set to `false` and call `.UseSkia()` to enable real rendering and frame capture. |
+| `FrameBufferFormat` | `PixelFormat` | `Rgba8888` | Pixel format of the headless framebuffer used when rendering is enabled. |
 
 ### Capturing a frame
 


### PR DESCRIPTION
I've had Claude add some information about the various platform options. I had it read the source for each from Master and add the docs. Some of the XML documentation doesn't match the implementation though. 

For example:

- The [XML documentation](https://github.com/AvaloniaUI/Avalonia/blob/5efb4a2bd7bd92b86809ac01c4b623d6eeb838e1/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs#L60) for macOS is wrong. We should fix that. 

- I'm unsure what the situation is with [iOS](https://github.com/AvaloniaUI/Avalonia/blob/master/src/iOS/Avalonia.iOS/Platform.cs). The docs match the code from Master, which shows OpenGL as being the default, which feels like a mistake given macOS is using Metal.  Can we confirm if Metal is genuinely unstable on iOS, or is the XML comment old?  