### PR TITLE
Reactivate giscus comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@docusaurus/preset-classic": "^3.8.1",
         "@docusaurus/theme-mermaid": "^3.8.1",
         "@fluentui/react-icons": "^2.0.306",
+        "@giscus/react": "^3.1.0",
         "@gracefullight/docusaurus-plugin-microsoft-clarity": "^1.0.0",
         "@ionic-internal/ionic-ds": "^7.0.0",
         "@mdx-js/react": "^3.1.0",
@@ -4641,6 +4642,18 @@
         "react": ">=16.8.0 <19.0.0"
       }
     },
+    "node_modules/@giscus/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+      "dependencies": {
+        "giscus": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/@gracefullight/docusaurus-plugin-microsoft-clarity": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@gracefullight/docusaurus-plugin-microsoft-clarity/-/docusaurus-plugin-microsoft-clarity-1.0.0.tgz",
@@ -5256,6 +5269,21 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.0",
@@ -6952,8 +6980,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -11002,6 +11029,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/giscus": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+      "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3.2.1"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
@@ -12750,6 +12786,37 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-mermaid": "^3.8.1",
     "@fluentui/react-icons": "^2.0.306",
+    "@giscus/react": "^3.1.0",
     "@gracefullight/docusaurus-plugin-microsoft-clarity": "^1.0.0",
     "@ionic-internal/ionic-ds": "^7.0.0",
     "@mdx-js/react": "^3.1.0",

--- a/src/components/comments/index.js
+++ b/src/components/comments/index.js
@@ -1,0 +1,4 @@
+import React from "react";
+import Giscus from "@giscus/react";
+import { useColorMode } from "@docusaurus/theme-common";
+

--- a/src/components/comments/index.js
+++ b/src/components/comments/index.js
@@ -2,3 +2,25 @@ import React from "react";
 import Giscus from "@giscus/react";
 import { useColorMode } from "@docusaurus/theme-common";
 
+export default function Comments() {
+  const { colorMode } = useColorMode();
+  
+  return (
+    <div>
+      <Giscus
+        id="comments"
+        repo="AvaloniaUI/avalonia-docs"
+        repoId="R_kgDOJarc8w"
+        category="General"
+        categoryId="DIC_kwDOJarc884CbUsp"
+        mapping="pathname"
+        strict="1"
+        reactionsEnabled="1"
+        emitMetadata="0"
+        inputPosition="top"
+        lang="en"
+        loading="lazy"
+      />
+    </div>
+  );
+}

--- a/src/components/comments/index.js
+++ b/src/components/comments/index.js
@@ -20,6 +20,7 @@ export default function Comments() {
         inputPosition="top"
         lang="en"
         loading="lazy"
+        theme={colorMode}
       />
     </div>
   );

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -4,7 +4,7 @@ import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import TagsListInline from '@theme/TagsListInline';
 import EditMetaRow from '@theme/EditMetaRow';
-import Comments from "@site/src/components/comments";
+import Comments from '@site/src/components/comments';
 
 export default function DocItemFooter(): JSX.Element | null {
   const {metadata} = useDoc();
@@ -31,16 +31,16 @@ export default function DocItemFooter(): JSX.Element | null {
       )}
       {canDisplayEditMetaRow && (
         <>
-        <EditMetaRow
-          className={clsx(
-            'row margin-top--sm',
-            ThemeClassNames.docs.docFooterEditMetaRow,
-          )}
-          editUrl={editUrl}
-          lastUpdatedAt={lastUpdatedAt}
-          lastUpdatedBy={lastUpdatedBy}
-        />
-        <Comments />
+          <EditMetaRow
+            className={clsx(
+              'row margin-top--sm',
+              ThemeClassNames.docs.docFooterEditMetaRow,
+            )}
+            editUrl={editUrl}
+            lastUpdatedAt={lastUpdatedAt}
+            lastUpdatedBy={lastUpdatedBy}
+          />
+          <Comments />
         </>
       )}
     </footer>

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -4,6 +4,7 @@ import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import TagsListInline from '@theme/TagsListInline';
 import EditMetaRow from '@theme/EditMetaRow';
+import Comments from "@site/src/components/comments";
 
 export default function DocItemFooter(): JSX.Element | null {
   const {metadata} = useDoc();
@@ -29,6 +30,7 @@ export default function DocItemFooter(): JSX.Element | null {
         </div>
       )}
       {canDisplayEditMetaRow && (
+        <>
         <EditMetaRow
           className={clsx(
             'row margin-top--sm',
@@ -38,6 +40,8 @@ export default function DocItemFooter(): JSX.Element | null {
           lastUpdatedAt={lastUpdatedAt}
           lastUpdatedBy={lastUpdatedBy}
         />
+        <Comments />
+        </>
       )}
     </footer>
   );


### PR DESCRIPTION
This PR reactivates the giscus commenting component on the docs site.

Configuration is identical to the previous implementation on the v11 docs site.

A review of discussions on this repo confirmed that only five discussions have a title that exactly match the pathname of a live page: 
- docs/get-started/starter-tutorial/converting-data
- docs/get-started/starter-tutorial/establishing-events-and-responses
- docs/get-started/starter-tutorial/customizing-the-avalonia-window
- docs/get-started/starter-tutorial/adding-some-layout
- docs/get-started/starter-tutorial/adding-a-control

These are all subpages of the new Getting Started tutorial, which is unchanged between v11 and v12. Therefore, there is no risk of outdated discussions surfacing on pages containing new v12 content.