### PR TITLE
Move GitHubSampleLink to separate style file

### DIFF
--- a/src/components/global/GitHubSampleLink.tsx
+++ b/src/components/global/GitHubSampleLink.tsx
@@ -11,12 +11,9 @@ export default function GitHubSampleLink({ title, link }: GitHubSampleLinkProps)
   return (
     <div className="flex items-center gap-2.5">
       {link && (
-        <Link
-          to={link}
-          className="flex items-center gap-1 rounded-lg py-1 px-3 border border-primary !text-primary"
-        >
-          <GitHub className="h-4 w-4" />
-          <span className="font-semibold">Clone the {title} sample</span>
+        <Link to={link} className="github-sample-link">
+          <GitHub />
+          <span>Clone the {title} sample</span>
         </Link>
       )}
     </div>

--- a/src/components/global/XpfAdvert.tsx
+++ b/src/components/global/XpfAdvert.tsx
@@ -1,3 +1,5 @@
+// NEEDS UPDATING BEFORE USE — not tested since the update to Tailwind v4, which has broken styling on other components. This component is not currently used anywhere in the docs, so it can be updated when needed.
+
 import React from 'react';
 
 const XpfLogo = () => (

--- a/src/components/global/XpfAdvert.tsx
+++ b/src/components/global/XpfAdvert.tsx
@@ -1,4 +1,5 @@
-// NEEDS UPDATING BEFORE USE — not tested since the update to Tailwind v4, which has broken styling on other components. This component is not currently used anywhere in the docs, so it can be updated when needed.
+// TODO: Verify/update this component's Tailwind v4 styling before using it.
+// It's currently registered in MDXComponents as `XpfAd`, but not referenced by any MDX content.
 
 import React from 'react';
 

--- a/src/styles/components/_github-sample-link.scss
+++ b/src/styles/components/_github-sample-link.scss
@@ -1,0 +1,37 @@
+// Clone-the-sample button, rendered by components/global/GitHubSampleLink.tsx
+//
+// Styled here rather than with Tailwind utilities: Infima styles bare `a`
+// elements unlayered, while Tailwind utilities live in `@layer utilities`, so
+// utility colours only win with `!important`. The production minifier then
+// hoists `:hover` rules out of that layer, and because `!important` reverses
+// layer precedence the base colour outranks the hover colour. A plain
+// unlayered class sidesteps the whole interaction.
+
+.github-sample-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+
+  padding: 0.25rem 0.75rem;
+
+  font-weight: 600;
+
+  color: var(--color-brand-500);
+  border: 1px solid var(--color-brand-500);
+  border-radius: 0.75rem;
+
+  transition:
+    background-color 0.2s ease-out,
+    color 0.2s ease-out;
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: var(--color-brand-500);
+    text-decoration: none;
+  }
+}

--- a/src/styles/custom.scss
+++ b/src/styles/custom.scss
@@ -25,6 +25,7 @@
 @import 'components/cards';
 @import 'components/dropdown';
 @import 'components/edit-this-page';
+@import 'components/github-sample-link';
 @import 'components/markdown';
 @import 'components/tabs';
 @import 'components/tables';


### PR DESCRIPTION
Third attempt at fixing styling on the GitHub-sample button introduced by the upgrade to Tailwind v4.

Setting `!important` state didn't work in the previous attempt. Unsure what caused the issue, but since it worked on a local build but not production, it's likely to be one of the CSS processes that only runs on `npm build` but not `start`.

Moving styling for the component to its own file in src/styles/components, like the standard Button component. This approach is confirmed to work in a local env.

Also adding a note to the XpfAdvert component, which may need updating before future use for simillar reasons.