### PR TITLE
Disable AskAI

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -457,10 +457,10 @@ gtag('consent', 'default', {
           },
         },
       },
-      askAi: {
-        assistantId: 'ILptDNvSVJ1v',
-        sidePanel: true,
-      },
+      // askAi: {
+      //   assistantId: 'ILptDNvSVJ1v',
+      //   sidePanel: true,
+      // },
     },
   },
 };


### PR DESCRIPTION
Fix requires further work with upstream components. Temporarily disable Algolia AskAI while we work on it.