### PR TITLE
Change GitHubSampleLink style

### DIFF
--- a/src/components/global/GitHubSampleLink.tsx
+++ b/src/components/global/GitHubSampleLink.tsx
@@ -13,7 +13,8 @@ export default function GitHubSampleLink({ title, link }: GitHubSampleLinkProps)
       {link && (
         <Link
           to={link}
-          className="flex items-center gap-1 rounded-lg py-1 px-3 text-white bg-primary hover:text-white transition-colors"
+          className="flex items-center gap-1 rounded-lg py-1 px-3 border border-primary text-primary! hover:bg-primary hover:text-white! hover:no-underline! transition-colors"
+
         >
           <GitHub className="h-4 w-4" />
           <span className="font-semibold">Clone the {title} sample</span>

--- a/src/components/global/GitHubSampleLink.tsx
+++ b/src/components/global/GitHubSampleLink.tsx
@@ -13,8 +13,7 @@ export default function GitHubSampleLink({ title, link }: GitHubSampleLinkProps)
       {link && (
         <Link
           to={link}
-          className="flex items-center gap-1 rounded-lg py-1 px-3 border border-primary text-primary! hover:bg-primary hover:text-white! hover:no-underline! transition-colors"
-
+          className="flex items-center gap-1 rounded-lg py-1 px-3 border border-primary !text-primary hover:bg-primary hover:!text-white hover:!no-underline transition-colors"
         >
           <GitHub className="h-4 w-4" />
           <span className="font-semibold">Clone the {title} sample</span>


### PR DESCRIPTION
GitHubSampleLink buttons have been rendering blue text on blue background since the Tailwind version up, likely due to conflicting style declarations.

Tweak the component's style to have a blue border with transparent fill, which flips to a solid blue fill with white text on hover.