### PR TITLE
Adjust block heights in gradient examples

### DIFF
--- a/docs/graphics-animation/gradients.md
+++ b/docs/graphics-animation/gradients.md
@@ -235,9 +235,9 @@ The same pattern applies to `RadialGradientBrush` and `ConicGradientBrush`.
 <XamlPreview>
 
 ```xml
-<StackPanel Spacing="20" Margin="20" xmlns="https://github.com/avaloniaui">
+<StackPanel Spacing="16" Margin="16" xmlns="https://github.com/avaloniaui">
     <!-- Horizontal gradient -->
-    <Border Height="100" CornerRadius="8">
+    <Border Height="80" CornerRadius="8">
         <Border.Background>
             <LinearGradientBrush StartPoint="0%,50%" EndPoint="100%,50%">
                 <GradientStop Color="#FF6B6B" Offset="0.0"/>
@@ -253,7 +253,7 @@ The same pattern applies to `RadialGradientBrush` and `ConicGradientBrush`.
     </Border>
 
     <!-- Vertical gradient -->
-    <Border Height="100" CornerRadius="8">
+    <Border Height="80" CornerRadius="8">
         <Border.Background>
             <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
                 <GradientStop Color="#A8E6CF" Offset="0.0"/>
@@ -268,7 +268,7 @@ The same pattern applies to `RadialGradientBrush` and `ConicGradientBrush`.
     </Border>
 
     <!-- Radial gradient -->
-    <Border Height="100" CornerRadius="8">
+    <Border Height="80" CornerRadius="8">
         <Border.Background>
             <RadialGradientBrush GradientOrigin="30%,30%">
                 <GradientStop Color="White" Offset="0.0"/>
@@ -282,7 +282,7 @@ The same pattern applies to `RadialGradientBrush` and `ConicGradientBrush`.
     </Border>
 
     <!-- Conic gradient -->
-    <Border Height="100" CornerRadius="8">
+    <Border Height="80" CornerRadius="8">
         <Border.Background>
             <ConicGradientBrush Center="50%,50%">
                 <GradientStop Color="#FF6B6B" Offset="0.0"/>


### PR DESCRIPTION
Fixes https://github.com/AvaloniaUI/avalonia-docs/discussions/1100#discussioncomment-17932432

From
<img width="1115" height="425" alt="image" src="https://github.com/user-attachments/assets/d8e90c69-5741-40f2-996f-3c82d972512c" />


To

<img width="1143" height="405" alt="image" src="https://github.com/user-attachments/assets/97703b36-dc42-4e95-b2c8-eadb94a11dc2" />
