### PR TITLE
Add redirects for links in DevTools without them

### DIFF
--- a/redirects/v12-docs-redirects.ts
+++ b/redirects/v12-docs-redirects.ts
@@ -1267,7 +1267,10 @@ const redirects: Redirect[] = [
         "to": "/controls/data-display/structured-data/treedatagrid/filtering"
     },
     {
-        "from": "/accelerate/tools/dev-tools/getting-started",
+        "from": [
+            "/accelerate/tools/dev-tools/getting-started",
+            "/tools/developer-tools"
+        ],
         "to": "/tools/developer-tools/installation"
     },
     {
@@ -1297,23 +1300,38 @@ const redirects: Redirect[] = [
         "to": "/tools/developer-tools/elements-tool"
     },
     {
-        "from": "/accelerate/tools/dev-tools/tools/logs",
+        "from": [
+            "/accelerate/tools/dev-tools/tools/logs",
+            "/tools/developer-tools/tools/logs"
+        ],
         "to": "/tools/developer-tools/logs-tool"
     },
     {
-        "from": "/accelerate/tools/dev-tools/tools/events",
+        "from": [
+            "/accelerate/tools/dev-tools/tools/events",
+            "/tools/developer-tools/tools/events"
+        ],
         "to": "/tools/developer-tools/events-tool"
     },
     {
-        "from": "/accelerate/tools/dev-tools/tools/breakpoints",
+        "from": [
+            "/accelerate/tools/dev-tools/tools/breakpoints",
+            "/tools/developer-tools/tools/breakpoints"
+        ],
         "to": "/tools/developer-tools/breakpoints-tool"
     },
     {
-        "from": "/accelerate/tools/dev-tools/tools/metrics",
+        "from": [
+            "/accelerate/tools/dev-tools/tools/metrics",
+            "/tools/developer-tools/tools/metrics"
+        ],
         "to": "/tools/developer-tools/metrics-tool"
     },
     {
-        "from": "/accelerate/tools/dev-tools/tools/profiler",
+        "from": [
+            "/accelerate/tools/dev-tools/tools/profiler",
+            "/tools/developer-tools/tools/profiler"
+        ],
         "to": "/tools/developer-tools/profiler-tool"
     },
     {
@@ -1415,6 +1433,7 @@ const redirects: Redirect[] = [
         "from": [
             "/docs/distribution-publishing/",
             "/accelerate/tools/parcel/getting-started",
+            "/tools/parcel"
         ],
         "to": "/tools/parcel/setup"
     },


### PR DESCRIPTION
This PR adds new redirects for older links in the Dev Tools that didn't have them.

Adding these redirects will help users of the Dev Tools reach a live page instead of a 404 when they click the links for more information under each tool tab.

https://support.avaloniaui.net/agent/tickets/1585