### PR TITLE
1036 starting from version 12 the call bindingpluginsdatavalidatorsremoveat0 must be removed

### DIFF
--- a/docs/app-development/dependency-injection.md
+++ b/docs/app-development/dependency-injection.md
@@ -12,7 +12,7 @@ This guide shows you step by step how to use DI with Avalonia and the MVVM patte
 ## Prerequisites
 
 - An Avalonia project (created from the Avalonia template or an existing application)
-- .NET 8.0 SDK or later
+- .NET 8.0 SDK or later (.NET 10 is recommended)
 
 ## Step 0: Context and initial code
 
@@ -101,10 +101,6 @@ public class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
-        // If you use CommunityToolkit, line below is needed to remove Avalonia data validation.
-        // Without this line you will get duplicate validations from both Avalonia and CT
-        BindingPlugins.DataValidators.RemoveAt(0);
-
         // Register all the services needed for the application to run
         var collection = new ServiceCollection();
         collection.AddCommonServices();

--- a/docs/app-development/dependency-injection.md
+++ b/docs/app-development/dependency-injection.md
@@ -5,18 +5,22 @@ description: Set up dependency injection in an Avalonia app using Microsoft.Exte
 doc-type: how-to
 ---
 
-[Dependency injection (DI)](https://en.wikipedia.org/wiki/Dependency_injection) allows developers to write cleaner, more modular, and testable code. It accomplishes this by creating discrete services that are passed around/created as needed.
+[Dependency injection (DI)](https://en.wikipedia.org/wiki/Dependency_injection) allows you to write cleaner, more modular, more testable code. This is done by creating discrete services that are passed around or created as needed.
 
-This guide shows you step by step how to use DI with Avalonia and the [Model-View-ViewModel (MVVM) pattern](/docs/fundamentals/the-mvvm-pattern).
+This guide shows you how to use DI with Avalonia and the [Model-View-ViewModel (MVVM) pattern](/docs/fundamentals/the-mvvm-pattern).
 
 ## Prerequisites
 
-- An Avalonia project (created from the Avalonia template or an existing application)
+- An Avalonia project
 - .NET 8.0 SDK or later (.NET 10 is recommended)
 
 ## Step 0: Context and initial code
 
-Assume that you have an app with a `MainViewModel`, a `BusinessService` and a `Repository`. `MainViewModel` has a dependency on `IBusinessService` and `BusinessService` on `IRepository`. A simple implementation would look like this:
+Assume that you have an app with a `MainViewModel`, a `BusinessService` and a `Repository`. `MainViewModel` has a dependency on `IBusinessService`, and `BusinessService` has one on `IRepository`.
+
+<Tabs>
+
+<TabItem value="mainviewmodel" label="MainViewModel">
 
 ```csharp
 public partial class MainViewModel
@@ -30,6 +34,10 @@ public partial class MainViewModel
 }
 ```
 
+</TabItem>
+
+<TabItem value="businessservice" label="BusinessService">
+
 ```csharp
 public class BusinessService : IBusinessService
 {
@@ -42,13 +50,21 @@ public class BusinessService : IBusinessService
 }
 ```
 
+</TabItem>
+
+<TabItem value="repository" label="Repository">
+
 ```csharp
 public class Repository : IRepository
 {
 }
 ```
 
-Traditionally, you would directly instantiate `Repository` and pass it into `BusinessService` then pass it into `MainViewModel`, like this:
+</TabItem>
+
+</Tabs>
+
+Traditionally, you would directly instantiate `Repository`, pass it into `BusinessService`, then pass it into `MainViewModel`, like this:
 
 ```csharp
 var window = new MainWindow
@@ -57,23 +73,26 @@ var window = new MainWindow
 }
 ```
 
-This works great for simple constructors that are not used very often and don't ever change. But this pattern does not scale well, because:
-- The more dependencies your constructor has the more things you will need to instantiate yourself and pass in. Instantiating the dependencies locally in the constructor (such as by doing `new MainViewModel(new MyService())`) results in direct rigid coupling to a specific instance of the dependencies. 
-- Similarly if the `MainViewModel` constructor itself creates its own dependencies, it also becomes directly coupled to the creation of the dependencies which can result in many of the same problems. 
-- Furthermore, if `MainViewModel` is instantiated in many places, _every_ instantiation of `MainViewModel` would also need to be updated should the dependencies of `MainViewModel` ever change (such as the addition of new dependencies, or changing which implementation of a dependency to use).
+This approach is frequently used for simple constructors that are not used often and do not change. However, it does not scale well with increasing complexity, because:
 
-Dependency injection solves this problem by abstracting away the creation of objects and their dependencies. This allows for well encapsulated services that will be automatically passed into any other service that is registered to use them.
+- The more dependencies your constructor has, the more things you will need to instantiate and pass in. Instantiating the dependencies locally in the constructor (such as `new MainViewModel(new MyService())`) results in rigid coupling to a specific instance of a dependency.
+- If the `MainViewModel` constructor creates its own dependencies, it also becomes directly coupled to the creation of dependencies.
+- If `MainViewModel` is instantiated in many places, _every_ instantiation of `MainViewModel` would need to be updated should the dependencies ever change.
+
+Dependency injection solves this problem by abstracting away the creation of objects and their dependencies. This allows for well-encapsulated services that are automatically passed into any service registered to use them.
 
 ## Step 1: Install the NuGet package for DI
-There are many DI container providers available ([DryIoC](https://github.com/dadhi/DryIoc), [Autofac](https://github.com/autofac/Autofac), [Pure.DI](https://github.com/DevTeam/Pure.DI)) but this guide focuses on `Microsoft.Extensions.DependencyInjection`, a lightweight, extensible dependency injection container. It provides a convention-based way to add DI to .NET applications, including Avalonia-based desktop applications.
 
-Run the following command in a terminal inside your project directory to install the DI package:
+Many DI container providers are available (e.g., [DryIoC](https://github.com/dadhi/DryIoc), [Autofac](https://github.com/autofac/Autofac), [Pure.DI](https://github.com/DevTeam/Pure.DI)), but this guide focuses on `Microsoft.Extensions.DependencyInjection`, a lightweight, extensible DI container. It provides a convention-based approach to add DI to .NET applications, including Avalonia applications.
+
+To install the DI package, run the following command inside your project directory.
 
 ```shell
 dotnet add package Microsoft.Extensions.DependencyInjection
 ```
 
-## Step 2: Add ServiceCollectionExtensions
+## Step 2: Add `ServiceCollectionExtensions`
+
 The following code creates an extension method for `IServiceCollection`. The method registers services to the service collection and makes them available for injection.
 
 ```csharp
@@ -88,8 +107,9 @@ public static class ServiceCollectionExtensions
 }
 ```
 
-## Step 3: Modify App.axaml.cs
-Next, modify the `App.axaml.cs` class to use the DI container. This allows the view model registered in the previous step to be resolved via the dependency injection container. The fully realized view model can then be set to the data context of the `MainWindow`/`MainView`.
+## Step 3: Modify `App.axaml.cs`
+
+Modify `App.axaml.cs` to use the DI container. This allows the view model registered in the previous step to be resolved via the DI container. The fully realized view model can then be set to the data context of the `MainWindow`/`MainView`.
 
 ```csharp
 public class App : Application
@@ -129,7 +149,7 @@ public class App : Application
 }
 ```
 
-## Verify the result
+## Step 4: Verify the result
 
 Run your application. If the DI container is configured correctly, the `MainWindow` (or `MainView`) appears with its `DataContext` set to a fully resolved `MainViewModel` instance, including all injected dependencies.
 

--- a/docs/app-development/dependency-injection.md
+++ b/docs/app-development/dependency-injection.md
@@ -2,12 +2,12 @@
 id: dependency-injection
 title: Implementing dependency injection
 description: Set up dependency injection in an Avalonia app using Microsoft.Extensions.DependencyInjection.
-doc-type: tutorial
+doc-type: how-to
 ---
 
 [Dependency injection (DI)](https://en.wikipedia.org/wiki/Dependency_injection) allows developers to write cleaner, more modular, and testable code. It accomplishes this by creating discrete services that are passed around/created as needed.
 
-This guide shows you step by step how to use DI with Avalonia and the MVVM pattern.
+This guide shows you step by step how to use DI with Avalonia and the [Model-View-ViewModel (MVVM) pattern](/docs/fundamentals/the-mvvm-pattern).
 
 ## Prerequisites
 
@@ -62,7 +62,7 @@ This works great for simple constructors that are not used very often and don't 
 - Similarly if the `MainViewModel` constructor itself creates its own dependencies, it also becomes directly coupled to the creation of the dependencies which can result in many of the same problems. 
 - Furthermore, if `MainViewModel` is instantiated in many places, _every_ instantiation of `MainViewModel` would also need to be updated should the dependencies of `MainViewModel` ever change (such as the addition of new dependencies, or changing which implementation of a dependency to use).
 
-Dependency injection solves these problem by abstracting away the creation of objects and their dependencies. This allows for well encapsulated services that will be automatically passed into any other service that is registered to use them.
+Dependency injection solves this problem by abstracting away the creation of objects and their dependencies. This allows for well encapsulated services that will be automatically passed into any other service that is registered to use them.
 
 ## Step 1: Install the NuGet package for DI
 There are many DI container providers available ([DryIoC](https://github.com/dadhi/DryIoc), [Autofac](https://github.com/autofac/Autofac), [Pure.DI](https://github.com/DevTeam/Pure.DI)) but this guide focuses on `Microsoft.Extensions.DependencyInjection`, a lightweight, extensible dependency injection container. It provides a convention-based way to add DI to .NET applications, including Avalonia-based desktop applications.
@@ -89,7 +89,7 @@ public static class ServiceCollectionExtensions
 ```
 
 ## Step 3: Modify App.axaml.cs
-Next, modify the `App.axaml.cs` class to use the DI container. This allows the view model registered in the previous step to be resolved via the dependency injection container. The fully realised view model can then be set to the data context of the `MainWindow`/`MainView`.
+Next, modify the `App.axaml.cs` class to use the DI container. This allows the view model registered in the previous step to be resolved via the dependency injection container. The fully realized view model can then be set to the data context of the `MainWindow`/`MainView`.
 
 ```csharp
 public class App : Application


### PR DESCRIPTION
This PR updates https://docs.avaloniaui.net/docs/app-development/dependency-injection to align with changes introduced by Avalonia v12.