### PR TITLE
Add breadcrumbs to docs site

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -106,6 +106,7 @@ const config: Config = {
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
           lastVersion: 'current',
+          breadcrumbs: true,
           versions: {
             current: {
               label: "12.0.x",

--- a/src/styles/components/_breadcrumbs.scss
+++ b/src/styles/components/_breadcrumbs.scss
@@ -3,6 +3,7 @@
 .breadcrumbs {
   display: flex;
   align-items: center;
+  line-height: 0.75;
 
   &__item {
     display: inline-flex;

--- a/src/styles/components/_breadcrumbs.scss
+++ b/src/styles/components/_breadcrumbs.scss
@@ -3,7 +3,6 @@
 .breadcrumbs {
   display: flex;
   align-items: center;
-  line-height: 0.75;
 
   &__item {
     display: inline-flex;

--- a/src/styles/components/_doc-item.scss
+++ b/src/styles/components/_doc-item.scss
@@ -21,23 +21,6 @@
   }
 
   [class*='docMainContainer_'] {
-    .doc-demo-wrapper {
-      @media (max-width: 1364px) {
-        display: none;
-      }
-
-      .doc-demo {
-        position: sticky;
-        top: calc(var(--ifm-navbar-height));
-
-        padding-block-end: 32px;
-
-        margin-block-start: 5rem;
-        overflow-y: auto;
-        max-height: calc(100vh - var(--ifm-navbar-height));
-      }
-    }
-
     > .container {
       > .row {
         > .col {
@@ -45,18 +28,6 @@
           justify-content: center;
 
           min-width: 0;
-
-          // Docs Demo
-          &.col--4 {
-            @media (max-width: 1364px) {
-              // The docs demo is hidden on mobile and tablet.
-              // Since the docs demo is the only thing in the right column,
-              // the column should be hidden as well.
-              // Otherwise, it will be a blank column, making it
-              // look like there is a lot of empty space.
-              display: none;
-            }
-          }
         }
       }
     }

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -1,0 +1,207 @@
+/**
+ * DocBreadcrumbs renders the breadcrumb trail at the top of every doc page.
+ *
+ * Original source:
+ * @link https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
+ *
+ * Reason for overriding:
+ * - The upstream root crumb is a house icon hardcoded to `useBaseUrl('/')`, and
+ *   src/pages/index.tsx redirects '/' to '/docs/welcome'. So on every section
+ *   other than Guides, the house silently took the reader out of the section
+ *   they were browsing. Here the root crumb is the *section* instead: it links
+ *   to the section landing page and is labelled with the section name.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import {translate} from '@docusaurus/Translate';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {
+  useSidebarBreadcrumbs,
+  useActivePlugin,
+} from '@docusaurus/plugin-content-docs/client';
+import type {PropSidebarBreadcrumbsItem} from '@docusaurus/plugin-content-docs';
+import IconHome from '@theme/Icon/Home';
+import DocBreadcrumbsStructuredData from '@theme/DocBreadcrumbs/StructuredData';
+import styles from './styles.module.css';
+
+type Section = {
+  label: string;
+  href: string;
+};
+
+/**
+ * Each docs section is a separate content-docs plugin instance, so the section
+ * is keyed by plugin id (the sidebar id can't be used: five of the six sidebars
+ * share the id `documentationSidebar`). Keep in sync with the plugin instances
+ * and the navbar items in docusaurus.config.ts.
+ *
+ * Guides points at /docs/welcome rather than /docs, which has no index doc.
+ */
+function useSections(): Record<string, Section> {
+  return {
+    default: {
+      href: '/docs/welcome',
+      label: translate({
+        id: 'theme.docs.breadcrumbs.section.guides',
+        message: 'Guides',
+        description: 'Breadcrumb label for the Guides docs section',
+      }),
+    },
+    controls: {
+      href: '/controls',
+      label: translate({
+        id: 'theme.docs.breadcrumbs.section.controls',
+        message: 'Controls',
+        description: 'Breadcrumb label for the Controls docs section',
+      }),
+    },
+    tools: {
+      href: '/tools',
+      label: translate({
+        id: 'theme.docs.breadcrumbs.section.tools',
+        message: 'Tools',
+        description: 'Breadcrumb label for the Tools docs section',
+      }),
+    },
+    api: {
+      href: '/api',
+      label: translate({
+        id: 'theme.docs.breadcrumbs.section.api',
+        message: 'APIs',
+        description: 'Breadcrumb label for the API reference docs section',
+      }),
+    },
+    troubleshooting: {
+      href: '/troubleshooting',
+      label: translate({
+        id: 'theme.docs.breadcrumbs.section.troubleshooting',
+        message: 'Troubleshooting',
+        description: 'Breadcrumb label for the Troubleshooting docs section',
+      }),
+    },
+    xpf: {
+      href: '/xpf',
+      label: translate({
+        id: 'theme.docs.breadcrumbs.section.xpf',
+        message: 'Avalonia XPF',
+        description: 'Breadcrumb label for the Avalonia XPF docs section',
+      }),
+    },
+  };
+}
+
+/** Same semantics as theme-common's isSamePath, which is not public API. */
+function isSamePath(path1: string | undefined, path2: string | undefined) {
+  const normalize = (pathname: string | undefined) =>
+    (!pathname || pathname.endsWith('/') ? pathname : `${pathname}/`)?.toLowerCase();
+  return normalize(path1) === normalize(path2);
+}
+
+function BreadcrumbsItemLink({
+  children,
+  href,
+  isLast,
+}: {
+  children: React.ReactNode;
+  href: string | undefined;
+  isLast: boolean;
+}): JSX.Element {
+  const className = clsx('breadcrumbs__link', styles.breadcrumbLink);
+  if (isLast) {
+    return <span className={className}>{children}</span>;
+  }
+  return href ? (
+    <Link className="breadcrumbs__link" href={href}>
+      <span className={styles.breadcrumbLink}>{children}</span>
+    </Link>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+}
+
+function BreadcrumbsItem({
+  children,
+  active,
+}: {
+  children: React.ReactNode;
+  active?: boolean;
+}): JSX.Element {
+  return (
+    <li
+      className={clsx('breadcrumbs__item', {
+        'breadcrumbs__item--active': active,
+      })}>
+      {children}
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs(): JSX.Element | null {
+  const sidebarBreadcrumbs = useSidebarBreadcrumbs();
+  const activePlugin = useActivePlugin();
+  const sections = useSections();
+
+  const section = activePlugin ? sections[activePlugin.pluginId] : undefined;
+  const sectionHref = useBaseUrl(section?.href ?? '/');
+
+  if (!sidebarBreadcrumbs) {
+    return null;
+  }
+
+  // A single array drives both the visible trail and the structured data, so
+  // the two can't drift apart.
+  const breadcrumbs: PropSidebarBreadcrumbsItem[] = section
+    ? [
+        {type: 'link', label: section.label, href: sectionHref},
+        // On a section landing page the sidebar's own first crumb is already
+        // the section (/controls yields 'Home', /api yields the index title),
+        // which would render as 'Controls > Home'.
+        ...sidebarBreadcrumbs.filter(
+          (item, idx) => !(idx === 0 && isSamePath(item.href, sectionHref)),
+        ),
+      ]
+    : sidebarBreadcrumbs;
+
+  return (
+    <>
+      <DocBreadcrumbsStructuredData breadcrumbs={breadcrumbs} />
+      <nav
+        className={clsx(
+          ThemeClassNames.docs.docBreadcrumbs,
+          styles.breadcrumbsContainer,
+        )}
+        aria-label={translate({
+          id: 'theme.docs.breadcrumbs.navAriaLabel',
+          message: 'Breadcrumbs',
+          description: 'The ARIA label for the breadcrumbs',
+        })}>
+        <ul className="breadcrumbs">
+          {breadcrumbs.map((item, idx) => {
+            const isLast = idx === breadcrumbs.length - 1;
+            const isSection = !!section && idx === 0;
+            const href =
+              item.type === 'category' && item.linkUnlisted
+                ? undefined
+                : item.href;
+            return (
+              <BreadcrumbsItem key={idx} active={isLast}>
+                <BreadcrumbsItemLink href={href} isLast={isLast}>
+                  {isSection && (
+                    <IconHome
+                      className={styles.breadcrumbHomeIcon}
+                      aria-hidden="true"
+                    />
+                  )}
+                  {item.label}
+                </BreadcrumbsItemLink>
+              </BreadcrumbsItem>
+            );
+          })}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -110,15 +110,17 @@ function BreadcrumbsItemLink({
   isLast: boolean;
 }): JSX.Element {
   const className = clsx('breadcrumbs__link', styles.breadcrumbLink);
-  if (isLast) {
-    return <span className={className}>{children}</span>;
+   if (isLast || !href) {
+     return (
+       <span className={className} aria-current={isLast ? 'page' : undefined}>
+         {children}
+       </span>
+     );
   }
-  return href ? (
-    <Link className="breadcrumbs__link" href={href}>
-      <span className={styles.breadcrumbLink}>{children}</span>
+   return (
+     <Link className={className} to={href}>
+       {children}
     </Link>
-  ) : (
-    <span className={className}>{children}</span>
   );
 }
 

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,19 @@
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}
+
+/* The icon shares a crumb with the section label, rather than sitting alone in
+   its own crumb as it does upstream, so the crumb centres the two on a row.
+   Upstream's vertical-align/top nudge doesn't apply to a flex child. */
+.breadcrumbLink {
+  display: inline-flex;
+  align-items: center;
+}
+
+.breadcrumbHomeIcon {
+  flex-shrink: 0;
+  height: 1.1rem;
+  width: 1.1rem;
+  margin-right: 0.35rem;
+}

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -13,7 +13,7 @@
 
 .breadcrumbHomeIcon {
   flex-shrink: 0;
-  height: 1.1rem;
+  height: 1rem;
   width: 1.1rem;
   margin-right: 0.35rem;
 }

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -6,7 +6,7 @@
  * @link https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocItem/Layout/index.tsx
  *
  * Reason for overriding:
- * - Add a phone demo to the right of the page, e.g. /docs
+ * - Move the version banner above the content row, so it spans the full width
  */
 
 import React from 'react';
@@ -20,54 +20,20 @@ import DocItemFooter from '@theme/DocItem/Footer';
 import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
 import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
 import DocItemContent from '@theme/DocItem/Content';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import ContentVisibility from '@theme/ContentVisibility';
 import type {Props} from '@theme/DocItem/Layout';
 import styles from '@docusaurus/theme-classic/lib/theme/DocItem/Layout/styles.module.css';
-
-// Extended frontMatter type for custom demo properties
-interface ExtendedFrontMatter {
-  hide_table_of_contents?: boolean;
-  demoUrl?: string;
-  demoSourceUrl?: string;
-  [key: string]: unknown;
-}
-
-// DocDemo component for rendering embedded demos
-interface DocDemoProps {
-  url: string;
-  source?: string;
-}
-
-function DocDemo({ url, source }: DocDemoProps): JSX.Element {
-  return (
-    <div className="doc-demo">
-      <iframe
-        src={url}
-        title="Demo"
-        style={{ width: '100%', height: '600px', border: 'none', borderRadius: '8px' }}
-      />
-      {source && (
-        <a href={source} target="_blank" rel="noopener noreferrer" className="doc-demo-source">
-          View Source
-        </a>
-      )}
-    </div>
-  );
-}
 
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
  */
 function useDocTOC() {
-  const {frontMatter: rawFrontMatter, toc} = useDoc();
-  const frontMatter = rawFrontMatter as ExtendedFrontMatter;
+  const {frontMatter, toc} = useDoc();
   const windowSize = useWindowSize();
 
   const hidden = frontMatter.hide_table_of_contents;
-  // CUSTOM CODE
-  const demoUrl = frontMatter.demoUrl;
-  const canRender = !hidden && toc.length > 0 && !demoUrl;
-  // CUSTOM CODE END
+  const canRender = !hidden && toc.length > 0;
 
   const mobile = canRender ? <DocItemTOCMobile /> : undefined;
   const desktop =
@@ -82,25 +48,9 @@ function useDocTOC() {
   };
 }
 
-// CUSTOM CODE
-function useDocDemo() {
-  const {frontMatter: rawFrontMatter} = useDoc();
-  const frontMatter = rawFrontMatter as ExtendedFrontMatter;
-  const demoUrl = frontMatter.demoUrl;
-  const demoSourceUrl = frontMatter.demoSourceUrl;
-  return {
-    demoUrl,
-    demoSourceUrl,
-  };
-}
-// CUSTOM CODE END
-
-export default function DocItemLayout({children, ...props}: Props): JSX.Element {
+export default function DocItemLayout({children}: Props): JSX.Element {
   const docTOC = useDocTOC();
   const {metadata} = useDoc();
-  // CUSTOM CODE
-  const {demoUrl, demoSourceUrl} = useDocDemo();
-  // CUSTOM CODE END
   return (
     <>
       {/* ------- CUSTOM CODE -------- */}
@@ -113,25 +63,15 @@ export default function DocItemLayout({children, ...props}: Props): JSX.Element 
           <ContentVisibility metadata={metadata} />
           <div className={styles.docItemContainer}>
             <article>
+              <DocBreadcrumbs />
               <DocVersionBadge />
               {docTOC.mobile}
               <DocItemContent>{children}</DocItemContent>
               <DocItemFooter />
               <DocItemPaginator />
             </article>
-           
           </div>
         </div>
-        {/* ------- CUSTOM CODE -------- */}
-        {/* Ideally this would only render if there is a demoUrl and the it's a mobile device. However,the `windowSize` does not provide a tablet so we have to hide it through CSS. */}
-        {demoUrl && (
-          <div className='col col--4'>
-            <div className='doc-demo-wrapper'>
-              <DocDemo url={demoUrl} source={demoSourceUrl} />
-            </div>
-          </div>
-        )}
-        {/* ------- CUSTOM CODE END -------- */}
         {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
       </div>
     </>


### PR DESCRIPTION
This PR add breadcrumbs to the Avalonia docs site.

**Rationale**
The Avalonia docs site is large and complex. Many docs share similar names or cover related topics. This causes navigation issues for readers, for example being unable to remember which section a doc was in, or being unaware that a doc is under a specialized category when searching for a certain keyword.

Breadcrumbs at the top of each page act as a navigational guide. They provide a visual guide for the site's information structure, as well as an interactive element to discover related pages.

**Problems encountered**
- The existing docs site actually had breadcrumbs enabled, but which never rendered.
- Out-of-the-box Docusaurus breadcrumbs always navigate back to the site's landing page when the Home icon in the breadcrumbs is clicked. This design is lacking for the Avalonia docs site, which is segregated into multiple sections. Being ejected to /docs/welcome from the /controls or /api sections makes a poor user experience.

**Summary of work**
- Amend Layout theme file to display <DocBreadcrumbs /> at the top of each page.
- Remove unused phone demo code from Layout theme file and component file.
- Set an explicit `breadcrumbs: true` in the Docusaurus config. (Not strictly needed because the default is true, but this is meant as a statement of intent to help future maintainers understand this option was consciously enabled.)
- Swizzle DocBreadcrumbs component. Override default Home URL of '/', and instead get the component to refer to a six-entry map to link to the relevant section as defined by plugin-id. This means clicking Home goes to /controls when in the Controls section, or goes to /api when in the API section, etc.
- In addition to the above, display the name of the current section (using plugin-id) next to the Home icon, so that it's clear where it goes.
- Adjust CSS to ensure the icon and text in the breadcrumbs align properly.

**Result**
Each page on the docs site automatically displays a breadcrumb trail at the top of the page, which displays the section, then sidebar categories, then the page title, e.g., "Controls > Layout > Panels > Canvas".

Any portion of the breadcrumbs can be clicked to navigate to the corresponding page, except where the sidebar category is just a category and does not have a page.

The root landing page is never shown in the breadcrumbs, meaning there is no possibility of breadcrumb clicks accidentally ejecting the user from the section they are currently browsing. (Unless they are reading the main "Guides" section, whose index page /docs/welcome is also the site's landing page.)

**Testing**
- `npm typecheck` and `npm run build` ran successfully.
- Manually tested with local build on desktop and mobile orientations with no issues detected.

**Notes**
- Section mapping is hardcoded manually in the DocBreadcrumbs component file. Any new sections added in the future will need to be manually added to the map.
- Mapping uses plugin-id instead of sidebar-id, because every sidebar-id on this site is documentationSidebar.