### PR TITLE
Update Avalonia Plus tool installation instructions

### DIFF
--- a/tools/developer-tools/installation.md
+++ b/tools/developer-tools/installation.md
@@ -112,7 +112,7 @@ On macOS or Linux, the installation location may not be automatically added to t
 
 To resolve this issue, you must append the tool location to the PATH environment variable. The default location is usually `$HOME/.dotnet/tools`.
 
-For more information, see [Troubleshooting .NET tool usage issues](https://learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#executable-file-not-found).
+For more information, see [Troubleshooting .NET tool usage issues](https://learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#global-tools).
 :::
 
 ## Step 2: Installing Diagnostics Support package

--- a/tools/developer-tools/installation.md
+++ b/tools/developer-tools/installation.md
@@ -31,12 +31,6 @@ Support package requires **Avalonia 11.2.0** or newer, and built on **.NET Stand
 
 This package is compatible with Browser and Android/iOS projects.
 
-:::note
-
-Demo project with Developer Tools preconfigured can be found at [AvaloniaUI/AvaloniaUI.DeveloperTools/samples/SimpleToDoList](https://github.com/AvaloniaUI/AvaloniaUI.DeveloperTools/tree/main/samples/SimpleToDoList#simpletodolist).
-
-:::
-
 ## Step 1: Installing AvaloniaUI Developer Tools
 
 AvaloniaUI Developer Tools is currently a native [.NET tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools), with update mechanism provided by the SDK.
@@ -53,20 +47,17 @@ If you are upgrading app from .NET 8/9 installation, you should first uninstall 
 
 Developer Tools can be then updated by running `dotnet tool update` command.
 
-<details>
-<summary>Developer tools update command</summary>
-
 ```bash
 dotnet tool update --global AvaloniaUI.DeveloperTools
 ```
-
-</details>
-
 
 </TabItem>
 <TabItem value="net8" label=".NET 8/9">
 
 If you're using .NET SDK older than 10, you must install a specific package depending on the running platform.
+
+<details>
+<summary>Installation commands</summary>
 
 **Windows:**
 
@@ -86,10 +77,12 @@ dotnet tool install --global AvaloniaUI.DeveloperTools.macOS
 dotnet tool install --global AvaloniaUI.DeveloperTools.Linux
 ```
 
+</details>
+
 Developer Tools can be then updated by running `dotnet tool update` command.
 
 <details>
-<summary>Developer tools update commands</summary>
+<summary>Update commands</summary>
 
 **Windows:**
 
@@ -113,6 +106,14 @@ dotnet tool update --global AvaloniaUI.DeveloperTools.Linux
 
 </TabItem>
 </Tabs>
+
+:::warning
+On macOS or Linux, the installation location may not be automatically added to the PATH environment variable. This surfaces as a "command not found" error when trying to run `avdt`.
+
+To resolve this issue, you must append the tool location to the PATH environment variable. The default location is usually `$HOME/.dotnet/tools`.
+
+For more information, see [Troubleshooting .NET tool usage issues](https://learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#executable-file-not-found).
+:::
 
 ## Step 2: Installing Diagnostics Support package
 

--- a/tools/developer-tools/mcp.md
+++ b/tools/developer-tools/mcp.md
@@ -327,13 +327,9 @@ If the assistant returns the tree structure, setup is complete.
 
 ### "avdt" command not found
 
-The `avdt` command must be on your system PATH. If you installed it as a global .NET tool, ensure `~/.dotnet/tools` (macOS/Linux) or `%USERPROFILE%\.dotnet\tools` (Windows) is in your PATH.
+The `avdt` command must be on your system PATH. If you installed it as a global .NET tool, check if `$HOME/.dotnet/tools` (macOS/Linux) or `%USERPROFILE%\.dotnet\tools` (Windows) is in your PATH. If not, add the directory to your PATH.
 
-You can verify the tool is installed by running:
-
-```bash
-dotnet tool list -g
-```
+For more information, see [Troubleshooting .NET tool usage issues](https://learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#executable-file-not-found).
 
 ### License key not detected
 

--- a/tools/parcel/mcp.md
+++ b/tools/parcel/mcp.md
@@ -245,13 +245,9 @@ If the assistant returns a list of capabilities, setup is complete.
 
 ### "parcel" command not found
 
-The `parcel` command must be on your system PATH. If you installed it as a global .NET tool, ensure `~/.dotnet/tools` (macOS/Linux) or `%USERPROFILE%\.dotnet\tools` (Windows) is in your PATH.
+The `parcel` command must be on your system PATH. If you installed it as a global .NET tool, check if `$HOME/.dotnet/tools` (macOS/Linux) or `%USERPROFILE%\.dotnet\tools` (Windows) is in your PATH. If not, add the directory to your PATH.
 
-You can verify the tool is installed by running:
-
-```bash
-dotnet tool list -g
-```
+For more information, see [Troubleshooting .NET tool usage issues](https://learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#executable-file-not-found).
 
 ### License key not detected
 

--- a/tools/parcel/setup.md
+++ b/tools/parcel/setup.md
@@ -38,20 +38,17 @@ If you are upgrading app from .NET 8/9 installation, you should first uninstall 
 
 Parcel can then be updated by running the `dotnet tool update` command.
 
-<details>
-<summary>Parcel update command</summary>
-
 ```bash
 dotnet tool update --global AvaloniaUI.Parcel
 ```
-
-</details>
-
 
 </TabItem>
 <TabItem value="net8" label=".NET 8/9">
 
 If you're using .NET SDK older than 10, you must install a specific package depending on the running platform.
+
+<details>
+<summary>Installation commands</summary>
 
 **Windows:**
 
@@ -71,10 +68,12 @@ dotnet tool install --global AvaloniaUI.Parcel.macOS
 dotnet tool install --global AvaloniaUI.Parcel.Linux
 ```
 
+</details>
+
 Parcel can then be updated by running the `dotnet tool update` command.
 
 <details>
-<summary>Parcel update commands</summary>
+<summary>Update commands</summary>
 
 **Windows:**
 
@@ -98,6 +97,14 @@ dotnet tool update --global AvaloniaUI.Parcel.Linux
 
 </TabItem>
 </Tabs>
+
+:::warning
+On macOS or Linux, the installation location may not be automatically added to the PATH environment variable. This surfaces as a "command not found" error when trying to run `parcel`.
+
+To resolve this issue, you must append the tool location to the PATH environment variable. The default location is usually `$HOME/.dotnet/tools`.
+
+For more information, see [Troubleshooting .NET tool usage issues](https://learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#executable-file-not-found).
+:::
 
 ## Step 2: Run the tool
 


### PR DESCRIPTION
- Update formatting of tabbed sections in DevTools and Parcel installation docs.
- Add callouts to warn about PATH issues in DevTools and Parcel installation docs.
- Edit troubleshooting sections of DevTools and Parcel MCP docs to explicitly mention adding intallation locations to PATH.
- Add links to .NET documentation.