### PR TITLE
Fix hero image links going to broken pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -321,7 +321,7 @@ gtag('consent', 'default', {
       respectPrefersColorScheme: true,
     },
     zoom: {
-      selector: '.markdown :not(em) > img:not(.Card-icon)',
+      selector: '.markdown :not(em) > img:not(.Card-icon):not(.Card-image)',
       background: {
         light: 'rgb(196, 196, 196)',
         dark: 'rgb(17, 17, 19)'


### PR DESCRIPTION
This PR adjusts the Docusaurus config to not trigger image zoom behavior on Card-image components.

This stops the image zoom from seeming to break the linked page, even though the page actually serves correctly.