### PR TITLE
Clarify tip for sharing license key

### DIFF
--- a/tools/installing-avalonia-pro.md
+++ b/tools/installing-avalonia-pro.md
@@ -56,10 +56,12 @@ Include your Avalonia license key in the executable project file (`.csproj`):
 
 Replace `YOUR_LICENSE_KEY` with the key from your [Avalonia portal](https://portal.avaloniaui.net) account.
 
-For multi-project solutions, you can store your license key in an [environment variable](https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-use-environment-variables-in-a-build) or a [shared props file](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022#directorybuildprops-example) to avoid duplication.
-
-:::warning
 Do not leave the license key value blank. If left blank, you may be unable to build or open your project.
+
+:::tip
+To share a license key between multiple projects, you can use an [environment variable](https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-use-environment-variables-in-a-build) or a [shared props file](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022#directorybuildprops-example).
+
+See the [Avalonia Pro samples repository](https://github.com/AvaloniaUI/AvaloniaPro.Samples/blob/main/Directory.Build.props) for an example of how to do this with a shared `Directory.Build.props` file.
 :::
 
 ## Verify the installation


### PR DESCRIPTION
- Move information on sharing license key to a `tip` callout box.
- Edit text and add link to sample project.