### PR TITLE
Set a secondary color for the hover text

### DIFF
--- a/src/components/global/GitHubSampleLink.tsx
+++ b/src/components/global/GitHubSampleLink.tsx
@@ -13,7 +13,7 @@ export default function GitHubSampleLink({ title, link }: GitHubSampleLinkProps)
       {link && (
         <Link
           to={link}
-          className="flex items-center gap-1 rounded-lg py-1 px-3 border border-primary !text-primary hover:bg-primary hover:!text-white hover:!no-underline transition-colors"
+          className="flex items-center gap-1 rounded-lg py-1 px-3 border border-primary !text-primary hover:bg-primary hover:!text-secondary hover:!no-underline transition-colors"
         >
           <GitHub className="h-4 w-4" />
           <span className="font-semibold">Clone the {title} sample</span>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -139,8 +139,7 @@ module.exports = {
           200: 'rgb(var(--docs-color-primary-200, 0 125 249) / <alpha-value>)',
         },
         secondary: {
-          DEFAULT:
-            'rgb(var(--docs-color-secondary-1000, 0 0 0) / <alpha-value>)',
+          DEFAULT: 'var(--color-brand-25)',
           1000: 'rgb(var(--docs-color-secondary-1000, 0 0 0) / <alpha-value>)',
           900: 'rgb(var(--docs-color-secondary-900, 25 25 25) / <alpha-value>)',
           800: 'rgb(var(--docs-color-secondary-800, 38 38 38) / <alpha-value>)',


### PR DESCRIPTION
Using `text-white` in the previous PR somehow worked on a local build but not production. Set an offwhite color from the palette as secondary instead and see if that helps.