### PR TITLE
Transparency-related edits

### DIFF
--- a/docs/fundamentals/top-level.md
+++ b/docs/fundamentals/top-level.md
@@ -138,7 +138,7 @@ IStorageProvider StorageProvider { get; }
 
 ### TransparencyBackgroundFallback
 
-Gets or sets the `IBrush` that transparency will blend with when transparency is not supported. By default this is a solid white brush.
+Gets or sets the `IBrush` that transparency will blend with when transparency is not supported or is restricted. By default this is a solid white brush.
 
 ```csharp
 IBrush TransparencyBackgroundFallback { get; set; }

--- a/docs/how-to/window-how-to.md
+++ b/docs/how-to/window-how-to.md
@@ -246,6 +246,8 @@ Check which transparency levels are supported at runtime:
 var supported = this.ActualTransparencyLevel;
 ```
 
+If `ActualTransparencyLevel` returns a lower level than requested, this may be due to an OS restriction rather than a configuration error. For example, macOS and Linux have more limited support for transparency, and Windows may suppress compositor effects when in battery saver mode. It is advisable to set a [`TransparencyBackgroundFallback`](/docs/fundamentals/top-level#transparencybackgroundfallback) with a solid color appropriate for your UI, in case transparency is unavailable on the user's device.
+
 ### Transparent click-through window
 
 To create a transparent overlay window where mouse clicks pass through empty areas to applications underneath, set `TransparencyLevelHint="Transparent"` and remove the window's `Background` by setting it to `{x:Null}`. Interactive controls placed in the window remain clickable.

--- a/docs/platform-specific-guides/windows.md
+++ b/docs/platform-specific-guides/windows.md
@@ -43,6 +43,10 @@ Set the window's `Background` to `Transparent` for any transparency level to tak
 
 For more details, see [Window Management](/docs/app-development/window-management).
 
+:::caution
+Windows may suppress transparency at the OS level regardless of your Avalonia configuration. Common causes are battery saver mode or remote/virtual sessions. It is advisable to set a non-transparent fallback that fits your UI, in case your users run your app under such conditions.
+:::
+
 ## Custom title bars
 
 Windows supports extending the client area into the title bar region for custom chrome. Set `ExtendClientAreaToDecorationsHint` to push your content into the title bar area, and use `WindowDecorationProperties.ElementRole` to mark a region as the draggable title bar:


### PR DESCRIPTION
Edit docs that mention transparency to explicitly call out OS restriction as a possible cause for transparency effects not displaying.