### PR TITLE
Parcel 1.1 documentation changes

### DIFF
--- a/src/components/global/MinVersion.tsx
+++ b/src/components/global/MinVersion.tsx
@@ -3,19 +3,21 @@ import styles from './MinVersion.module.css';
 
 interface MinVersionProps {
   version: string;
+  isNewVersion?: boolean;
+  isPreviewVersion?: boolean;
 }
 
-const newVersion = '11.2';
-const previewVersion = '11.3';
+const newVersion = '12.1';
+const previewVersion = '12.2';
 
-export default function MinVersion({ version }: MinVersionProps) {
+export default function MinVersion({ version, isNewVersion, isPreviewVersion }: MinVersionProps) {
     let variantClass: string;
     let description: string;
 
-    if (version === newVersion) {
+    if (isNewVersion || version === newVersion) {
         variantClass = styles.new;
         description = ' New!';
-    } else if (version === previewVersion) {
+    } else if (isPreviewVersion || version === previewVersion) {
         variantClass = styles.preview;
         description = ' Preview!';
     } else {

--- a/tools-sidebar.ts
+++ b/tools-sidebar.ts
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'parcel/setup',
+        'parcel/configuration-reference',
         'parcel/command-line-reference',
         'parcel/packaging-for-macos',
         'parcel/packaging-for-windows',

--- a/tools/parcel/command-line-reference.md
+++ b/tools/parcel/command-line-reference.md
@@ -12,7 +12,7 @@ Parcel provides a command-line tool that packages Avalonia apps for Windows, mac
 Before using Parcel, ensure you have:
 
 1. **Parcel .NET tool installed** - Follow the [Setup guide](/tools/parcel/setup).
-2. **Valid license key** - Set the `PARCEL_LICENSE_KEY` environment variable or use the `--license-key` option with a valid license key from the portal.
+2. **Valid license key** - Set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable or use the `--license-key` option with a valid license key from the portal.
 
 :::note
 Parcel CLI is only available with a [Avalonia Plus](https://avaloniaui.net/pricing) license.
@@ -30,7 +30,7 @@ parcel [command] [options]
 |--------|-------------|
 | `-?, -h, --help` | Show help and usage information |
 | `--version` | Show version information |
-| `--license-key` | License key necessary to run Parcel. If unset, falls back to the "PARCEL_LICENSE_KEY" environment variable, or existing app session |
+| `--license-key` | License key necessary to run Parcel. If unset, falls back to `AVALONIA_TOOLS_LICENSE_KEY`, then to an existing app session |
 | `--verbosity` | Set the verbosity level (quiet, minimal, normal, detailed, diagnostic) |
 
 ## Commands
@@ -53,17 +53,17 @@ parcel pack <project> [options]
 |--------|-------------|---------|
 | `-o, --output` | Output directory | `<project-dir>\bin\packages` |
 | `-r, --runtimes` | Runtime identifiers to pack application with (can specify multiple) | current platform runtime |
-| `-p, --packages` | Package formats to output: `deb`, `dmg`, `nsis`, `zip` (can specify multiple) | current platform package  |
+| `-p, --packages` | Package formats to output: `deb`, `dmg`, `msix`, `nsis`, `pkg`, `rpm`, `zip` (can specify multiple) | current platform package  |
 | `--no-build` | Skip recompiling input project | false |
 
 **Example:**
 
 ```bash
 # Pack for current platform
-parcel pack MyApp.parcel.xml
+parcel pack MyApp.parcel
 
 # Pack for multiple platforms and formats
-parcel pack MyApp.parcel.xml -r osx-x64 -r linux-x64 -p dmg -p deb
+parcel pack MyApp.parcel -r osx-x64 -r linux-x64 -p dmg -p deb
 ```
 
 ### step
@@ -86,8 +86,11 @@ parcel step [command] <input> <output> [options]
 | `sign-win` | Signs Windows executable | Application executable or installed | Signed executable or installer |
 | `create-zip` | Creates zip archive for distribution | Directory or file | Zip archive (.zip) |
 | `create-dmg` | Creates DMG disk image for macOS | App bundle (.app) | Unsigned DMG image file |
+| `create-pkg` | Creates a macOS installer package | App bundle (.app) | Unsigned PKG installer (.pkg) |
 | `create-deb` | Creates Debian package for Linux | Application directory | Debian package (.deb) |
+| `create-rpm` | Creates RPM package for Linux | Application directory | RPM package (.rpm) |
 | `create-nsis` | Creates Windows NSIS installer | Application directory | Unsigned NSIS installer (.exe) |
+| `create-msix` | Creates Windows MSIX package | Application directory | Unsigned MSIX package (.msix) |
 
 **Example:**
 
@@ -189,7 +192,7 @@ parcel install-tools [options]
 | Option | Description |
 |--------|-------------|
 | `-r, --runtimes` | Runtime identifiers (can specify multiple) |
-| `-p, --packages` | Package formats: `deb`, `dmg`, `nsis`, `zip` (can specify multiple) |
+| `-p, --packages` | Package formats: `deb`, `dmg`, `msix`, `nsis`, `pkg`, `rpm`, `zip` (can specify multiple) |
 
 **Example:**
 
@@ -212,7 +215,35 @@ See [Model Context Protocol](/tools/parcel/mcp) for more details on usage.
 
 ## Environment Variables
 
-- `PARCEL_LICENSE_KEY` - Default license key used when `--license-key` option is not provided
+### Parcel and console behavior
+
+| Variable | Description |
+|---|---|
+| `AVALONIA_TOOLS_LICENSE_KEY` | License key used when `--license-key` is not provided. |
+| `AVALONIA_TOOLS_LOG_LEVEL` | Parcel application and MCP log level, such as `Debug` or `Information`. |
+| `AVALONIA_TELEMETRY_OPTOUT` | Set to `true` or `1` to disable Avalonia tooling telemetry. |
+| `NO_COLOR` | Set to any non-empty value to disable colored console packaging output. |
+| `SOURCE_DATE_EPOCH` | Unix timestamp used for deterministic package timestamps. |
+
+### Tool discovery
+
+| Variable | Description |
+|---|---|
+| `PARCEL_JAVA_EXE` | Explicit path to the Java executable used by cross-platform Windows signing. `JAVA_HOME` is also respected. |
+| `PARCEL_SIGNTOOL_EXE` | Explicit path to SignTool on Windows. |
+| `PARCEL_WSL_DISTRIBUTION` | WSL2 distribution used by packaging steps that require WSL on Windows. |
+| `PARCEL_WSL_USER` | User account used when Parcel starts the selected WSL2 distribution. |
+
+### Cloud signing
+
+| Variable | Description |
+|---|---|
+| `AZURE_TENANT_ID` | Microsoft Entra tenant used by Azure Artifact Signing or Key Vault. |
+| `AZURE_CLIENT_ID` | Azure service principal client ID. |
+| `AZURE_CLIENT_SECRET` | Azure service principal secret. |
+| `AWS_ACCESS_KEY_ID` | AWS access key used by AWS KMS signing. |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key used by AWS KMS signing. |
+| `AWS_SESSION_TOKEN` | Optional AWS temporary-session token. |
 
 ## Notes
 

--- a/tools/parcel/command-line-reference.md
+++ b/tools/parcel/command-line-reference.md
@@ -12,10 +12,10 @@ Use the Parcel command-line tool to package Avalonia applications for Windows, m
 Before you use Parcel, make sure that you have these items:
 
 1. **Parcel .NET tool** - Follow the [setup guide](/tools/parcel/setup) to install it.
-2. **Valid license key** - Set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable or use the `--license-key` option. Get a license key from the Avalonia Portal.
+2. **Valid license key** - Set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable or use the `--license-key` option. Get a license key from the [Avalonia Portal](https://portal.avaloniaui.net/).
 
 :::note
-Parcel CLI is only available with a [Avalonia Plus](https://avaloniaui.net/pricing) license.
+Parcel CLI is only available with an [Avalonia Plus](https://avaloniaui.net/pricing) license.
 :::
 
 ## Overview
@@ -52,9 +52,9 @@ parcel pack <project> [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-o, --output` | Output directory | `<project-dir>\bin\packages` |
-| `-r, --runtimes` | Runtime identifiers to package. You can specify this option more than once | Current platform runtime |
-| `-p, --packages` | Output formats: `deb`, `dmg`, `msix`, `nsis`, `pkg`, `rpm`, or `zip`. You can specify this option more than once | Current platform package |
-| `--no-build` | Do not rebuild the input project | `false` |
+| `-r, --runtimes` | Runtime identifiers to package. You can specify this option more than once. | Current platform runtime |
+| `-p, --packages` | Output formats: `deb`, `dmg`, `msix`, `nsis`, `pkg`, `rpm`, or `zip`. You can specify this option more than once. | Current platform package |
+| `--no-build` | Do not rebuild the input project. | `false` |
 
 **Example:**
 
@@ -78,7 +78,7 @@ parcel step [command] <input> <output> [options]
 
 | Command | Description | Input | Output |
 |---------|-------------|-------|--------|
-| `publish` | Publishes the .NET project for a target platform and runtime | No explicit input. Parcel reads the project from the `.parcel` file | Published application directory |
+| `publish` | Publishes the .NET project for a target platform and runtime | No explicit input. Parcel reads the project from the `.parcel` file. | Published application directory |
 | `merge-mac` | Merges architecture builds into a universal macOS application bundle | Directory with architecture-specific subdirectories (`osx-x64`, `osx-arm64`) | Universal application directory |
 | `bundle-mac` | Packages a macOS application and its dependencies into one bundle | Application directory | Application bundle (`.app`) |
 | `sign-mac` | Signs a macOS application bundle and its components with the credentials in the project settings | Application bundle or flat directory | Signed application bundle or directory |
@@ -90,7 +90,7 @@ parcel step [command] <input> <output> [options]
 | `create-deb` | Creates Debian package for Linux | Application directory | Debian package (.deb) |
 | `create-rpm` | Creates an RPM package for Linux | Application directory | RPM package (`.rpm`) |
 | `create-nsis` | Creates Windows NSIS installer | Application directory | Unsigned NSIS installer (.exe) |
-| `create-msix` | Creates a Windows MSIX package. Parcel generates the manifest or patches a project template | Application directory | MSIX package (`.msix`) |
+| `create-msix` | Creates a Windows MSIX package. Parcel generates the manifest or patches a project template. | Application directory | MSIX package (`.msix`) |
 
 **Example:**
 
@@ -240,7 +240,7 @@ For setup and usage information, see [Parcel MCP](/tools/parcel/mcp).
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key used by AWS KMS signing. |
 | `AWS_SESSION_TOKEN` | Optional AWS temporary-session token. |
 
-You can override supported scalar settings with automatic `PARCEL_<SECTION>_<SETTING>` environment variables. The [Parcel configuration reference](/tools/parcel/configuration-reference) gives the exact name for each setting.
+You can override supported scalar settings with automatic `PARCEL_<SECTION>_<SETTING>` environment variables. See the [Parcel configuration reference](/tools/parcel/configuration-reference) for the exact name of each setting.
 
 ## Notes
 

--- a/tools/parcel/command-line-reference.md
+++ b/tools/parcel/command-line-reference.md
@@ -219,9 +219,6 @@ For setup and usage information, see [Parcel MCP](/tools/parcel/mcp).
 |---|---|
 | `AVALONIA_TOOLS_LICENSE_KEY` | License key used when `--license-key` is not provided. |
 | `AVALONIA_TOOLS_LOG_LEVEL` | Sets the Parcel application and MCP log level, such as `Debug` or `Information`. |
-| `AVALONIA_TELEMETRY_OPTOUT` | Set to `true` or `1` to disable Avalonia tooling telemetry. |
-| `NO_COLOR` | Set to any non-empty value to disable colored console packaging output. |
-| `SOURCE_DATE_EPOCH` | Sets the Unix timestamp for reproducible package timestamps. |
 
 ### Tool discovery
 

--- a/tools/parcel/command-line-reference.md
+++ b/tools/parcel/command-line-reference.md
@@ -5,14 +5,14 @@ sidebar_label: Command line reference
 doc-type: reference
 ---
 
-Parcel provides a command-line tool that packages Avalonia apps for Windows, macOS, and Linux. It includes app signing and packaging capabilities to simplify distribution of ready-to-install binaries.
+Use the Parcel command-line tool to package Avalonia applications for Windows, macOS, and Linux. Parcel can also sign applications and packages.
 
 ## Prerequisites
 
-Before using Parcel, ensure you have:
+Before you use Parcel, make sure that you have these items:
 
-1. **Parcel .NET tool installed** - Follow the [Setup guide](/tools/parcel/setup).
-2. **Valid license key** - Set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable or use the `--license-key` option with a valid license key from the portal.
+1. **Parcel .NET tool** - Follow the [setup guide](/tools/parcel/setup) to install it.
+2. **Valid license key** - Set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable or use the `--license-key` option. Get a license key from the Avalonia Portal.
 
 :::note
 Parcel CLI is only available with a [Avalonia Plus](https://avaloniaui.net/pricing) license.
@@ -30,14 +30,14 @@ parcel [command] [options]
 |--------|-------------|
 | `-?, -h, --help` | Show help and usage information |
 | `--version` | Show version information |
-| `--license-key` | License key necessary to run Parcel. If unset, falls back to `AVALONIA_TOOLS_LICENSE_KEY`, then to an existing app session |
+| `--license-key` | Set the Parcel license key. If you omit this option, Parcel uses `AVALONIA_TOOLS_LICENSE_KEY` and then an existing application session |
 | `--verbosity` | Set the verbosity level (quiet, minimal, normal, detailed, diagnostic) |
 
 ## Commands
 
 ### pack
 
-Builds and packs a project according to pre-defined settings and input parameters.
+Builds and packages a project with the specified settings and parameters.
 
 ```bash
 parcel pack <project> [options]
@@ -45,16 +45,16 @@ parcel pack <project> [options]
 
 **Arguments:**
 
-- `<project>` - Parcel project file to load config from
+- `<project>` - Parcel project file that contains the configuration
 
 **Options:**
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-o, --output` | Output directory | `<project-dir>\bin\packages` |
-| `-r, --runtimes` | Runtime identifiers to pack application with (can specify multiple) | current platform runtime |
-| `-p, --packages` | Package formats to output: `deb`, `dmg`, `msix`, `nsis`, `pkg`, `rpm`, `zip` (can specify multiple) | current platform package  |
-| `--no-build` | Skip recompiling input project | false |
+| `-r, --runtimes` | Runtime identifiers to package. You can specify this option more than once | Current platform runtime |
+| `-p, --packages` | Output formats: `deb`, `dmg`, `msix`, `nsis`, `pkg`, `rpm`, or `zip`. You can specify this option more than once | Current platform package |
+| `--no-build` | Do not rebuild the input project | `false` |
 
 **Example:**
 
@@ -68,7 +68,7 @@ parcel pack MyApp.parcel -r osx-x64 -r linux-x64 -p dmg -p deb
 
 ### step
 
-Runs a specific step from the packaging process. Useful for debugging or customized packaging workflows.
+Runs one packaging step. Use this command to debug or customize a packaging workflow.
 
 ```bash
 parcel step [command] <input> <output> [options]
@@ -78,25 +78,25 @@ parcel step [command] <input> <output> [options]
 
 | Command | Description | Input | Output |
 |---------|-------------|-------|--------|
-| `publish` | Publishes .NET project for target platform | -unused- | Published application directory |
-| `merge-mac` | Merges multiple architectures into universal macOS app | Directory with arch subdirectories (osx-x64, osx-arm64) | Universal app directory |
-| `bundle-mac` | Packages macOS app into single bundle | Application directory | App bundle (.app) |
-| `sign-mac` | Signs macOS app bundle with credentials | App bundle or flat directory | Signed bundle |
-| `notary-mac` | Submits app for Apple notarization | Zipped app bundle or DMG | Notarized file (stapled in case of DMG) |
-| `sign-win` | Signs Windows executable | Application executable or installed | Signed executable or installer |
-| `create-zip` | Creates zip archive for distribution | Directory or file | Zip archive (.zip) |
+| `publish` | Publishes the .NET project for a target platform and runtime | No explicit input. Parcel reads the project from the `.parcel` file | Published application directory |
+| `merge-mac` | Merges architecture builds into a universal macOS application bundle | Directory with architecture-specific subdirectories (`osx-x64`, `osx-arm64`) | Universal application directory |
+| `bundle-mac` | Packages a macOS application and its dependencies into one bundle | Application directory | Application bundle (`.app`) |
+| `sign-mac` | Signs a macOS application bundle and its components with the credentials in the project settings | Application bundle or flat directory | Signed application bundle or directory |
+| `notary-mac` | Submits an application for Apple notarization and staples the ticket if Apple accepts it | Zipped application bundle or DMG file | Notarized file |
+| `sign-win` | Signs a Windows application executable with the provider in the project settings | Application directory with an executable that matches `AssemblyName` | Signed executable |
+| `create-zip` | Creates a ZIP archive and preserves file permissions and symbolic links | Directory or file that contains application files | ZIP archive (`.zip`) |
 | `create-dmg` | Creates DMG disk image for macOS | App bundle (.app) | Unsigned DMG image file |
-| `create-pkg` | Creates a macOS installer package | App bundle (.app) | Unsigned PKG installer (.pkg) |
+| `create-pkg` | Creates a macOS installer package with the settings in the Parcel project | Application bundle (`.app`) | PKG installer (`.pkg`) |
 | `create-deb` | Creates Debian package for Linux | Application directory | Debian package (.deb) |
-| `create-rpm` | Creates RPM package for Linux | Application directory | RPM package (.rpm) |
+| `create-rpm` | Creates an RPM package for Linux | Application directory | RPM package (`.rpm`) |
 | `create-nsis` | Creates Windows NSIS installer | Application directory | Unsigned NSIS installer (.exe) |
-| `create-msix` | Creates Windows MSIX package | Application directory | Unsigned MSIX package (.msix) |
+| `create-msix` | Creates a Windows MSIX package. Parcel generates the manifest or patches a project template | Application directory | MSIX package (`.msix`) |
 
 **Example:**
 
-While these commands don't have a strict order, and can be executed independently, standard approach is following per platform.
+The step commands are independent and do not have a required order. The following examples show a typical order for each platform.
 
-Any of these steps can be replaced with your scripts allowing for higher flexibility than standard "parcel pack" command.
+You can replace a step with your own script to customize the workflow.
 
 
 <Tabs>
@@ -147,11 +147,9 @@ parcel step create-zip ./notarized.app ./archive.zip -p project.parcel
 
 :::note
 
-Universal packages are necessary if you aim for native performance on both Intel and Apple Silicon processors, avoiding layer of emulation.
+Use a universal package to get native performance on both Intel and Apple silicon processors. A universal executable can be up to twice the size of a single-architecture executable.
 
-As a downside, universal packages are up to x2 in size of executable binaries.
-
-If you don't need that, `merge-mac` step can be skipped completely.
+If you do not need a universal package, omit the `merge-mac` step.
 
 :::
 
@@ -175,7 +173,7 @@ parcel step create-zip ./publish ./archive.zip -p project.parcel
 
 **Common Options:**
 
-- `-p, --project` - Parcel project file to load config from
+- `-p, --project` - Parcel project file that contains the configuration
 - `-w, --overwrite` - Overwrite existing output files
 - `-r, --runtime` - Runtime identifier (for publish command)
 
@@ -201,17 +199,17 @@ parcel install-tools [options]
 parcel install-tools -r win-x64 -r osx-x64 -p nsis -p dmg
 ```
 
-This specific command will pre-download **NSIS** and **DMG** tooling required for Parcel to run.
+This command downloads the NSIS and DMG tools before Parcel needs them.
 
 ### mcp
 
-Runs a Model Context Protocol server, allowing Parcel commands to be executed from LLM AI sessions.
+Runs a Model Context Protocol (MCP) server. The server lets an AI assistant run Parcel commands.
 
 ```bash
 parcel mcp
 ```
 
-See [Model Context Protocol](/tools/parcel/mcp) for more details on usage.
+For setup and usage information, see [Parcel MCP](/tools/parcel/mcp).
 
 ## Environment Variables
 
@@ -220,19 +218,19 @@ See [Model Context Protocol](/tools/parcel/mcp) for more details on usage.
 | Variable | Description |
 |---|---|
 | `AVALONIA_TOOLS_LICENSE_KEY` | License key used when `--license-key` is not provided. |
-| `AVALONIA_TOOLS_LOG_LEVEL` | Parcel application and MCP log level, such as `Debug` or `Information`. |
+| `AVALONIA_TOOLS_LOG_LEVEL` | Sets the Parcel application and MCP log level, such as `Debug` or `Information`. |
 | `AVALONIA_TELEMETRY_OPTOUT` | Set to `true` or `1` to disable Avalonia tooling telemetry. |
 | `NO_COLOR` | Set to any non-empty value to disable colored console packaging output. |
-| `SOURCE_DATE_EPOCH` | Unix timestamp used for deterministic package timestamps. |
+| `SOURCE_DATE_EPOCH` | Sets the Unix timestamp for reproducible package timestamps. |
 
 ### Tool discovery
 
 | Variable | Description |
 |---|---|
-| `PARCEL_JAVA_EXE` | Explicit path to the Java executable used by cross-platform Windows signing. `JAVA_HOME` is also respected. |
-| `PARCEL_SIGNTOOL_EXE` | Explicit path to SignTool on Windows. |
+| `PARCEL_JAVA_EXE` | Sets the path to the Java executable for cross-platform Windows signing. Parcel also reads `JAVA_HOME`. |
+| `PARCEL_SIGNTOOL_EXE` | Sets the path to SignTool on Windows. |
 | `PARCEL_WSL_DISTRIBUTION` | WSL2 distribution used by packaging steps that require WSL on Windows. |
-| `PARCEL_WSL_USER` | User account used when Parcel starts the selected WSL2 distribution. |
+| `PARCEL_WSL_USER` | Sets the user account for the selected WSL2 distribution. |
 
 ### Cloud signing
 
@@ -245,14 +243,17 @@ See [Model Context Protocol](/tools/parcel/mcp) for more details on usage.
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key used by AWS KMS signing. |
 | `AWS_SESSION_TOKEN` | Optional AWS temporary-session token. |
 
+You can override supported scalar settings with automatic `PARCEL_<SECTION>_<SETTING>` environment variables. The [Parcel configuration reference](/tools/parcel/configuration-reference) gives the exact name for each setting.
+
 ## Notes
 
-- All packaging options, signing credentials, and visual customizations are defined in the Parcel project file (.parcel)
-- When using `--no-build`, ensure that publish-related settings (trimming, AOT, single-file) match between your build and Parcel configuration
+- Define all packaging options, signing credentials, and visual settings in the Parcel project file (`.parcel`).
+- When you use `--no-build`, make sure that the publish settings match your Parcel configuration. These settings include trimming, AOT, and single-file publishing.
 
 ## See also
 
 - [Parcel setup](/tools/parcel/setup)
+- [Parcel configuration reference](/tools/parcel/configuration-reference)
 - [Packaging for macOS](/tools/parcel/packaging-for-macos)
 - [Packaging for Windows](/tools/parcel/packaging-for-windows)
 - [Packaging for Linux](/tools/parcel/packaging-for-linux)

--- a/tools/parcel/configuration-reference.md
+++ b/tools/parcel/configuration-reference.md
@@ -1,0 +1,230 @@
+---
+id: configuration-reference
+title: Parcel configuration reference
+description: Reference for the general, .NET, Windows, macOS, and Linux settings stored in an Avalonia Parcel project.
+sidebar_label: Configuration reference
+doc-type: reference
+tags:
+  - avalonia plus
+  - avalonia pro
+  - avalonia enterprise
+---
+
+A `.parcel` file contains the settings that Parcel uses to publish, package, and sign an application. The file has five top-level sections: `GeneralSettings`, `PublishSettings`, `Win32Settings`, `MacOsSettings`, and `LinuxSettings`.
+
+Parcel resolves relative paths from the location of the `.parcel` file. When you use **Save As** or **Move To**, Parcel updates relative paths for the new project location.
+
+## Setting values
+
+For most scalar settings, you can specify a literal value, an environment variable, or an MSBuild property. In the GUI, select the value source next to the setting. Use environment variables for passwords, access tokens, and other secrets. Do not store secrets directly in a `.parcel` file.
+
+If the project does not define a supported setting, Parcel checks its automatic environment variable. The following tables give the exact variable names. Collection settings and structured-object settings do not have automatic environment-variable overrides.
+
+The defaults in this reference describe the resulting package behavior. Parcel writes some defaults when it creates a project. It applies other defaults during packaging when a setting is empty.
+
+## General settings
+
+These settings appear on the **Basics** page and apply to every target platform.
+
+| Setting | `.parcel` property | Type or values | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Project | `GeneralSettings.NetProjectPath` | Path | Required | — | Path to the application `.csproj` file. Parcel manages this field. |
+| Package Name | `GeneralSettings.PackageName` | String | Assembly name | `PARCEL_GENERAL_PACKAGE_NAME` | Package identifier and output file name. Platform-specific normalization may apply. |
+| Assembly Name | `GeneralSettings.AssemblyName` | String | Project file name | `PARCEL_GENERAL_ASSEMBLY_NAME` | Name of the executable assembly. This advanced field is normally read from the .NET project. |
+| Application Name | `GeneralSettings.ApplicationName` | String | Package name | `PARCEL_GENERAL_APPLICATION_NAME` | Display name used by installers, bundles, shortcuts, and desktop entries. |
+| Version | `GeneralSettings.Version` | Version string | `1.0.0` | `PARCEL_GENERAL_VERSION` | Application and package version. Parcel converts it to the format required by each platform. |
+| Application Icon | `GeneralSettings.Icon` | Path to an icon | Parcel default icon | `PARCEL_GENERAL_ICON` | Shared application icon. A platform icon overrides it when configured. |
+| Company | `GeneralSettings.Company` | String, maximum 255 characters | Package name where required | `PARCEL_GENERAL_COMPANY` | Sets the Windows publisher and Linux package maintainer unless a platform setting overrides it. |
+| File Associations | `GeneralSettings.FileTypes` | Collection | None | — | File types registered by supported installers and bundles. |
+| URL Schemes | `GeneralSettings.UrlTypes` | Collection | None | — | URL schemes registered by supported installers and bundles. |
+
+### File associations <MinVersion version="1.1" isNewVersion="true" />
+
+Each entry in `GeneralSettings.FileTypes` has the following properties:
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `GeneralSettings.FileTypes[].Name` | String | Yes | Human-readable file type name. |
+| `GeneralSettings.FileTypes[].Extension` | String | Extension or MIME type | Extension with or without a leading period. After normalization, it must contain 1–10 lowercase letters or digits. |
+| `GeneralSettings.FileTypes[].MimeType` | String | Extension or MIME type | MIME type such as `application/x-example`. Parcel generates one when Linux needs it and it is omitted. |
+
+Each entry in `GeneralSettings.UrlTypes` has the following properties:
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `GeneralSettings.UrlTypes[].Name` | String | Yes | Human-readable name for the URL type. |
+| `GeneralSettings.UrlTypes[].Schemes` | String | Yes | One or more RFC 3986 schemes without `://`, separated by commas, semicolons, or spaces. |
+
+Parcel adds associations to NSIS and MSIX packages on Windows, application bundles on macOS, and DEB and RPM desktop entries on Linux. A Windows file association requires an extension. Windows cannot register an entry that contains only a MIME type. On macOS, associations require `MacOsSettings.CreateBundle`.
+
+## .NET publish settings
+
+These settings control the `dotnet publish` operation Parcel runs before packaging.
+
+| Setting | `.parcel` property | Type | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Configuration | `PublishSettings.Configuration` | String | .NET project default | `PARCEL_NET_CONFIGURATION` | Build configuration. It must begin with a letter and contain only letters, digits, `_`, or `-`. |
+| Publish Single File | `PublishSettings.PublishSingleFile` | Boolean | Enabled for new Parcel projects | `PARCEL_NET_PUBLISH_SINGLE_FILE` | Publishes managed assemblies in a single executable. |
+| Publish Trimmed | `PublishSettings.PublishTrimmed` | Boolean | .NET project default | `PARCEL_NET_PUBLISH_TRIMMED` | Enables trimming to reduce the package size. Test the trimmed application. |
+| Publish AOT | `PublishSettings.PublishAot` | Boolean | .NET project default | `PARCEL_NET_PUBLISH_AOT` | Enables Native AOT compilation. |
+| Publish ReadyToRun | `PublishSettings.PublishReadyToRun` | Boolean | .NET project default | `PARCEL_NET_PUBLISH_READY_TO_RUN` | Precompiles assemblies to improve startup performance. |
+| Publish Self-Contained | `PublishSettings.PublishSelfContained` | Boolean | `true` | `PARCEL_NET_PUBLISH_SELF_CONTAINED` | Includes the .NET runtime. This advanced field is not shown in the GUI. |
+| MSBuild Properties | `PublishSettings.ExtraBuildProperties` | String dictionary | Empty | — | Additional properties passed to `dotnet publish`. |
+| Exclude Files | `PublishSettings.ExcludeFilePatterns` | List of glob patterns | Empty | — | Removes matching files and directories from the published output before packaging. |
+
+## Windows settings
+
+### Installer and MSIX
+
+| Setting | `.parcel` property | Type | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Installer Icon | `Win32Settings.InstallerIcon` | Path to ICO or SVG | Application Icon | `PARCEL_WINDOWS_INSTALLER_ICON` | Overrides the shared icon for the NSIS installer and generated MSIX assets. |
+| Create Company Folder | `Win32Settings.CompanyFolder` | Boolean | `false` | `PARCEL_WINDOWS_COMPANY_FOLDER` | Adds a company directory to the NSIS installation and Start Menu paths. |
+| License File | `Win32Settings.InstallerLicense` | Path to TXT or RTF | None | `PARCEL_WINDOWS_INSTALLER_LICENSE` | Displays a license acceptance page in the NSIS installer. |
+| Requires Admin | `Win32Settings.InstallerRequiresAdmin` | Boolean | `true` | `PARCEL_WINDOWS_INSTALLER_REQUIRES_ADMIN` | Installs NSIS packages under Program Files with elevation; when disabled, installs for the current user. |
+| Include uninstaller with the app | `Win32Settings.IncludeUninstaller` | Boolean | `true` | `PARCEL_WINDOWS_INCLUDE_UNINSTALLER` | Includes an NSIS uninstaller and registers the application in Windows installed-app listings. |
+| Publisher | `Win32Settings.MsixPublisher` | Distinguished name | Company or application name | `PARCEL_WINDOWS_MSIX_PUBLISHER` | MSIX publisher identity. For signed packages, it must exactly match the certificate subject. |
+
+### Signing
+
+`Win32Settings.SigningType` accepts `None`, `LocalCertificate`, `WindowsCertificateStore`, `AzureTrustedSigning`, `AzureKeyVault`, `AwsKeyManagementService`, `DigiCert`, `GoogleKeyManagementService`, or `ESigner`. The GUI names `AzureTrustedSigning` **Azure Artifact Signing**.
+
+| Setting | `.parcel` property | Type | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Signing Type | `Win32Settings.SigningType` | Signing type | `None` | `PARCEL_WINDOWS_SIGNING_TYPE` | Selects the Authenticode signing provider. |
+| Sign Installer | `Win32Settings.SignInstaller` | Boolean | `true` | `PARCEL_WINDOWS_SIGN_INSTALLER` | Signs the generated NSIS or MSIX package and the application files. Disable it when a store or later pipeline signs the package. |
+| Additional signing patterns | `Win32Settings.AdditionalSignPatterns` | List of glob patterns | Empty | — | Includes additional code files in application signing. |
+| Timestamp Server URL | `Win32Settings.SigningTimestampServer` | URL | None | `PARCEL_WINDOWS_SIGNING_TIMESTAMP_SERVER` | Timestamp authority used with a local certificate or the Windows certificate store. |
+| Local Signing Certificate File | `Win32Settings.LocalSigningCertificate` | Path to PFX or P12 | Required for local certificate | `PARCEL_WINDOWS_LOCAL_SIGNING_CERTIFICATE` | Certificate and private key used for local signing. |
+| Local Signing Certificate Password | `Win32Settings.LocalSigningCertificatePassword` | Secret string | Empty | `PARCEL_WINDOWS_LOCAL_SIGNING_CERTIFICATE_PASSWORD` | Password protecting the local certificate. |
+| Store Certificate Name | `Win32Settings.StoreCertificateName` | String | Required for certificate store | `PARCEL_WINDOWS_STORE_CERTIFICATE_NAME` | Certificate subject or thumbprint in the Windows certificate store. |
+| Use Local Machine Certificate Store | `Win32Settings.UseLocalMachineCertificateStore` | Boolean | `false` | `PARCEL_WINDOWS_USE_LOCAL_MACHINE_CERTIFICATE_STORE` | Searches Local Machine instead of Current User. Windows only. |
+| Auto-Detect Matching Certificate | `Win32Settings.AutoDetectMatchingCertificate` | Boolean | `false` | `PARCEL_WINDOWS_AUTO_DETECT_MATCHING_CERTIFICATE` | Allows SignTool to choose a matching certificate. Windows only. |
+| Azure Artifact Signing Endpoint | `Win32Settings.TrustedSigningEndpoint` | Azure signing URL | Required | `PARCEL_WINDOWS_TRUSTED_SIGNING_ENDPOINT` | Azure Artifact Signing service endpoint. |
+| Azure Artifact Signing Certificate Profile Name | `Win32Settings.TrustedSigningCertificateProfileName` | String | Required | `PARCEL_WINDOWS_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME` | Azure Artifact Signing certificate profile. |
+| Azure Artifact Signing Account Name | `Win32Settings.TrustedSigningCodeSigningAccountName` | String | Required | `PARCEL_WINDOWS_TRUSTED_SIGNING_CODE_SIGNING_ACCOUNT_NAME` | Azure Artifact Signing account. |
+| Azure Key Vault Name | `Win32Settings.AzureKeyVaultName` | String | Required unless URL identifies it | `PARCEL_WINDOWS_AZURE_KEY_VAULT_NAME` | Azure Key Vault name. |
+| Azure Key Vault URL | `Win32Settings.AzureKeyVaultUrl` | Absolute HTTP(S) URL | Public Azure endpoint | `PARCEL_WINDOWS_AZURE_KEY_VAULT_URL` | Full vault URL, including sovereign-cloud endpoints. |
+| Azure Key Vault Certificate Name | `Win32Settings.AzureKeyVaultCertificateName` | String | Required | `PARCEL_WINDOWS_AZURE_KEY_VAULT_CERTIFICATE_NAME` | Certificate stored in Azure Key Vault. |
+| AWS Region Code | `Win32Settings.AwsSigningRegionCode` | String | Required | `PARCEL_WINDOWS_AWS_SIGNING_REGION_CODE` | AWS region containing the signing key. |
+| AWS Signing Certificate File | `Win32Settings.AwsSigningCertificateFile` | Path | Required | `PARCEL_WINDOWS_AWS_SIGNING_CERTIFICATE_FILE` | Certificate corresponding to the private key in AWS KMS. |
+| AWS Signing Key ID or Alias | `Win32Settings.AwsSigningKeyIdOrAlias` | String | Required | `PARCEL_WINDOWS_AWS_SIGNING_KEY_ID_OR_ALIAS` | AWS KMS key identifier or alias. |
+| DigiCert API Key | `Win32Settings.DigiCertApiKey` | Secret string | Required | `PARCEL_WINDOWS_DIGI_CERT_API_KEY` | DigiCert ONE API key. |
+| DigiCert Keystore | `Win32Settings.DigiCertKeystore` | Path to PKCS#12 | Required | `PARCEL_WINDOWS_DIGI_CERT_KEYSTORE` | Client-authentication keystore. |
+| DigiCert Storepass | `Win32Settings.DigiCertStorepass` | Secret string | Required | `PARCEL_WINDOWS_DIGI_CERT_STOREPASS` | Password for the DigiCert keystore. |
+| DigiCert Certificate Name or ID | `Win32Settings.DigiCertCertificateNameOrId` | String | Required | `PARCEL_WINDOWS_DIGI_CERT_CERTIFICATE_NAME_OR_ID` | Certificate name or ID in DigiCert ONE. |
+| DigiCert Host | `Win32Settings.DigiCertHost` | HTTP(S) URL | US DigiCert ONE host | `PARCEL_WINDOWS_DIGI_CERT_HOST` | Overrides the DigiCert ONE service host. |
+| Google Access Token | `Win32Settings.GoogleAccessToken` | Secret string | Required | `PARCEL_WINDOWS_GOOGLE_ACCESS_TOKEN` | OAuth 2.0 access token for Google Cloud KMS. |
+| Google Signing Keyring | `Win32Settings.GoogleSigningKeyring` | Keyring resource path | Required | `PARCEL_WINDOWS_GOOGLE_SIGNING_KEYRING` | Resource path through `projects`, `locations`, and `keyRings`. |
+| Google Signing Certificate File | `Win32Settings.GoogleSigningCertificateFile` | Path | Required | `PARCEL_WINDOWS_GOOGLE_SIGNING_CERTIFICATE_FILE` | Certificate corresponding to the Google Cloud KMS key. |
+| Google Signing Certificate Version | `Win32Settings.GoogleSigningCertificateVersion` | String | Latest | `PARCEL_WINDOWS_GOOGLE_SIGNING_CERTIFICATE_VERSION` | Specific key version to use. |
+| eSigner User Name | `Win32Settings.ESignerUserName` | String | Required | `PARCEL_WINDOWS_E_SIGNER_USER_NAME` | SSL.com account username. |
+| eSigner Password | `Win32Settings.ESignerPassword` | Secret string | Required | `PARCEL_WINDOWS_E_SIGNER_PASSWORD` | SSL.com account password. |
+| eSigner Key Password | `Win32Settings.ESignerKeyPassword` | Secret string | Required | `PARCEL_WINDOWS_E_SIGNER_KEY_PASSWORD` | Base64-encoded TOTP secret. |
+| eSigner Credential ID | `Win32Settings.ESignerCredentialId` | String | Required | `PARCEL_WINDOWS_E_SIGNER_CREDENTIAL_ID` | SSL.com signing credential identifier. |
+| eSigner Sandbox | `Win32Settings.ESignerSandbox` | Boolean | `false` | `PARCEL_WINDOWS_E_SIGNER_SANDBOX` | Uses the SSL.com sandbox service. |
+
+## macOS settings
+
+### Bundle, DMG, and PKG
+
+| Setting | `.parcel` property | Type | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Create Bundle | `MacOsSettings.CreateBundle` | Boolean | `true` for new projects | `PARCEL_MACOS_CREATE_BUNDLE` | Creates a macOS `.app` bundle. DMG, PKG, permissions, and associations require a bundle. |
+| Bundle Identifier | `MacOsSettings.BundleIdentifier` | Reverse-DNS string | Derived from company and package name | `PARCEL_MACOS_BUNDLE_IDENTIFIER` | `CFBundleIdentifier` used for signing and distribution. |
+| Team ID | `MacOsSettings.TeamId` | 10 uppercase letters or digits | None | `PARCEL_MACOS_TEAM_ID` | Apple Developer team identifier used by signing and notarization. |
+| App Category | `MacOsSettings.BundleCategory` | Apple bundle category | `Other` | `PARCEL_MACOS_BUNDLE_CATEGORY` | macOS and App Store application category. |
+| Application Icon | `MacOsSettings.AppIcon` | Path to ICNS or SVG | Application Icon | `PARCEL_MACOS_APP_ICON` | Overrides the shared icon for the app bundle. |
+| Permissions | `MacOsSettings.Permissions` | Permission-description dictionary | Empty | — | Adds macOS usage descriptions for Camera, Microphone, Location, Contacts, Calendars, Desktop, Documents, Downloads, and Network. |
+| Resource file patterns | `MacOsSettings.BundleResourcePatterns` | List of glob patterns | Empty | — | Moves matching files to `Contents/Resources` and replaces their original locations with symlinks. |
+| Automatically Move Bundle Frameworks | `MacOsSettings.AutomaticallyMoveBundleFrameworks` | Boolean | `false` | `PARCEL_MACOS_AUTOMATICALLY_MOVE_BUNDLE_FRAMEWORKS` | Advanced compatibility option for relocating frameworks. Not shown in the GUI. |
+| Automatically Move Bundle Resources | `MacOsSettings.AutomaticallyMoveBundleResources` | Boolean | `false` | `PARCEL_MACOS_AUTOMATICALLY_MOVE_BUNDLE_RESOURCES` | Advanced compatibility option for relocating resources. Not shown in the GUI. |
+| DMG Background Image | `MacOsSettings.DmgBackground` | Path to TIFF | None | `PARCEL_MACOS_DMG_BACKGROUND` | Background displayed in the DMG window. |
+| DMG Layout | `MacOsSettings.DmgLayout` | Layout object | Standard Parcel layout | — | Window, grid, icon, text, background color, app position, and Applications-link position settings. |
+| DMG License File | `MacOsSettings.DmgLicense` | Path | None | `PARCEL_MACOS_DMG_LICENSE` | File embedded at the root of the DMG. |
+| Install Location | `MacOsSettings.InstallerLocation` | Absolute path | `/Applications` | `PARCEL_MACOS_INSTALLER_LOCATION` | PKG installation directory. This advanced field is not shown in the GUI. |
+| Install Scripts Directory | `MacOsSettings.InstallerScripts` | Directory path | None | `PARCEL_MACOS_INSTALLER_SCRIPTS` | Directory containing executable `preinstall` and `postinstall` scripts. This advanced field is not shown in the GUI. |
+| Package Identifier | `MacOsSettings.InstallerIdentifier` | Reverse-DNS string | Bundle identifier | `PARCEL_MACOS_INSTALLER_IDENTIFIER` | Identifier registered by the PKG installer. This advanced field is not shown in the GUI. |
+
+The DMG layout object supports these advanced properties:
+
+| `.parcel` property | Type | Default | Description |
+|---|---|---|---|
+| `MacOsSettings.DmgLayout.BackgroundColorRed` | Number | `1` | Red component of the window background color. |
+| `MacOsSettings.DmgLayout.BackgroundColorGreen` | Number | `1` | Green component of the window background color. |
+| `MacOsSettings.DmgLayout.BackgroundColorBlue` | Number | `1` | Blue component of the window background color. |
+| `MacOsSettings.DmgLayout.GridOffsetX` | Integer | `0` | Horizontal grid offset. |
+| `MacOsSettings.DmgLayout.GridOffsetY` | Integer | `0` | Vertical grid offset. |
+| `MacOsSettings.DmgLayout.GridSpacing` | Integer | `100` | Spacing between grid positions. |
+| `MacOsSettings.DmgLayout.X` | Integer | `100` | Horizontal position of the DMG window. |
+| `MacOsSettings.DmgLayout.Y` | Integer | `100` | Vertical position of the DMG window. |
+| `MacOsSettings.DmgLayout.Width` | Integer | `660` | DMG window width. |
+| `MacOsSettings.DmgLayout.Height` | Integer | `422` | DMG window height. |
+| `MacOsSettings.DmgLayout.IconSize` | Integer | `128` | Icon size in pixels. |
+| `MacOsSettings.DmgLayout.TextSize` | Integer | `12` | Icon-label text size. |
+| `MacOsSettings.DmgLayout.BundlePositionX` | Integer | `173` | Horizontal position of the app bundle. |
+| `MacOsSettings.DmgLayout.BundlePositionY` | Integer | `231` | Vertical position of the app bundle. |
+| `MacOsSettings.DmgLayout.ApplicationsPositionX` | Integer | `485` | Horizontal position of the Applications link. |
+| `MacOsSettings.DmgLayout.ApplicationsPositionY` | Integer | `231` | Vertical position of the Applications link. |
+
+### Application signing
+
+`MacOsSettings.SigningCredentialsType` accepts `None`, `AdHoc`, `KeyChainIdentity`, `P12Certificate`, or `PemCertificate`.
+
+| Setting | `.parcel` property | Type | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Signing Credentials | `MacOsSettings.SigningCredentialsType` | Credential type | `AdHoc` | `PARCEL_MACOS_SIGNING_CREDENTIALS_TYPE` | Selects how the app bundle, code, and optionally DMG are signed. |
+| Enable App Sandbox | `MacOsSettings.EnableSandbox` | Boolean | `false` | `PARCEL_MACOS_ENABLE_SANDBOX` | Runs the application in the macOS App Sandbox. The application can access only resources covered by its entitlements. Required for Mac App Store distribution. |
+| Sign DMG | `MacOsSettings.SignDmg` | Boolean | `true` | `PARCEL_MACOS_SIGN_DMG` | Signs the generated DMG using the application-signing credentials. |
+| Additional signing patterns | `MacOsSettings.AdditionalSignPatterns` | List of glob patterns | Empty | — | Includes additional code files in bundle signing. |
+| Signing Identity | `MacOsSettings.SigningIdentity` | Keychain identity | Required for Keychain | `PARCEL_MACOS_SIGNING_IDENTITY` | Application-signing identity in the macOS Keychain. |
+| Signing P12 Certificate | `MacOsSettings.SigningP12Certificate` | Path to P12 | Required for P12 | `PARCEL_MACOS_SIGNING_P12_CERTIFICATE` | Portable application-signing certificate and private key. |
+| Signing Password | `MacOsSettings.SigningP12Password` | Secret string | Empty | `PARCEL_MACOS_SIGNING_P12_PASSWORD` | Password protecting the application P12 certificate. |
+| Signing PEM Certificate | `MacOsSettings.SigningPemCertificate` | Path to PEM | Required for PEM | `PARCEL_MACOS_SIGNING_PEM_CERTIFICATE` | PEM application-signing certificate. |
+| Deep Signing | `MacOsSettings.SignDeep` | Boolean | `false` | `PARCEL_MACOS_SIGN_DEEP` | Advanced compatibility option for deep signing. Not shown in the GUI. |
+
+### Installer signing
+
+A PKG installer requires a separate installer certificate. `MacOsSettings.InstallerSigningCredentialsType` accepts the same credential types as application signing. Ad hoc signing cannot create a signed PKG.
+
+| Setting | `.parcel` property | Type | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Installer Signing Credentials | `MacOsSettings.InstallerSigningCredentialsType` | Credential type | `None` | `PARCEL_MACOS_INSTALLER_SIGNING_CREDENTIALS_TYPE` | Selects the certificate used to sign PKG installers. |
+| Installer Signing Identity | `MacOsSettings.InstallerSigningIdentity` | Keychain identity | Required for Keychain | `PARCEL_MACOS_INSTALLER_SIGNING_IDENTITY` | Installer identity in the macOS Keychain. |
+| Installer Signing P12 Certificate | `MacOsSettings.InstallerSigningP12Certificate` | Path to P12 | Required for P12 | `PARCEL_MACOS_INSTALLER_SIGNING_P12_CERTIFICATE` | Portable installer certificate and private key. |
+| Installer Signing Password | `MacOsSettings.InstallerSigningP12Password` | Secret string | Empty | `PARCEL_MACOS_INSTALLER_SIGNING_P12_PASSWORD` | Password protecting the installer P12 certificate. |
+| Installer Signing PEM Certificate | `MacOsSettings.InstallerSigningPemCertificate` | Path to PEM | Required for PEM | `PARCEL_MACOS_INSTALLER_SIGNING_PEM_CERTIFICATE` | PEM installer-signing certificate. |
+
+### Notarization
+
+`MacOsSettings.NotaryCredentialsType` accepts `None`, `KeyChainProfile`, or `AppleAccount`.
+
+| Setting | `.parcel` property | Type | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Notary Credentials | `MacOsSettings.NotaryCredentialsType` | Credential type | `None` | `PARCEL_MACOS_NOTARY_CREDENTIALS_TYPE` | Selects authentication for Apple's notary service. |
+| Notary Keychain Profile | `MacOsSettings.NotaryKeychainProfile` | String | Required for Keychain profile | `PARCEL_MACOS_NOTARY_KEYCHAIN_PROFILE` | `notarytool` profile stored in the macOS Keychain. |
+| Notary Apple ID | `MacOsSettings.NotaryAppleId` | Email address | Required for Apple account | `PARCEL_MACOS_NOTARY_APPLE_ID` | Apple ID used for notarization. |
+| Notary App Password | `MacOsSettings.NotaryAppPassword` | Secret string | Required for Apple account | `PARCEL_MACOS_NOTARY_APP_PASSWORD` | App-specific password used by the notary service. |
+
+## Linux settings
+
+| Setting | `.parcel` property | Type or values | Default | Environment variable | Description |
+|---|---|---|---|---|---|
+| Install Directory Name | `LinuxSettings.InstallDirName` | Lowercase package-directory name | `app-{package-name}` | `PARCEL_LINUX_INSTALL_DIR_NAME` | Directory created under `/usr/share`. It must start and end with a letter or number. Maximum 100 characters. |
+| Application Icon | `LinuxSettings.AppIcon` | Path to PNG or SVG | Application Icon | `PARCEL_LINUX_APP_ICON` | Overrides the shared icon for DEB and RPM packages. |
+| Maintainer | `LinuxSettings.Maintainer` | String, maximum 255 characters | Company, then package name | `PARCEL_LINUX_MAINTAINER` | Package maintainer, preferably in `Name <email@example.com>` format. |
+| Copyright | `LinuxSettings.CopyrightFile` | Path | None | `PARCEL_LINUX_COPYRIGHT_FILE` | Copyright file included in DEB and RPM metadata. |
+| Desktop Category | `LinuxSettings.DesktopCategory` | Linux desktop category | `Application` | `PARCEL_LINUX_DESKTOP_CATEGORY` | Category used in desktop menus and mapped to package-manager metadata. |
+| Create `/usr/bin/` symlink | `LinuxSettings.CreateBinSymlink` | Boolean | `true` | `PARCEL_LINUX_CREATE_BIN_SYMLINK` | Creates a command-line symlink to the application executable. |
+| Additional DEB Dependencies | `LinuxSettings.AdditionalDebDependencies` | List | Empty | — | Adds Debian package dependencies. Separate alternatives with a vertical bar. |
+| Additional RPM Dependencies | `LinuxSettings.AdditionalRpmDependencies` | List | Empty | — | Adds RPM package names or capabilities. |
+
+You can use the main freedesktop categories and common additional categories. These include `Development`, `Education`, `Game`, `Graphics`, `Network`, `Office`, `Science`, `Settings`, `System`, `Utility`, `WebBrowser`, `TextEditor`, and `TerminalEmulator`.
+
+## See also
+
+- [Parcel setup](/tools/parcel/setup)
+- [Parcel command line reference](/tools/parcel/command-line-reference)
+- [Packaging for Windows](/tools/parcel/packaging-for-windows)
+- [Packaging for macOS](/tools/parcel/packaging-for-macos)
+- [Packaging for Linux](/tools/parcel/packaging-for-linux)

--- a/tools/parcel/configuration-reference.md
+++ b/tools/parcel/configuration-reference.md
@@ -12,7 +12,7 @@ tags:
 
 A `.parcel` file contains the settings that Parcel uses to publish, package, and sign an application. The file has five top-level sections: `GeneralSettings`, `PublishSettings`, `Win32Settings`, `MacOsSettings`, and `LinuxSettings`.
 
-Parcel resolves relative paths from the location of the `.parcel` file. When you use **Save As** or **Move To**, Parcel updates relative paths for the new project location.
+Parcel resolves relative paths from the location of the `.parcel` file. If you use **Save As** or **Move To**, Parcel updates relative paths for the new project location.
 
 ## Setting values
 
@@ -20,11 +20,11 @@ For most scalar settings, you can specify a literal value, an environment variab
 
 If the project does not define a supported setting, Parcel checks its automatic environment variable. The following tables give the exact variable names. Collection settings and structured-object settings do not have automatic environment-variable overrides.
 
-The defaults in this reference describe the resulting package behavior. Parcel writes some defaults when it creates a project. It applies other defaults during packaging when a setting is empty.
+The defaults in this reference describe the resulting package behavior. Parcel writes some defaults when it creates a project. It applies other defaults during packaging if a setting is empty.
 
 ## General settings
 
-These settings appear on the **Basics** page and apply to every target platform.
+These settings apply to every target platform. They appear on the **Basics** page.
 
 | Setting | `.parcel` property | Type or values | Default | Environment variable | Description |
 |---|---|---|---|---|---|
@@ -34,7 +34,7 @@ These settings appear on the **Basics** page and apply to every target platform.
 | Application Name | `GeneralSettings.ApplicationName` | String | Package name | `PARCEL_GENERAL_APPLICATION_NAME` | Display name used by installers, bundles, shortcuts, and desktop entries. |
 | Version | `GeneralSettings.Version` | Version string | `1.0.0` | `PARCEL_GENERAL_VERSION` | Application and package version. Parcel converts it to the format required by each platform. |
 | Application Icon | `GeneralSettings.Icon` | Path to an icon | Parcel default icon | `PARCEL_GENERAL_ICON` | Shared application icon. A platform icon overrides it when configured. |
-| Company | `GeneralSettings.Company` | String, maximum 255 characters | Package name where required | `PARCEL_GENERAL_COMPANY` | Sets the Windows publisher and Linux package maintainer unless a platform setting overrides it. |
+| Company | `GeneralSettings.Company` | String | Package name where required | `PARCEL_GENERAL_COMPANY` | Sets the Windows publisher and Linux package maintainer unless a platform setting overrides it. Maximum 255 characters. |
 | File Associations | `GeneralSettings.FileTypes` | Collection | None | — | File types registered by supported installers and bundles. |
 | URL Schemes | `GeneralSettings.UrlTypes` | Collection | None | — | URL schemes registered by supported installers and bundles. |
 
@@ -55,7 +55,11 @@ Each entry in `GeneralSettings.UrlTypes` has the following properties:
 | `GeneralSettings.UrlTypes[].Name` | String | Yes | Human-readable name for the URL type. |
 | `GeneralSettings.UrlTypes[].Schemes` | String | Yes | One or more RFC 3986 schemes without `://`, separated by commas, semicolons, or spaces. |
 
-Parcel adds associations to NSIS and MSIX packages on Windows, application bundles on macOS, and DEB and RPM desktop entries on Linux. A Windows file association requires an extension. Windows cannot register an entry that contains only a MIME type. On macOS, associations require `MacOsSettings.CreateBundle`.
+Parcel adds associations to NSIS and MSIX packages on Windows, application bundles on macOS, and DEB and RPM desktop entries on Linux.
+
+On Windows, file association requires an extension. Windows cannot register an entry that contains only a MIME type.
+
+On macOS, associations require `MacOsSettings.CreateBundle`.
 
 ## .NET publish settings
 
@@ -65,7 +69,7 @@ These settings control the `dotnet publish` operation Parcel runs before packagi
 |---|---|---|---|---|---|
 | Configuration | `PublishSettings.Configuration` | String | .NET project default | `PARCEL_NET_CONFIGURATION` | Build configuration. It must begin with a letter and contain only letters, digits, `_`, or `-`. |
 | Publish Single File | `PublishSettings.PublishSingleFile` | Boolean | Enabled for new Parcel projects | `PARCEL_NET_PUBLISH_SINGLE_FILE` | Publishes managed assemblies in a single executable. |
-| Publish Trimmed | `PublishSettings.PublishTrimmed` | Boolean | .NET project default | `PARCEL_NET_PUBLISH_TRIMMED` | Enables trimming to reduce the package size. Test the trimmed application. |
+| Publish Trimmed | `PublishSettings.PublishTrimmed` | Boolean | .NET project default | `PARCEL_NET_PUBLISH_TRIMMED` | Enables trimming to reduce the package size. Testing the trimmed application is recommended. |
 | Publish AOT | `PublishSettings.PublishAot` | Boolean | .NET project default | `PARCEL_NET_PUBLISH_AOT` | Enables Native AOT compilation. |
 | Publish ReadyToRun | `PublishSettings.PublishReadyToRun` | Boolean | .NET project default | `PARCEL_NET_PUBLISH_READY_TO_RUN` | Precompiles assemblies to improve startup performance. |
 | Publish Self-Contained | `PublishSettings.PublishSelfContained` | Boolean | `true` | `PARCEL_NET_PUBLISH_SELF_CONTAINED` | Includes the .NET runtime. This advanced field is not shown in the GUI. |
@@ -73,7 +77,7 @@ These settings control the `dotnet publish` operation Parcel runs before packagi
 | Exclude Files | `PublishSettings.ExcludeFilePatterns` | List of glob patterns | Empty | — | Removes matching files and directories from the published output before packaging. |
 
 :::note
-.NET publish properties defined in the *.csproj file are also respected, there is no need to duplicate them in the parcel config.
+Parcel respects .NET publish properties defined in the *.csproj file. There is no need to duplicate them in the Parcel config.
 :::
 
 ## Windows settings
@@ -85,7 +89,7 @@ These settings control the `dotnet publish` operation Parcel runs before packagi
 | Installer Icon | `Win32Settings.InstallerIcon` | Path to ICO or SVG | Application Icon | `PARCEL_WINDOWS_INSTALLER_ICON` | Overrides the shared icon for the NSIS installer and generated MSIX assets. |
 | Create Company Folder | `Win32Settings.CompanyFolder` | Boolean | `false` | `PARCEL_WINDOWS_COMPANY_FOLDER` | Adds a company directory to the NSIS installation and Start Menu paths. |
 | License File | `Win32Settings.InstallerLicense` | Path to TXT or RTF | None | `PARCEL_WINDOWS_INSTALLER_LICENSE` | Displays a license acceptance page in the NSIS installer. |
-| Requires Admin | `Win32Settings.InstallerRequiresAdmin` | Boolean | `true` | `PARCEL_WINDOWS_INSTALLER_REQUIRES_ADMIN` | Installs NSIS packages under Program Files with elevation; when disabled, installs for the current user. |
+| Requires Admin | `Win32Settings.InstallerRequiresAdmin` | Boolean | `true` | `PARCEL_WINDOWS_INSTALLER_REQUIRES_ADMIN` | Installs NSIS packages under Program Files with elevation. When disabled, installs for the current user. |
 | Include uninstaller with the app | `Win32Settings.IncludeUninstaller` | Boolean | `true` | `PARCEL_WINDOWS_INCLUDE_UNINSTALLER` | Includes an NSIS uninstaller and registers the application in Windows installed-app listings. |
 | Publisher | `Win32Settings.MsixPublisher` | Distinguished name | Company or application name | `PARCEL_WINDOWS_MSIX_PUBLISHER` | MSIX publisher identity. For signed packages, it must exactly match the certificate subject. |
 
@@ -136,7 +140,7 @@ These settings control the `dotnet publish` operation Parcel runs before packagi
 |---|---|---|---|---|---|
 | Create Bundle | `MacOsSettings.CreateBundle` | Boolean | `true` for new projects | `PARCEL_MACOS_CREATE_BUNDLE` | Creates a macOS `.app` bundle. DMG, PKG, permissions, and associations require a bundle. |
 | Bundle Identifier | `MacOsSettings.BundleIdentifier` | Reverse-DNS string | Derived from company and package name | `PARCEL_MACOS_BUNDLE_IDENTIFIER` | `CFBundleIdentifier` used for signing and distribution. |
-| Team ID | `MacOsSettings.TeamId` | 10 uppercase letters or digits | None | `PARCEL_MACOS_TEAM_ID` | Apple Developer team identifier used by signing and notarization. |
+| Team ID | `MacOsSettings.TeamId` | 10 uppercase letters or digits | None | `PARCEL_MACOS_TEAM_ID` | Apple Developer team identifier used for signing and notarization. |
 | App Category | `MacOsSettings.BundleCategory` | Apple bundle category | `Other` | `PARCEL_MACOS_BUNDLE_CATEGORY` | macOS and App Store application category. |
 | Application Icon | `MacOsSettings.AppIcon` | Path to ICNS or SVG | Application Icon | `PARCEL_MACOS_APP_ICON` | Overrides the shared icon for the app bundle. |
 | Permissions | `MacOsSettings.Permissions` | Permission-description dictionary | Empty | — | Adds macOS usage descriptions for Camera, Microphone, Location, Contacts, Calendars, Desktop, Documents, Downloads, and Network. |
@@ -189,7 +193,7 @@ The DMG layout object supports these advanced properties:
 
 ### Installer signing
 
-A PKG installer requires a separate installer certificate. `MacOsSettings.InstallerSigningCredentialsType` accepts the same credential types as application signing. Ad hoc signing cannot create a signed PKG.
+A PKG installer requires a separate installer certificate. `MacOsSettings.InstallerSigningCredentialsType` accepts the same credential types as [application signing](#application-signing). Ad hoc signing cannot create a signed PKG.
 
 | Setting | `.parcel` property | Type | Default | Environment variable | Description |
 |---|---|---|---|---|---|
@@ -216,14 +220,14 @@ A PKG installer requires a separate installer certificate. `MacOsSettings.Instal
 |---|---|---|---|---|---|
 | Install Directory Name | `LinuxSettings.InstallDirName` | Lowercase package-directory name | `app-{package-name}` | `PARCEL_LINUX_INSTALL_DIR_NAME` | Directory created under `/usr/share`. It must start and end with a letter or number. Maximum 100 characters. |
 | Application Icon | `LinuxSettings.AppIcon` | Path to PNG or SVG | Application Icon | `PARCEL_LINUX_APP_ICON` | Overrides the shared icon for DEB and RPM packages. |
-| Maintainer | `LinuxSettings.Maintainer` | String, maximum 255 characters | Company, then package name | `PARCEL_LINUX_MAINTAINER` | Package maintainer, preferably in `Name <email@example.com>` format. |
+| Maintainer | `LinuxSettings.Maintainer` | String | Company, then package name | `PARCEL_LINUX_MAINTAINER` | Package maintainer, preferably in `Name <email@example.com>` format. Maximum 255 characters. |
 | Copyright | `LinuxSettings.CopyrightFile` | Path | None | `PARCEL_LINUX_COPYRIGHT_FILE` | Copyright file included in DEB and RPM metadata. |
 | Desktop Category | `LinuxSettings.DesktopCategory` | Linux desktop category | `Application` | `PARCEL_LINUX_DESKTOP_CATEGORY` | Category used in desktop menus and mapped to package-manager metadata. |
 | Create `/usr/bin/` symlink | `LinuxSettings.CreateBinSymlink` | Boolean | `true` | `PARCEL_LINUX_CREATE_BIN_SYMLINK` | Creates a command-line symlink to the application executable. |
 | Additional DEB Dependencies | `LinuxSettings.AdditionalDebDependencies` | List | Empty | — | Adds Debian package dependencies. Separate alternatives with a vertical bar. |
 | Additional RPM Dependencies | `LinuxSettings.AdditionalRpmDependencies` | List | Empty | — | Adds RPM package names or capabilities. |
 
-You can use the main freedesktop categories and common additional categories. These include `Development`, `Education`, `Game`, `Graphics`, `Network`, `Office`, `Science`, `Settings`, `System`, `Utility`, `WebBrowser`, `TextEditor`, and `TerminalEmulator`.
+You can use the main [freedesktop categories](https://specifications.freedesktop.org/menu-spec/latest/category-registry.html) and common additional categories, e.g., `Development`, `Education`, `Game`, `Graphics`, `Network`, `Office`, `Science`, `Settings`, `System`, `Utility`, `WebBrowser`, `TextEditor`, `TerminalEmulator`.
 
 ## See also
 

--- a/tools/parcel/configuration-reference.md
+++ b/tools/parcel/configuration-reference.md
@@ -72,6 +72,10 @@ These settings control the `dotnet publish` operation Parcel runs before packagi
 | MSBuild Properties | `PublishSettings.ExtraBuildProperties` | String dictionary | Empty | — | Additional properties passed to `dotnet publish`. |
 | Exclude Files | `PublishSettings.ExcludeFilePatterns` | List of glob patterns | Empty | — | Removes matching files and directories from the published output before packaging. |
 
+:::note
+.NET publish properties defined in the *.csproj file are also respected, there is no need to duplicate them in the parcel config.
+:::
+
 ## Windows settings
 
 ### Installer and MSIX

--- a/tools/parcel/mcp.md
+++ b/tools/parcel/mcp.md
@@ -10,20 +10,20 @@ import TabItem from '@theme/TabItem';
 
 ## What is Parcel MCP?
 
-The Parcel MCP server lets AI assistants interact directly with Parcel's packaging tools. Your assistant can create packaging configurations from your .NET projects, set up code signing and notarisation, and build installers for Windows, macOS, and Linux, all from a natural language conversation.
+The Parcel MCP server lets AI assistants use Parcel packaging tools. Your assistant can create packaging configurations from .NET projects. It can also configure code signing and notarization and build packages for Windows, macOS, and Linux.
 
 For a general introduction to MCP, see [AI Tools](/tools/ai-tools/).
 
 ## Prerequisites
 
-Before setting up the MCP server, ensure you have:
+Before you configure the MCP server, make sure that you have these items:
 
 1. **Parcel .NET tool installed.** Follow the [Setup guide](/tools/parcel/setup).
 2. **Valid Avalonia Plus license key.** You can get one from the [Avalonia portal](https://portal.avaloniaui.net/).
 
 ### Setting your license key
 
-The MCP server reads your license from the `AVALONIA_TOOLS_LICENSE_KEY` environment variable. You can find your license key in the [Avalonia Customer Portal](https://portal.avaloniaui.net/). MCP is a paid feature and is not included with the Community edition.
+The MCP server reads the license from the `AVALONIA_TOOLS_LICENSE_KEY` environment variable. Get your license key from the [Avalonia Customer Portal](https://portal.avaloniaui.net/). MCP is a paid feature and is not included with the Community edition.
 
 Set the key in your shell profile so it persists across sessions:
 
@@ -66,7 +66,7 @@ Restart any open terminals and editors to pick up the change.
 </Tabs>
 
 :::caution[Editors launched from GUI shortcuts]
-If you launch your editor from a desktop shortcut or application menu (rather than from a terminal), it may not inherit environment variables from your shell profile. If the MCP server reports a missing license key, you can set it directly in the MCP configuration by adding an `env` block:
+If you start your editor from a desktop shortcut or application menu, it might not read environment variables from your shell profile. If the MCP server reports a missing license key, add an `env` block to the MCP configuration:
 
 ```json
 {
@@ -85,7 +85,7 @@ Parcel MCP is only available with a full [Avalonia Plus](https://avaloniaui.net/
 
 ## Setting up the MCP server
 
-Parcel provides an MCP server that runs as a local process. The underlying command is `parcel mcp`, but you do not need to run it manually. Your editor starts it automatically once configured.
+The Parcel MCP server runs as a local process. Its command is `parcel mcp`. You do not need to run this command manually. After configuration, your editor starts the server automatically.
 
 Choose your editor below:
 
@@ -230,7 +230,7 @@ Claude Desktop does not inherit environment variables from your shell profile, s
 
 ## Verify the connection
 
-After configuring the MCP server, verify it is working:
+After you configure the MCP server, test the connection:
 
 1. **Check the server is running.** Open your editor's MCP panel or status indicator and confirm `parcel` appears as a connected server. In VS Code, run **MCP: List Servers** from the command palette.
 2. **Test with a prompt.** Ask your AI assistant:
@@ -239,13 +239,13 @@ After configuring the MCP server, verify it is working:
 "List the available Parcel packaging tools."
 ```
 
-If the assistant returns a list of capabilities, setup is complete.
+If the assistant returns a list of capabilities, the connection works.
 
 ## Troubleshooting
 
 ### "parcel" command not found
 
-The `parcel` command must be on your system PATH. If you installed it as a global .NET tool, check if `$HOME/.dotnet/tools` (macOS/Linux) or `%USERPROFILE%\.dotnet\tools` (Windows) is in your PATH. If not, add the directory to your PATH.
+The `parcel` command must be on the system `PATH`. For a global .NET tool installation, check for `$HOME/.dotnet/tools` on macOS and Linux. On Windows, check for `%USERPROFILE%\.dotnet\tools`. If the applicable directory is not in `PATH`, add it.
 
 For more information, see [Troubleshooting .NET tool usage issues](https://learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#executable-file-not-found).
 
@@ -264,7 +264,7 @@ If the MCP server starts but reports a missing or invalid license key:
 
 ### Updating Parcel
 
-If tools behave unexpectedly, ensure you are running the latest version:
+If the tools do not work as expected, make sure that you use the latest version:
 
 ```bash
 dotnet tool update --global AvaloniaUI.Parcel

--- a/tools/parcel/mcp.md
+++ b/tools/parcel/mcp.md
@@ -23,7 +23,7 @@ Before setting up the MCP server, ensure you have:
 
 ### Setting your license key
 
-The MCP server reads your license from the `PARCEL_LICENSE_KEY` environment variable. You can find your license key in the [Avalonia Customer Portal](https://portal.avaloniaui.net/). MCP is a paid feature and is not included with the Community edition.
+The MCP server reads your license from the `AVALONIA_TOOLS_LICENSE_KEY` environment variable. You can find your license key in the [Avalonia Customer Portal](https://portal.avaloniaui.net/). MCP is a paid feature and is not included with the Community edition.
 
 Set the key in your shell profile so it persists across sessions:
 
@@ -33,7 +33,7 @@ Set the key in your shell profile so it persists across sessions:
 Add this line to your shell profile (`~/.zshrc`, `~/.bashrc`, or equivalent):
 
 ```bash
-export PARCEL_LICENSE_KEY="your-license-key"
+export AVALONIA_TOOLS_LICENSE_KEY="your-license-key"
 ```
 
 Then reload the profile or open a new terminal:
@@ -48,7 +48,7 @@ source ~/.zshrc
 Set a persistent environment variable for your user account:
 
 ```powershell
-[System.Environment]::SetEnvironmentVariable('PARCEL_LICENSE_KEY', 'your-license-key', 'User')
+[System.Environment]::SetEnvironmentVariable('AVALONIA_TOOLS_LICENSE_KEY', 'your-license-key', 'User')
 ```
 
 Restart any open terminals and editors to pick up the change.
@@ -57,7 +57,7 @@ Restart any open terminals and editors to pick up the change.
 <TabItem value="windows-cmd" label="Windows (Command Prompt)">
 
 ```cmd
-setx PARCEL_LICENSE_KEY "your-license-key"
+setx AVALONIA_TOOLS_LICENSE_KEY "your-license-key"
 ```
 
 Restart any open terminals and editors to pick up the change.
@@ -71,7 +71,7 @@ If you launch your editor from a desktop shortcut or application menu (rather th
 ```json
 {
     "env": {
-        "PARCEL_LICENSE_KEY": "your-license-key"
+        "AVALONIA_TOOLS_LICENSE_KEY": "your-license-key"
     }
 }
 ```
@@ -212,7 +212,7 @@ claude mcp list
             "command": "parcel",
             "args": ["mcp"],
             "env": {
-                "PARCEL_LICENSE_KEY": "your-license-key"
+                "AVALONIA_TOOLS_LICENSE_KEY": "your-license-key"
             }
         }
     }
@@ -253,7 +253,7 @@ For more information, see [Troubleshooting .NET tool usage issues](https://learn
 
 If the MCP server starts but reports a missing or invalid license key:
 
-- **Confirm the variable is set** by running `echo $PARCEL_LICENSE_KEY` (macOS/Linux) or `echo %PARCEL_LICENSE_KEY%` (Windows) in the same terminal where you launch your editor.
+- **Confirm the variable is set** by running `echo $AVALONIA_TOOLS_LICENSE_KEY` (macOS/Linux) or `echo %AVALONIA_TOOLS_LICENSE_KEY%` (Windows) in the same terminal where you launch your editor.
 - **If your editor is launched from a GUI shortcut**, it may not inherit shell environment variables. Add an `env` block to your MCP configuration as shown in the [license key setup](#setting-your-license-key) section above.
 
 ### MCP server does not appear in the editor
@@ -267,7 +267,7 @@ If the MCP server starts but reports a missing or invalid license key:
 If tools behave unexpectedly, ensure you are running the latest version:
 
 ```bash
-dotnet tool update -g parcel
+dotnet tool update --global AvaloniaUI.Parcel
 ```
 
 ## Capabilities
@@ -282,14 +282,14 @@ Once the MCP server is configured, your AI assistant can help with:
 
 ### Code signing setup
 
-- **Windows Azure Trusted Signing** - Configure certificates and signing parameters
+- **Windows Azure Artifact Signing** - Configure certificates and signing parameters
 - **macOS Code Signing** - Set up P12 certificates and provisioning profiles
 - **macOS Notarization** - Configure Apple ID and app-specific passwords
 
 ### Building and packaging
 
 - **Build and package** applications for multiple platforms (Windows, macOS, Linux)
-- **Generate installers** in various formats (DMG, DEB, NSIS, ZIP, etc.)
+- **Generate packages** in NSIS, MSIX, DMG, PKG, DEB, RPM, and ZIP formats
 - **Cross-platform packaging** with runtime-specific outputs
 
 ## Usage examples
@@ -322,4 +322,5 @@ Describe what you want to accomplish in natural language. The AI assistant calls
 
 - [AI Tools overview](/tools/ai-tools/)
 - [Parcel setup](/tools/parcel/setup)
+- [Parcel configuration reference](/tools/parcel/configuration-reference)
 - [DevTools MCP](/tools/developer-tools/mcp)

--- a/tools/parcel/mcp.md
+++ b/tools/parcel/mcp.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 ## What is Parcel MCP?
 
-The Parcel MCP server lets AI assistants use Parcel packaging tools. Your assistant can create packaging configurations from .NET projects. It can also configure code signing and notarization and build packages for Windows, macOS, and Linux.
+The Parcel MCP server lets AI assistants use Parcel packaging tools. Your assistant can create packaging configurations from .NET projects. It can also configure code signing and notarization, and build packages for Windows, macOS, and Linux.
 
 For a general introduction to MCP, see [AI Tools](/tools/ai-tools/).
 
@@ -23,7 +23,7 @@ Before you configure the MCP server, make sure that you have these items:
 
 ### Setting your license key
 
-The MCP server reads the license from the `AVALONIA_TOOLS_LICENSE_KEY` environment variable. Get your license key from the [Avalonia Customer Portal](https://portal.avaloniaui.net/). MCP is a paid feature and is not included with the Community edition.
+The MCP server reads the license from the `AVALONIA_TOOLS_LICENSE_KEY` environment variable. Get your license key from the [Avalonia Portal](https://portal.avaloniaui.net/). Parcel MCP is a paid feature and is not included with the Community edition.
 
 Set the key in your shell profile so it persists across sessions:
 

--- a/tools/parcel/packaging-for-linux.md
+++ b/tools/parcel/packaging-for-linux.md
@@ -23,22 +23,27 @@ Parcel automatically generates a `.desktop` file for proper application launcher
 
 ## Dependencies
 
-Parcel includes following dependencies in DEB/RPM packages to ensure compatibility across Linux distributions:
+Parcel declares the following runtime dependencies in package metadata. Add any application- or distribution-specific libraries with the additional dependency settings.
 
-### Runtime Dependencies
-- `libc6` - GNU C Library
-- `libgcc1` or `libgcc-s1` - GCC runtime library
-- `libgssapi-krb5-2` - Kerberos authentication
-- `libstdc++6` - GNU Standard C++ Library
-- `zlib1g` - Compression library
-- `libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3` - SSL/TLS library (multiple versions supported)
-- `libicu` - Unicode and internationalization support (multiple versions supported)
+### DEB dependencies
 
-### Avalonia-Specific Dependencies
-- `libx11-6` - X11 client library
-- `libice6` - Inter-Client Exchange library
-- `libsm6` - X11 Session Management library
-- `libfontconfig1` - Font configuration library
+- `libc6`
+- `libgcc1`
+- `libgssapi-krb5-2`
+- `libstdc++6`
+- `zlib1g`
+- One of `libssl1.0.0`, `libssl1.0.2`, `libssl1.1`, or `libssl3`
+- `libicu` or a versioned `libicu` package
+
+### RPM dependencies
+
+- `glibc`
+- `libgcc`
+- `krb5-libs`
+- `libstdc++`
+- `zlib`
+- `openssl-libs`
+- `libicu`
 
 ## Bundle Configuration
 

--- a/tools/parcel/packaging-for-linux.md
+++ b/tools/parcel/packaging-for-linux.md
@@ -22,7 +22,7 @@ Parcel creates packages for different Linux package managers and distribution me
 
 DEB and RPM packages include a `.desktop` entry. They can also register icons, file associations, URL schemes, package dependencies, and an optional `/usr/bin` symlink.
 
-For the complete setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#linux-settings).
+For a complete list of setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#linux-settings).
 
 ## Dependencies
 
@@ -60,7 +60,7 @@ Display name in application launchers and desktop menus. Parcel adds this name t
 
 **Package Name**:
 
-The package identifier used in package metadata and output filenames. Parcel normalizes it to lower case for Linux packages.
+The package identifier used in package metadata and output filenames. Parcel normalizes this identifier to lowercase for Linux packages.
 
 **Install Directory Name**:
 

--- a/tools/parcel/packaging-for-linux.md
+++ b/tools/parcel/packaging-for-linux.md
@@ -10,7 +10,7 @@ tags:
   - avalonia enterprise
 ---
 
-Parcel packages Linux applications into multiple distribution formats optimized for different Linux package managers and use cases.
+Parcel creates packages for different Linux package managers and distribution methods.
 
 ## Supported Package Formats
 
@@ -18,14 +18,15 @@ Parcel packages Linux applications into multiple distribution formats optimized 
 |---|---|---|
 | DEB package (`.deb`) | `deb` | Debian, Ubuntu, and other Debian-based distributions |
 | RPM package (`.rpm`) | `rpm` | Fedora, RHEL, and other RPM-based distributions |
-| ZIP archive (`.zip`) | `zip` | Portable distribution without package-manager integration |
+| ZIP archive (`.zip`) | `zip` | Portable distribution without package manager integration |
 
-DEB and RPM packages include a `.desktop` entry and can register icons, file associations, URL schemes, package dependencies, and an optional `/usr/bin` symlink.
+DEB and RPM packages include a `.desktop` entry. They can also register icons, file associations, URL schemes, package dependencies, and an optional `/usr/bin` symlink.
 
+For the complete setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#linux-settings).
 
 ## Dependencies
 
-Parcel declares the following runtime dependencies in package metadata. Add any application- or distribution-specific libraries with the additional dependency settings.
+Parcel declares the following runtime dependencies in the package metadata. Use the additional dependency settings to add libraries for your application or Linux distribution.
 
 ### DEB dependencies
 
@@ -49,13 +50,13 @@ Parcel declares the following runtime dependencies in package metadata. Add any 
 
 ## Bundle Configuration
 
-Parcel provides configuration options to customize your Linux application packages for proper desktop integration and branding.
+Use the Linux settings to configure desktop integration and branding.
 
 ### Common Properties
 
 **Application Name**:
 
-Display name shown in application launchers and desktop menus. This is used in the `.desktop` entry file.
+Display name in application launchers and desktop menus. Parcel adds this name to the `.desktop` entry.
 
 **Package Name**:
 
@@ -63,7 +64,7 @@ The package identifier used in package metadata and output filenames. Parcel nor
 
 **Install Directory Name**:
 
-Name of the application directory under `/usr/share`. It defaults to `app-{package-name}` and must contain only lowercase letters, numbers, dashes, underscores, or dots.
+Name of the application directory under `/usr/share`. The default is `app-{package-name}`. Use only lowercase letters, numbers, dashes, underscores, or periods. The name must start and end with a letter or number.
 
 ### DEB/RPM Specific Properties
 
@@ -71,39 +72,40 @@ Additional configuration properties for Debian and RPM packages.
 
 **Application Icon**:
 
-Optional Linux-specific icon that overrides the shared Application Icon. Parcel automatically:
+Optional Linux icon that overrides **Application Icon**. Parcel automatically does the following tasks:
+
 - Generates hicolor icon theme entries at appropriate resolutions
 - Links the icon in the `.desktop` file
 
 **Supported formats**: PNG, SVG
 
-**Company/Maintainer**:
+**Maintainer**:
 
-The package maintainer or company name. This appears in package metadata and is displayed by package managers.
+Package maintainer or company name. Parcel adds this value to the package metadata.
 
 :::note
-If not specified, defaults to the shared Company setting and then to the Package Name.
+If you do not set this value, Parcel uses **Company**. If **Company** is empty, Parcel uses **Package Name**.
 :::
 
 **Desktop Category**:
 
-Application category for desktop environment menus and launchers. Determines where the application appears in the application menu hierarchy. Parcel follows the [freedesktop.org category registry](https://specifications.freedesktop.org/menu-spec/latest/category-registry.html).
+Category for desktop menus and launchers. This value controls where the application appears in the menu. Parcel uses the [freedesktop.org category registry](https://specifications.freedesktop.org/menu-spec/latest/category-registry.html).
 
 **Copyright**:
 
-Path to a copyright or license file included in DEB and RPM package metadata.
+Path to a copyright or license file. Parcel includes this file in the DEB and RPM package metadata.
 
-**Create `/usr/bin` Symlink**:
+**Create `/usr/bin/` symlink**:
 
-Creates a symlink to the application executable so it can be started from a terminal. Enabled by default.
+Creates a symlink to the application executable. The symlink lets users start the application from a terminal. This setting is enabled by default.
 
-**Additional Dependencies**:
+**Additional DEB Dependencies** and **Additional RPM Dependencies**:
 
-Add dependencies beyond Parcel's runtime defaults separately for DEB and RPM. DEB entries accept alternative package names separated with `|`; RPM entries accept package names or capabilities.
+Add dependencies that are not in the Parcel defaults. Configure DEB and RPM dependencies separately. For DEB, separate alternative package names with `|`. For RPM, enter package names or capabilities.
 
 ### Desktop integration
 
-File associations and URL schemes are configured once under Basics. Parcel adds matching MIME metadata and launch information to DEB and RPM packages. See [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations) and [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation) for handling activations in an Avalonia application.
+Configure file associations and URL schemes under **Basics**. Parcel adds the related MIME metadata and launch information to DEB and RPM packages. To handle activation in an Avalonia application, see [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations) and [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
 
 ## Installation & Removal
 
@@ -147,4 +149,5 @@ cd my-app
 ## See also
 
 - [Parcel setup](/tools/parcel/setup)
+- [Parcel configuration reference](/tools/parcel/configuration-reference)
 - [Parcel command line reference](/tools/parcel/command-line-reference)

--- a/tools/parcel/packaging-for-linux.md
+++ b/tools/parcel/packaging-for-linux.md
@@ -1,7 +1,7 @@
 ---
 id: packaging-for-linux
 title: Packaging apps for Linux
-description: Package Avalonia applications for Linux using Parcel, with support for DEB, RPM, ZIP, and AppImage formats, including dependency management and desktop integration.
+description: Package Avalonia applications for Linux using Parcel, with support for DEB, RPM, and ZIP formats, including dependency management and desktop integration.
 sidebar_label: Linux
 doc-type: reference
 tags:
@@ -14,12 +14,14 @@ Parcel packages Linux applications into multiple distribution formats optimized 
 
 ## Supported Package Formats
 
-- **DEB**: Debian/Ubuntu packages (`.deb`) - installable via `apt`
-- **RPM**: Red Hat/Fedora packages (`.rpm`) - installable via `dnf`/`yum`
-- **ZIP**: Compressed archive for manual installation
-- **AppImage**: Portable single-file application *(not yet available)*
+| Format | CLI code | Best suited for |
+|---|---|---|
+| DEB package (`.deb`) | `deb` | Debian, Ubuntu, and other Debian-based distributions |
+| RPM package (`.rpm`) | `rpm` | Fedora, RHEL, and other RPM-based distributions |
+| ZIP archive (`.zip`) | `zip` | Portable distribution without package-manager integration |
 
-Parcel automatically generates a `.desktop` file for proper application launcher integration.
+DEB and RPM packages include a `.desktop` entry and can register icons, file associations, URL schemes, package dependencies, and an optional `/usr/bin` symlink.
+
 
 ## Dependencies
 
@@ -57,7 +59,11 @@ Display name shown in application launchers and desktop menus. This is used in t
 
 **Package Name**:
 
-The package identifier used as the output filename, and `/usr/share/` app entry. Must not include spaces.
+The package identifier used in package metadata and output filenames. Parcel normalizes it to lower case for Linux packages.
+
+**Install Directory Name**:
+
+Name of the application directory under `/usr/share`. It defaults to `app-{package-name}` and must contain only lowercase letters, numbers, dashes, underscores, or dots.
 
 ### DEB/RPM Specific Properties
 
@@ -65,7 +71,7 @@ Additional configuration properties for Debian and RPM packages.
 
 **Application Icon**:
 
-Path to the application icon file. Parcel automatically:
+Optional Linux-specific icon that overrides the shared Application Icon. Parcel automatically:
 - Generates hicolor icon theme entries at appropriate resolutions
 - Links the icon in the `.desktop` file
 
@@ -76,12 +82,28 @@ Path to the application icon file. Parcel automatically:
 The package maintainer or company name. This appears in package metadata and is displayed by package managers.
 
 :::note
-If not specified, defaults to the Package Name value.
+If not specified, defaults to the shared Company setting and then to the Package Name.
 :::
 
 **Desktop Category**:
 
-Application category for desktop environment menus and launchers. Determines where the application appears in the application menu hierarchy.
+Application category for desktop environment menus and launchers. Determines where the application appears in the application menu hierarchy. Parcel follows the [freedesktop.org category registry](https://specifications.freedesktop.org/menu-spec/latest/category-registry.html).
+
+**Copyright**:
+
+Path to a copyright or license file included in DEB and RPM package metadata.
+
+**Create `/usr/bin` Symlink**:
+
+Creates a symlink to the application executable so it can be started from a terminal. Enabled by default.
+
+**Additional Dependencies**:
+
+Add dependencies beyond Parcel's runtime defaults separately for DEB and RPM. DEB entries accept alternative package names separated with `|`; RPM entries accept package names or capabilities.
+
+### Desktop integration
+
+File associations and URL schemes are configured once under Basics. Parcel adds matching MIME metadata and launch information to DEB and RPM packages. See [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations) and [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation) for handling activations in an Avalonia application.
 
 ## Installation & Removal
 

--- a/tools/parcel/packaging-for-macos.md
+++ b/tools/parcel/packaging-for-macos.md
@@ -245,34 +245,21 @@ The resulting `certificate.p12` and password can be used with Parcel on any plat
 
 </Tabs>
 
-## Troubleshooting
-
-See the [macOS troubleshooting page](/troubleshooting/platform-specific-issues/macos#code-signing).
-
 ## App Store Connect
 
 Submit a signed PKG to distribute an application through the Mac App Store. Do not submit a DMG or ZIP file. These formats are for direct distribution.
 
 ### Recommended configuration
 
-1. Create the macOS application record in App Store Connect. Register an explicit App ID. Its bundle ID must exactly match **Bundle Identifier** in Parcel. App Store Connect uses the bundle ID and version to associate an upload with the application record. Use a unique build string for each upload.
-2. Enable **Create Bundle** and select `pkg` as an output format.
-3. Sign the application with an **Apple Distribution** certificate. You can also use the legacy **3rd Party Mac Developer Application** identity from a Mac App Distribution certificate. Sign the PKG separately with a **Mac Installer Distribution** certificate. Parcel identifies this certificate as **3rd Party Mac Developer Installer**. Do not use Developer ID certificates for an App Store submission.
-4. Create and download a **Mac App Store Connect** provisioning profile for the same explicit App ID and application-signing certificate.
-5. Copy the provisioning profile to the directory that contains the Parcel project file. Rename the profile to match the configured .NET project. For example, use `MyApp.provisionprofile` when **.NET Project Path** points to `MyApp.csproj`. Parcel requires this exact file name. It copies the profile to `Contents/embedded.provisionprofile` in the application bundle.
-6. Enable **App Sandbox**. Configure only the permissions that the application needs. Before submission, test file access, network access, child processes, and bundled helper tools in the sandbox.
-7. Use the same Apple Developer team for **Team ID**, the provisioning profile, **Bundle Identifier**, and the selected certificate. Parcel checks these values during signing. It reports a mismatch before upload.
-8. Upload the PKG with Apple's Transporter application, Xcode tools, or another method that App Store Connect supports. Wait for processing to finish. Resolve all delivery warnings. Select the processed build for the macOS version, and submit it for review.
+1. Create the macOS application record in App Store Connect. Register an explicit App ID. Its bundle ID must exactly match **Bundle Identifier** in Parcel. App Store Connect uses the bundle ID and version to associate an upload with the application record.
+2. Configure signing with an **Apple Distribution** certificate. And configure PKG signing separately with a **Mac Installer Distribution** certificate. Do not use Developer ID certificates for an App Store submission, it will be rejected by Apple.
+3. Create and download a **Mac App Store Connect** provisioning profile for the same explicit App ID and application-signing certificate.
+4. Copy the provisioning profile to the directory that contains the Parcel project file. Rename the profile to match the configured .NET project. For example, use `MyApp.provisionprofile` when **.NET Project Path** points to `MyApp.csproj`. Parcel requires this exact file name.
+5. Make sure that **Create Bundle** and **Enable Sandbox** are enabled in MacOS settings. Notarization must be disabled for App Store Connect - it's only useful for sideloading.
+6. Optinally, configure custom `Entitlements.plist` file in the project directory, if the app requires custom permissions. Before submission, test file access, network access, child processes, and bundled helper tools in the sandbox.
+7. Upload the PKG with Apple's Transporter application, Xcode tools, or another method that App Store Connect supports. Wait for processing to finish. Resolve all delivery warnings. Select the processed build for the macOS version, and submit it for review.
 
 See Apple's documentation for [creating a Mac App Store Connect provisioning profile](https://developer.apple.com/help/account/provisioning-profiles/create-an-app-store-provisioning-profile), [certificate purposes](https://developer.apple.com/help/account/certificates/certificates-overview), and [uploading builds](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/).
-
-:::warning[Entitlements take precedence]
-If the project contains an `Entitlements.plist` file, Parcel preserves its values. A `com.apple.security.app-sandbox` value of `false` overrides **Enable App Sandbox** and causes an App Store rejection. The provisioning profile must authorize the signing certificate and all restricted capabilities that the application uses. Create a new profile after you change certificates or App ID capabilities.
-:::
-
-:::warning[Confirm that the profile was embedded]
-When Parcel finds the expected file, it logs that it is copying the provisioning profile. Check for this message in the packaging output. Parcel does not find or embed a profile that has a different name.
-:::
 
 :::note[Do not notarize App Store builds with Parcel]
 Parcel notarizes software that uses a Developer ID identity for distribution outside the Mac App Store. Apple validates App Store packages during upload and submission. Disable Parcel notarization for an App Store build.
@@ -362,6 +349,10 @@ Code-sign applications with a Developer ID certificate when available, even with
 ### Troubleshooting notarization issues
 
 See the [macOS troubleshooting page](/troubleshooting/platform-specific-issues/macos#notarization).
+
+## Troubleshooting
+
+See the [macOS troubleshooting page](/troubleshooting/platform-specific-issues/macos#code-signing).
 
 ## See also
 

--- a/tools/parcel/packaging-for-macos.md
+++ b/tools/parcel/packaging-for-macos.md
@@ -14,13 +14,15 @@ import TabItem from '@theme/TabItem';
 
 ## Packaging
 
-Parcel creates macOS application bundles (`.app`) and packages on Windows, macOS, and Linux.
+Parcel creates macOS application bundles (`.app`) and packages. You can run Parcel on Windows, macOS, or Linux.
 
 | Format | CLI code | Best suited for |
 |---|---|---|
 | DMG image (`.dmg`) | `dmg` | Direct distribution with a branded drag-and-drop experience |
 | PKG installer (`.pkg`) | `pkg` | Managed installation, direct distribution, and Mac App Store submission |
 | ZIP archive (`.zip`) | `zip` | Direct distribution of an app bundle without an installer |
+
+For the complete setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#macos-settings).
 
 ### Bundle Configuration
 
@@ -54,9 +56,9 @@ A unique identifier for your Apple Developer account. Using during signing and n
 
 The application category for macOS and App Store classification. This maps to Apple's `public.app-category.*` identifiers.
 
-**App Icon**:
+**Application Icon**:
 
-An optional macOS-specific icon in **ICNS** or **SVG** format. It overrides the shared Application Icon. ICNS files should include multiple resolutions from 16x16 to 1024x1024 pixels. Parcel generates the bundle icon structure from the source file.
+An optional macOS icon in **ICNS** or **SVG** format. This icon overrides **Application Icon**. An ICNS file should contain resolutions from 16 x 16 through 1024 x 1024 pixels. Parcel creates the bundle icon structure from the source file.
 
 **Permissions**:
 
@@ -66,19 +68,19 @@ System permissions with custom usage descriptions. Each permission requires a us
 Usage descriptions are mandatory; otherwise, the OS may deny access to system resources.
 :::
 
-**File Type Associations**:
+**File Associations**:
 
 Associate the application with specific file types by specifying file extensions (e.g., `.myfile`) and optionally adding MIME types.
 
 To handle these files in Avalonia applications, see [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
 
-**URL Scheme Handlers**:
+**URL Schemes**:
 
 Register custom URL schemes for deep linking by defining custom schemes (e.g., `myapp://`, `myprotocol://`). This enables other applications to launch the app with specific parameters.
 
 To handle URL schemes in Avalonia applications, see [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
 
-Associations are configured once under Basics and written to the app bundle's `Info.plist`. They are ignored when **Create Bundle** is disabled. See [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations).
+Configure associations under **Basics**. Parcel writes them to the application bundle's `Info.plist` file. Parcel ignores associations when **Create Bundle** is disabled. See [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations).
 
 #### Custom Info.plist Configuration
 
@@ -98,11 +100,11 @@ Parcel creates DMG installers with a drag-and-drop interface, custom backgrounds
 [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) is required for DMG creation on Windows. ZIP packages can be created without WSL2.
 :::
 
-**DMG Background**:
+**DMG Background Image**:
 
 The background image for the DMG installer in TIFF format.
 
-Parcel includes a visual DMG layout editor. The default layout uses a **660x422** pixel window with the following values:
+Parcel includes a visual DMG layout editor. The default layout uses a **660 x 422** pixel window with these values:
 
 - **App Bundle icon**: positioned at coordinates (173, 231)
 - **Applications folder**: positioned at coordinates (485, 231)
@@ -111,25 +113,21 @@ Parcel includes a visual DMG layout editor. The default layout uses a **660x422*
 
 Icons are positioned from the top left corner to the icon center.
 
-Use the editor to change the window position and size, icon and label sizes, grid, background color, and the App Bundle and Applications folder positions. Design the background image around the selected layout and drag-and-drop workflow.
+Use the editor to change the window position, window size, icon size, label size, grid, and background color. You can also change the positions of the application bundle and Applications folder. Design the background image for the selected layout.
 
 :::note
-The optional **DMG License File** is embedded at the root of the image. **Sign DMG** controls whether Parcel signs the completed image with the application-signing credentials.
+Parcel puts the optional **DMG License File** at the root of the image. Enable **Sign DMG** to sign the completed image with the application-signing credentials.
 :::
 
 ### ZIP Creation
 
 Parcel maintains executable permissions during ZIP creation. The bundle structure remains intact when extracted on macOS, and applications remain executable without additional steps.
 
-### PKG installers
+### PKG installers <MinVersion version="1.1" isNewVersion="true" />
 
-:::note[New in Parcel 1.1]
-Parcel 1.1 adds PKG packaging for macOS applications.
-:::
+PKG packages use the native macOS Installer. You can create them on every host that Parcel supports. PKG packages require **Create Bundle** and install the application in `/Applications` by default.
 
-PKG packages use the native macOS Installer experience and can be created on every host supported by Parcel. They require **Create Bundle** and install the app into `/Applications` by default.
-
-An installer package uses a different certificate from the application inside it. For direct distribution, sign the app with a **Developer ID Application** certificate and the PKG with a **Developer ID Installer** certificate, then notarize the package. For Mac App Store distribution, use **Apple Distribution** for the app and **3rd Party Mac Developer Installer** for the PKG, enable App Sandbox, and submit the package to App Store Connect instead of notarizing it. See Apple's [Mac software packaging guidance](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution) and [Developer ID overview](https://developer.apple.com/support/developer-id/).
+Use different certificates for the application and its installer package. For direct distribution, sign the application with a **Developer ID Application** certificate. Sign the PKG with a **Developer ID Installer** certificate. Then notarize the package. For Mac App Store distribution, see [App Store Connect](#app-store-connect). See also Apple's [Mac software packaging guidance](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution) and [Developer ID overview](https://developer.apple.com/support/developer-id/).
 
 ### Troubleshooting
 
@@ -141,7 +139,7 @@ Parcel signs macOS bundles using Apple Developer certificates. Cross-platform si
 
 ### Prerequisites
 
-Before signing macOS applications, ensure you have:
+Before you sign a macOS application, make sure that you have these items:
 
 - **Apple Developer Account**: Active [Apple Developer Program](https://developer.apple.com/programs/) membership ($99/year)
 - **Xcode Command Line Tools** (macOS only): Available on [Apple Developer Resources](https://developer.apple.com/xcode/resources/)
@@ -163,9 +161,13 @@ Apple doesn't provide P12 certificates directly, but they can be exported from t
 
 Parcel uses [rcodesign](https://github.com/indygreg/apple-platform-rs/tree/main/apple-codesign) to sign binaries and bundles on Windows and Linux machines.
 
+#### PEM Certificate (Cross-Platform)
+
+Uses a PEM certificate for cross-platform signing. For a PKG package, configure separate PEM certificate fields for the application and installer.
+
 ### Installer certificates for PKG
 
-PKG signing uses the **Installer Signing** group. Select a Keychain identity, P12 certificate, or PEM certificate that is authorized to sign installer packages. Application certificates cannot sign PKG installers, and installer certificates cannot sign the app bundle.
+Configure PKG signing in the **Installer Signing** group. Select a Keychain identity, P12 certificate, or PEM certificate that can sign installer packages. An application certificate cannot sign a PKG installer. An installer certificate cannot sign the application bundle.
 
 ### Create Developer Certificate
 
@@ -247,17 +249,46 @@ The resulting `certificate.p12` and password can be used with Parcel on any plat
 
 See the [macOS troubleshooting page](/troubleshooting/platform-specific-issues/macos#code-signing).
 
+## App Store Connect
+
+Submit a signed PKG to distribute an application through the Mac App Store. Do not submit a DMG or ZIP file. These formats are for direct distribution.
+
+### Recommended configuration
+
+1. Create the macOS application record in App Store Connect. Register an explicit App ID. Its bundle ID must exactly match **Bundle Identifier** in Parcel. App Store Connect uses the bundle ID and version to associate an upload with the application record. Use a unique build string for each upload.
+2. Enable **Create Bundle** and select `pkg` as an output format.
+3. Sign the application with an **Apple Distribution** certificate. You can also use the legacy **3rd Party Mac Developer Application** identity from a Mac App Distribution certificate. Sign the PKG separately with a **Mac Installer Distribution** certificate. Parcel identifies this certificate as **3rd Party Mac Developer Installer**. Do not use Developer ID certificates for an App Store submission.
+4. Create and download a **Mac App Store Connect** provisioning profile for the same explicit App ID and application-signing certificate.
+5. Copy the provisioning profile to the directory that contains the Parcel project file. Rename the profile to match the configured .NET project. For example, use `MyApp.provisionprofile` when **.NET Project Path** points to `MyApp.csproj`. Parcel requires this exact file name. It copies the profile to `Contents/embedded.provisionprofile` in the application bundle.
+6. Enable **App Sandbox**. Configure only the permissions that the application needs. Before submission, test file access, network access, child processes, and bundled helper tools in the sandbox.
+7. Use the same Apple Developer team for **Team ID**, the provisioning profile, **Bundle Identifier**, and the selected certificate. Parcel checks these values during signing. It reports a mismatch before upload.
+8. Upload the PKG with Apple's Transporter application, Xcode tools, or another method that App Store Connect supports. Wait for processing to finish. Resolve all delivery warnings. Select the processed build for the macOS version, and submit it for review.
+
+See Apple's documentation for [creating a Mac App Store Connect provisioning profile](https://developer.apple.com/help/account/provisioning-profiles/create-an-app-store-provisioning-profile), [certificate purposes](https://developer.apple.com/help/account/certificates/certificates-overview), and [uploading builds](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/).
+
+:::warning[Entitlements take precedence]
+If the project contains an `Entitlements.plist` file, Parcel preserves its values. A `com.apple.security.app-sandbox` value of `false` overrides **Enable App Sandbox** and causes an App Store rejection. The provisioning profile must authorize the signing certificate and all restricted capabilities that the application uses. Create a new profile after you change certificates or App ID capabilities.
+:::
+
+:::warning[Confirm that the profile was embedded]
+When Parcel finds the expected file, it logs that it is copying the provisioning profile. Check for this message in the packaging output. Parcel does not find or embed a profile that has a different name.
+:::
+
+:::note[Do not notarize App Store builds with Parcel]
+Parcel notarizes software that uses a Developer ID identity for distribution outside the Mac App Store. Apple validates App Store packages during upload and submission. Disable Parcel notarization for an App Store build.
+:::
+
 ## Notarization
 
 Apple notarization verifies that applications have been checked by Apple for malicious software. Notarization is required for macOS 10.15 (Catalina) and later when distributing applications outside the Mac App Store.
 
 The process uploads an application to Apple's servers for scanning and associates the bundle hash with the developer account.
 
-Mac App Store packages are validated during submission and are not notarized separately. For direct distribution, Parcel can submit and staple DMG and PKG artifacts signed with Developer ID certificates. See Apple's [notarization documentation](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution).
+Apple validates Mac App Store packages during submission. Do not notarize them separately. For direct distribution, Parcel can submit and staple DMG and PKG files that use Developer ID certificates. See Apple's [notarization documentation](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution).
 
 ### Prerequisites
 
-Before notarizing applications, ensure you have:
+Before you notarize an application, make sure that you have these items:
 
 - **Apple Developer Account**: Paid Apple Developer Program membership ($99/year)
 - **Valid Developer ID Certificate**: For code signing applications distributed outside the Mac App Store
@@ -319,7 +350,7 @@ For testing, development, or personal use without an Apple Developer Account, no
 When macOS blocks a non-notarized app, users can bypass the warning:
 
 1. Go to **System Preferences** → **Security & Privacy** → **General** tab
-2. Try to run the app - it will be blocked
+2. Try to run the application. macOS blocks it.
 3. Within a few minutes, a message appears in Security & Privacy about the blocked app
 4. Click **"Open Anyway"** next to the blocked app message
 5. Confirm by clicking **"Open"** in the dialog
@@ -335,4 +366,5 @@ See the [macOS troubleshooting page](/troubleshooting/platform-specific-issues/m
 ## See also
 
 - [Parcel setup](/tools/parcel/setup)
+- [Parcel configuration reference](/tools/parcel/configuration-reference)
 - [Parcel command line reference](/tools/parcel/command-line-reference)

--- a/tools/parcel/packaging-for-macos.md
+++ b/tools/parcel/packaging-for-macos.md
@@ -14,7 +14,13 @@ import TabItem from '@theme/TabItem';
 
 ## Packaging
 
-Parcel creates macOS application bundles (.app) that can be distributed via DMG images or ZIP archives. The tool handles bundle structure, Info.plist generation, and file permissions. Parcel can create macOS bundles on Windows and Linux platforms.
+Parcel creates macOS application bundles (`.app`) and packages on Windows, macOS, and Linux.
+
+| Format | CLI code | Best suited for |
+|---|---|---|
+| DMG image (`.dmg`) | `dmg` | Direct distribution with a branded drag-and-drop experience |
+| PKG installer (`.pkg`) | `pkg` | Managed installation, direct distribution, and Mac App Store submission |
+| ZIP archive (`.zip`) | `zip` | Direct distribution of an app bundle without an installer |
 
 ### Bundle Configuration
 
@@ -50,7 +56,7 @@ The application category for macOS and App Store classification. This maps to Ap
 
 **App Icon**:
 
-The application icon in **ICNS** or **SVG** format. ICNS files should include multiple resolutions from 16x16 to 1024x1024 pixels. Parcel generates the bundle icon structure from the source file.
+An optional macOS-specific icon in **ICNS** or **SVG** format. It overrides the shared Application Icon. ICNS files should include multiple resolutions from 16x16 to 1024x1024 pixels. Parcel generates the bundle icon structure from the source file.
 
 **Permissions**:
 
@@ -60,19 +66,19 @@ System permissions with custom usage descriptions. Each permission requires a us
 Usage descriptions are mandatory; otherwise, the OS may deny access to system resources.
 :::
 
-<!--- NOT YET AVAILABLE IN STABLE PARCEL
 **File Type Associations**:
 
 Associate the application with specific file types by specifying file extensions (e.g., `.myfile`) and optionally adding MIME types.
 
-To handle these files in Avalonia applications, see [Activatable Lifetime](https://docs.avaloniaui.net/docs/concepts/services/activatable-lifetime#handling-uri-activation) documentation.
+To handle these files in Avalonia applications, see [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
 
 **URL Scheme Handlers**:
 
 Register custom URL schemes for deep linking by defining custom schemes (e.g., `myapp://`, `myprotocol://`). This enables other applications to launch the app with specific parameters.
 
-To handle URL schemes in Avalonia applications, see [Activatable Lifetime](https://docs.avaloniaui.net/docs/concepts/services/activatable-lifetime#handling-uri-activation) documentation.
---->
+To handle URL schemes in Avalonia applications, see [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
+
+Associations are configured once under Basics and written to the app bundle's `Info.plist`. They are ignored when **Create Bundle** is disabled. See [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations).
 
 #### Custom Info.plist Configuration
 
@@ -96,23 +102,34 @@ Parcel creates DMG installers with a drag-and-drop interface, custom backgrounds
 
 The background image for the DMG installer in TIFF format.
 
-Parcel uses a fixed DMG window size of **660x422** pixels with the following layout:
+Parcel includes a visual DMG layout editor. The default layout uses a **660x422** pixel window with the following values:
 
-- **App Bundle icon**: positioned at coordinates (180, 170) with 160px icon size
-- **Applications folder**: positioned at coordinates (480, 170) with 160px icon size  
-- **Text size**: 12px for icon labels
+- **App Bundle icon**: positioned at coordinates (173, 231)
+- **Applications folder**: positioned at coordinates (485, 231)
+- **Icon size**: 128px
+- **Text size**: 12px
 
 Icons are positioned from the top left corner to the icon center.
 
-Design background images to accommodate these fixed positions and the drag-and-drop workflow.
+Use the editor to change the window position and size, icon and label sizes, grid, background color, and the App Bundle and Applications folder positions. Design the background image around the selected layout and drag-and-drop workflow.
 
 :::note
-DMG customization is currently limited to background images. A more flexible editor is planned for a future release.
+The optional **DMG License File** is embedded at the root of the image. **Sign DMG** controls whether Parcel signs the completed image with the application-signing credentials.
 :::
 
 ### ZIP Creation
 
 Parcel maintains executable permissions during ZIP creation. The bundle structure remains intact when extracted on macOS, and applications remain executable without additional steps.
+
+### PKG installers
+
+:::note[New in Parcel 1.1]
+Parcel 1.1 adds PKG packaging for macOS applications.
+:::
+
+PKG packages use the native macOS Installer experience and can be created on every host supported by Parcel. They require **Create Bundle** and install the app into `/Applications` by default.
+
+An installer package uses a different certificate from the application inside it. For direct distribution, sign the app with a **Developer ID Application** certificate and the PKG with a **Developer ID Installer** certificate, then notarize the package. For Mac App Store distribution, use **Apple Distribution** for the app and **3rd Party Mac Developer Installer** for the PKG, enable App Sandbox, and submit the package to App Store Connect instead of notarizing it. See Apple's [Mac software packaging guidance](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution) and [Developer ID overview](https://developer.apple.com/support/developer-id/).
 
 ### Troubleshooting
 
@@ -145,6 +162,10 @@ Portable certificate format containing both the certificate and private key.
 Apple doesn't provide P12 certificates directly, but they can be exported from the Keychain or generated with OpenSSL.
 
 Parcel uses [rcodesign](https://github.com/indygreg/apple-platform-rs/tree/main/apple-codesign) to sign binaries and bundles on Windows and Linux machines.
+
+### Installer certificates for PKG
+
+PKG signing uses the **Installer Signing** group. Select a Keychain identity, P12 certificate, or PEM certificate that is authorized to sign installer packages. Application certificates cannot sign PKG installers, and installer certificates cannot sign the app bundle.
 
 ### Create Developer Certificate
 
@@ -231,6 +252,8 @@ See the [macOS troubleshooting page](/troubleshooting/platform-specific-issues/m
 Apple notarization verifies that applications have been checked by Apple for malicious software. Notarization is required for macOS 10.15 (Catalina) and later when distributing applications outside the Mac App Store.
 
 The process uploads an application to Apple's servers for scanning and associates the bundle hash with the developer account.
+
+Mac App Store packages are validated during submission and are not notarized separately. For direct distribution, Parcel can submit and staple DMG and PKG artifacts signed with Developer ID certificates. See Apple's [notarization documentation](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution).
 
 ### Prerequisites
 

--- a/tools/parcel/packaging-for-macos.md
+++ b/tools/parcel/packaging-for-macos.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 ## Packaging
 
-Parcel creates macOS application bundles (`.app`) and packages. You can run Parcel on Windows, macOS, or Linux.
+Parcel creates macOS application bundles (`.app`) and packages. Packaging via Parcel can be run on Windows, macOS, or Linux.
 
 | Format | CLI code | Best suited for |
 |---|---|---|
@@ -22,7 +22,7 @@ Parcel creates macOS application bundles (`.app`) and packages. You can run Parc
 | PKG installer (`.pkg`) | `pkg` | Managed installation, direct distribution, and Mac App Store submission |
 | ZIP archive (`.zip`) | `zip` | Direct distribution of an app bundle without an installer |
 
-For the complete setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#macos-settings).
+For a complete list of setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#macos-settings).
 
 ### Bundle Configuration
 
@@ -113,7 +113,7 @@ Parcel includes a visual DMG layout editor. The default layout uses a **660 x 42
 
 Icons are positioned from the top left corner to the icon center.
 
-Use the editor to change the window position, window size, icon size, label size, grid, and background color. You can also change the positions of the application bundle and Applications folder. Design the background image for the selected layout.
+Use the editor to change the window position, window size, icon size, label size, grid, and background color. You can also change the positions of the application bundle and Applications folder, and design the background image for the selected layout.
 
 :::note
 Parcel puts the optional **DMG License File** at the root of the image. Enable **Sign DMG** to sign the completed image with the application-signing credentials.
@@ -125,9 +125,14 @@ Parcel maintains executable permissions during ZIP creation. The bundle structur
 
 ### PKG installers <MinVersion version="1.1" isNewVersion="true" />
 
-PKG packages use the native macOS Installer. You can create them on every host that Parcel supports. PKG packages require **Create Bundle** and install the application in `/Applications` by default.
+PKG packages use the native macOS Installer. You can create them on every host that Parcel supports. PKG packages require **Create Bundle**. They install the application in `/Applications` by default.
 
-Use different certificates for the application and its installer package. For direct distribution, sign the application with a **Developer ID Application** certificate. Sign the PKG with a **Developer ID Installer** certificate. Then notarize the package. For Mac App Store distribution, see [App Store Connect](#app-store-connect). See also Apple's [Mac software packaging guidance](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution) and [Developer ID overview](https://developer.apple.com/support/developer-id/).
+You must use different certificates for the application and its installer package.
+
+- For direct distribution, sign the application with a **Developer ID Application** certificate. Sign the PKG with a **Developer ID Installer** certificate. Then, notarize the package.
+- For Mac App Store distribution, see [App Store Connect](#app-store-connect).
+
+See also Apple's [Mac software packaging guidance](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution) and [Developer ID overview](https://developer.apple.com/support/developer-id/).
 
 ### Troubleshooting
 
@@ -161,9 +166,9 @@ Apple doesn't provide P12 certificates directly, but they can be exported from t
 
 Parcel uses [rcodesign](https://github.com/indygreg/apple-platform-rs/tree/main/apple-codesign) to sign binaries and bundles on Windows and Linux machines.
 
-#### PEM Certificate (Cross-Platform)
+#### PEM Certificate (Cross-platform)
 
-Uses a PEM certificate for cross-platform signing. For a PKG package, configure separate PEM certificate fields for the application and installer.
+Use a PEM certificate for cross-platform signing. For a PKG package, you must configure separate PEM certificate fields for the application and installer.
 
 ### Installer certificates for PKG
 
@@ -252,17 +257,17 @@ Submit a signed PKG to distribute an application through the Mac App Store. Do n
 ### Recommended configuration
 
 1. Create the macOS application record in App Store Connect. Register an explicit App ID. Its bundle ID must exactly match **Bundle Identifier** in Parcel. App Store Connect uses the bundle ID and version to associate an upload with the application record.
-2. Configure signing with an **Apple Distribution** certificate. And configure PKG signing separately with a **Mac Installer Distribution** certificate. Do not use Developer ID certificates for an App Store submission, it will be rejected by Apple.
+2. Configure application signing with an **Apple Distribution** certificate. Configure PKG signing separately with a **Mac Installer Distribution** certificate. Do not use Developer ID certificates for an App Store submission, or it will be rejected by Apple.
 3. Create and download a **Mac App Store Connect** provisioning profile for the same explicit App ID and application-signing certificate.
-4. Copy the provisioning profile to the directory that contains the Parcel project file. Rename the profile to match the configured .NET project. For example, use `MyApp.provisionprofile` when **.NET Project Path** points to `MyApp.csproj`. Parcel requires this exact file name.
-5. Make sure that **Create Bundle** and **Enable Sandbox** are enabled in MacOS settings. Notarization must be disabled for App Store Connect - it's only useful for sideloading.
-6. Optinally, configure custom `Entitlements.plist` file in the project directory, if the app requires custom permissions. Before submission, test file access, network access, child processes, and bundled helper tools in the sandbox.
+4. Copy the provisioning profile to the directory that contains the Parcel project file. Rename the profile to match the configured .NET project. For example, use `MyApp.provisionprofile` if **.NET Project Path** points to `MyApp.csproj`. Parcel requires the file name to match exactly.
+5. Make sure that **Create Bundle** and **Enable Sandbox** are enabled in MacOS settings. Notarization must be disabled for App Store Connect. It is only useful for sideloading.
+6. Optionally, configure a custom `Entitlements.plist` file in the project directory if the app requires custom permissions. Before submission, test file access, network access, child processes, and bundled helper tools in the sandbox.
 7. Upload the PKG with Apple's Transporter application, Xcode tools, or another method that App Store Connect supports. Wait for processing to finish. Resolve all delivery warnings. Select the processed build for the macOS version, and submit it for review.
 
-See Apple's documentation for [creating a Mac App Store Connect provisioning profile](https://developer.apple.com/help/account/provisioning-profiles/create-an-app-store-provisioning-profile), [certificate purposes](https://developer.apple.com/help/account/certificates/certificates-overview), and [uploading builds](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/).
+See Apple's documentation for [creating an App Store Connect provisioning profile](https://developer.apple.com/help/account/provisioning-profiles/create-an-app-store-provisioning-profile), [certificate purposes](https://developer.apple.com/help/account/certificates/certificates-overview), and [uploading builds](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/).
 
 :::note[Do not notarize App Store builds with Parcel]
-Parcel notarizes software that uses a Developer ID identity for distribution outside the Mac App Store. Apple validates App Store packages during upload and submission. Disable Parcel notarization for an App Store build.
+Parcel notarizes software that uses a Developer ID for distribution outside the Mac App Store. Apple validates App Store packages during upload and submission. Disable Parcel notarization for an App Store build.
 :::
 
 ## Notarization

--- a/tools/parcel/packaging-for-windows.md
+++ b/tools/parcel/packaging-for-windows.md
@@ -11,14 +11,15 @@ tags:
 
 ## Packaging
 
-Parcel creates Windows installers and archives on Windows, macOS, and Linux.
+Parcel creates Windows installers and archives. You can run Parcel on Windows, macOS, or Linux.
 
 | Format | CLI code | Best suited for |
 |---|---|---|
 | NSIS installer (`.exe`) | `nsis` | Traditional direct distribution with a customizable installation flow and optional uninstaller |
 | MSIX package (`.msix`) | `msix` | Modern Windows deployment, enterprise management, and Microsoft Store distribution |
-| ZIP archive (`.zip`) | `zip` | Portable distribution without installation or registration |
+| ZIP archive (`.zip`) | `zip` | Portable distribution that does not require installation or registration |
 
+For the complete setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#windows-settings).
 
 ### Package Configuration
 
@@ -46,7 +47,7 @@ The publisher name displayed in Windows properties, installers, and system dialo
 
 **Create Company Folder**:
 
-When enabled, the application will be installed in a company-specific subdirectory:
+When enabled, Parcel installs the application in a company-specific subdirectory:
 - Admin install: `Program Files\[Company]\[Application Name]\`
 - User install: `%LocalAppData%\[Company]\[Application Name]\`
 
@@ -72,7 +73,7 @@ When enabled (default), the application is installed to `Program Files` and requ
 
 Default: true.
 
-**Include Uninstaller**:
+**Include uninstaller with the app**:
 
 When enabled, Parcel includes an uninstaller executable with the application and creates an entry in Windows Settings > Apps & Features (or Control Panel > Programs and Features on older Windows versions).
 
@@ -86,33 +87,29 @@ Optional license file to be displayed during installation. Supported formats:
 
 The license is displayed on a dedicated page during installation, and users must accept it to proceed.
 
-### MSIX packages
+### MSIX packages <MinVersion version="1.1" isNewVersion="true" />
 
-:::note[New in Parcel 1.1]
-Parcel 1.1 adds MSIX packaging Windows applications.
-:::
+MSIX provides package identity, clean installation and removal, and integration with Windows deployment systems. Parcel creates MSIX packages on every supported host. It does not require the Windows SDK to create the package. Parcel generates the package manifest or patches an `.appxmanifest` template in the project. It creates visual assets from the shared application metadata and **Installer Icon** settings.
 
-MSIX provides package identity, clean installation and removal, and integration with Windows deployment systems. Parcel creates MSIX packages on every supported host without requiring the Windows SDK for package creation. It generates the required package manifest and visual assets from the shared application metadata and **Installer Icon** settings.
+The **Publisher** setting is the distinguished name in the MSIX identity, such as `CN=Contoso`. For a signed package that you distribute directly, this value must exactly match the signing certificate subject. Parcel gets the value from a local signing certificate when possible. Otherwise, it uses **Company** or **Application Name**.
 
-The **Publisher** setting is the distinguished name stored in the MSIX identity, such as `CN=Contoso`. For directly distributed, signed packages, it must exactly match the subject of the signing certificate. Parcel derives it from a local signing certificate when possible, or falls back to the Company or Application Name.
-
-For direct distribution, Windows requires the MSIX package to be signed by a certificate that the target device trusts. When publishing through the Microsoft Store, the Store signs the submitted package; disable **Sign Installer** when signing is handled after Parcel. See Microsoft's [MSIX signing overview](https://learn.microsoft.com/en-us/windows/msix/package/signing-package-overview) and [Microsoft Store publishing guidance](https://learn.microsoft.com/en-us/windows/apps/publish/get-started).
+For direct distribution, sign the MSIX package with a certificate that the target device trusts. For Microsoft Store distribution, the Store signs the submitted package. Disable **Sign Installer** when another process signs the package after Parcel. See Microsoft's [MSIX signing overview](https://learn.microsoft.com/en-us/windows/msix/package/signing-package-overview) and [Microsoft Store publishing guidance](https://learn.microsoft.com/en-us/windows/apps/publish/get-started).
 
 ### Desktop integration
 
-**File Type Associations**:
+**File Associations**:
 
 Associate the application with specific file types by specifying file extensions (e.g., `.myfile`) and optionally adding MIME types and custom icons. This creates registry entries for proper Windows Explorer integration.
 
 To handle these files in Avalonia applications, see [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
 
-**URL Scheme Handlers**:
+**URL Schemes**:
 
 Register custom URL schemes for deep linking by defining custom schemes (e.g., `myapp://`, `myprotocol://`). This creates registry entries that enable other applications and web browsers to launch your app with specific parameters.
 
 To handle URL schemes in Avalonia applications, see [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
 
-Associations are configured once under Basics and are applied to both NSIS and MSIX packages. See [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations).
+Configure associations under **Basics**. Parcel applies them to NSIS and MSIX packages. See [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations).
 
 ## Code Signing
 
@@ -124,7 +121,7 @@ This document explains how to integrate various signing methods with Parcel. It 
 
 ### Prerequisites
 
-Before signing Windows applications, ensure you have:
+Before you sign a Windows application, make sure that you have these items:
 
 - **Code Signing Certificate**: Valid Authenticode certificate from a trusted Certificate Authority
 - **Windows SDK** (Windows only): Can be installed with Visual Studio Build Tools (on CI) or Visual Studio (on Desktop) from [Visual Studio Downloads](https://visualstudio.microsoft.com/downloads/)
@@ -167,12 +164,12 @@ Use certificates installed in the Windows Certificate Store, including hardware 
 
 #### Azure Artifact Signing (Cross-Platform)
 
-Cloud-based signing service, formerly named Trusted Signing, that avoids managing local certificates and protects signing keys with hardware security modules (HSMs).
+Azure Artifact Signing is a cloud signing service that was formerly named Trusted Signing. It removes the need to manage local certificates. Hardware security modules (HSMs) protect the signing keys.
 
 **Required Configuration:**
-- **Artifact Signing Endpoint**: Azure Artifact Signing service endpoint URL (format: `https://[region].codesigning.azure.net/`)
-- **Certificate Profile Name**: Name of the certificate profile in Azure Artifact Signing
-- **Code Signing Account Name**: Azure Artifact Signing account name
+- **Azure Artifact Signing Endpoint**: Service endpoint URL (format: `https://[region].codesigning.azure.net/`)
+- **Azure Artifact Signing Certificate Profile Name**: Name of the certificate profile
+- **Azure Artifact Signing Account Name**: Name of the signing account
 
 **Authentication:**
 Azure CLI authentication or environment variables:
@@ -308,4 +305,5 @@ Powered by [JSign](https://github.com/ebourg/jsign), and requires Java Runtime.
 ## See also
 
 - [Parcel setup](/tools/parcel/setup)
+- [Parcel configuration reference](/tools/parcel/configuration-reference)
 - [Parcel command line reference](/tools/parcel/command-line-reference)

--- a/tools/parcel/packaging-for-windows.md
+++ b/tools/parcel/packaging-for-windows.md
@@ -11,7 +11,7 @@ tags:
 
 ## Packaging
 
-Parcel creates Windows installers and archives. You can run Parcel on Windows, macOS, or Linux.
+Parcel creates Windows installers and archives. Packaging via Parcel can be run on Windows, macOS, or Linux.
 
 | Format | CLI code | Best suited for |
 |---|---|---|
@@ -19,7 +19,7 @@ Parcel creates Windows installers and archives. You can run Parcel on Windows, m
 | MSIX package (`.msix`) | `msix` | Modern Windows deployment, enterprise management, and Microsoft Store distribution |
 | ZIP archive (`.zip`) | `zip` | Portable distribution that does not require installation or registration |
 
-For the complete setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#windows-settings).
+For a complete list of setting names, types, defaults, and environment variables, see the [Parcel configuration reference](/tools/parcel/configuration-reference#windows-settings).
 
 ### Package Configuration
 
@@ -162,12 +162,12 @@ Use certificates installed in the Windows Certificate Store, including hardware 
 **Documentation:**
 - [Windows Certificate Store Overview](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/certificate-stores)
 
-#### Azure Artifact Signing (Cross-Platform)
+#### Azure Artifact Signing (Cross-platform)
 
 Azure Artifact Signing is a cloud signing service that was formerly named Trusted Signing. It removes the need to manage local certificates. Hardware security modules (HSMs) protect the signing keys.
 
 **Required Configuration:**
-- **Azure Artifact Signing Endpoint**: Service endpoint URL (format: `https://[region].codesigning.azure.net/`)
+- **Azure Artifact Signing Endpoint**: Service endpoint URL, in the format of `https://[region].codesigning.azure.net/`
 - **Azure Artifact Signing Certificate Profile Name**: Name of the certificate profile
 - **Azure Artifact Signing Account Name**: Name of the signing account
 
@@ -197,7 +197,7 @@ Store certificates and private keys securely in Azure Key Vault for centralized 
 
 **Required Configuration:**
 - **Azure Key Vault Name**: Name of the Azure Key Vault instance
-- **Azure Key Vault URL** (optional): Full vault URL for sovereign clouds or a non-default endpoint
+- **Azure Key Vault URL**: (optional) Full vault URL for sovereign clouds or a non-default endpoint
 - **Azure Key Vault Certificate Name**: Name of the certificate stored in the vault
 
 **Authentication:**
@@ -268,7 +268,7 @@ Use Google Cloud Key Management Service for secure private key storage. The cert
 
 **Required Configuration:**
 - **Google Access Token**: OAuth 2.0 access token for authentication
-- **Google Signing Keyring**: Keyring path in format: `projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEYRING]`
+- **Google Signing Keyring**: Keyring path, in the format of `projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEYRING]`
 - **Google Signing Certificate File**: Path to the certificate file
 - **Google Signing Certificate Version** (optional): Specific version of the key (uses most recent if omitted)
 

--- a/tools/parcel/packaging-for-windows.md
+++ b/tools/parcel/packaging-for-windows.md
@@ -11,7 +11,14 @@ tags:
 
 ## Packaging
 
-Parcel creates Windows installers (NSIS executable) and portable executables that can be distributed via setup files or ZIP archives. The tool handles executable configuration, registry entries, and can create Windows packages on all supported platforms.
+Parcel creates Windows installers and archives on Windows, macOS, and Linux.
+
+| Format | CLI code | Best suited for |
+|---|---|---|
+| NSIS installer (`.exe`) | `nsis` | Traditional direct distribution with a customizable installation flow and optional uninstaller |
+| MSIX package (`.msix`) | `msix` | Modern Windows deployment, enterprise management, and Microsoft Store distribution |
+| ZIP archive (`.zip`) | `zip` | Portable distribution without installation or registration |
+
 
 ### Package Configuration
 
@@ -79,21 +86,33 @@ Optional license file to be displayed during installation. Supported formats:
 
 The license is displayed on a dedicated page during installation, and users must accept it to proceed.
 
-<!--- NOT YET AVAILABLE IN STABLE PARCEL
+### MSIX packages
+
+:::note[New in Parcel 1.1]
+Parcel 1.1 adds MSIX packaging Windows applications.
+:::
+
+MSIX provides package identity, clean installation and removal, and integration with Windows deployment systems. Parcel creates MSIX packages on every supported host without requiring the Windows SDK for package creation. It generates the required package manifest and visual assets from the shared application metadata and **Installer Icon** settings.
+
+The **Publisher** setting is the distinguished name stored in the MSIX identity, such as `CN=Contoso`. For directly distributed, signed packages, it must exactly match the subject of the signing certificate. Parcel derives it from a local signing certificate when possible, or falls back to the Company or Application Name.
+
+For direct distribution, Windows requires the MSIX package to be signed by a certificate that the target device trusts. When publishing through the Microsoft Store, the Store signs the submitted package; disable **Sign Installer** when signing is handled after Parcel. See Microsoft's [MSIX signing overview](https://learn.microsoft.com/en-us/windows/msix/package/signing-package-overview) and [Microsoft Store publishing guidance](https://learn.microsoft.com/en-us/windows/apps/publish/get-started).
+
+### Desktop integration
 
 **File Type Associations**:
 
 Associate the application with specific file types by specifying file extensions (e.g., `.myfile`) and optionally adding MIME types and custom icons. This creates registry entries for proper Windows Explorer integration.
 
-To handle these files in Avalonia applications, see [Activatable Lifetime](https://docs.avaloniaui.net/docs/concepts/services/activatable-lifetime#handling-uri-activation) documentation.
+To handle these files in Avalonia applications, see [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
 
 **URL Scheme Handlers**:
 
 Register custom URL schemes for deep linking by defining custom schemes (e.g., `myapp://`, `myprotocol://`). This creates registry entries that enable other applications and web browsers to launch your app with specific parameters.
 
-To handle URL schemes in Avalonia applications, see [Activatable Lifetime](https://docs.avaloniaui.net/docs/concepts/services/activatable-lifetime#handling-uri-activation) documentation.
+To handle URL schemes in Avalonia applications, see [Activatable lifetime](/docs/services/activatable-lifetime#handling-uri-activation).
 
---->
+Associations are configured once under Basics and are applied to both NSIS and MSIX packages. See [File associations and URL schemes](/tools/parcel/configuration-reference#file-associations).
 
 ## Code Signing
 
@@ -146,14 +165,14 @@ Use certificates installed in the Windows Certificate Store, including hardware 
 **Documentation:**
 - [Windows Certificate Store Overview](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/certificate-stores)
 
-#### Microsoft Trusted Signing (Cross-Platform)
+#### Azure Artifact Signing (Cross-Platform)
 
-Cloud-based signing service that provides the highest trust level without managing local certificates. Provides immediate SmartScreen bypass and enhanced security through hardware security modules (HSMs).
+Cloud-based signing service, formerly named Trusted Signing, that avoids managing local certificates and protects signing keys with hardware security modules (HSMs).
 
 **Required Configuration:**
-- **Trusted Signing Endpoint**: Azure Trusted Signing service endpoint URL (format: `https://[region].codesigning.azure.net/`)
-- **Certificate Profile Name**: Name of the certificate profile in Azure Trusted Signing
-- **Code Signing Account Name**: Azure Trusted Signing account name
+- **Artifact Signing Endpoint**: Azure Artifact Signing service endpoint URL (format: `https://[region].codesigning.azure.net/`)
+- **Certificate Profile Name**: Name of the certificate profile in Azure Artifact Signing
+- **Code Signing Account Name**: Azure Artifact Signing account name
 
 **Authentication:**
 Azure CLI authentication or environment variables:
@@ -168,12 +187,12 @@ Azure CLI authentication or environment variables:
 - **Linux/macOS**: Uses [JSign](https://github.com/ebourg/jsign) (requires Java Runtime)
 
 :::tip
-Microsoft Trusted Signing is the recommended solution for enterprises requiring immediate trust without building reputation over time.
+Azure Artifact Signing is the recommended solution for enterprises requiring immediate trust without building reputation over time.
 :::
 
 **Documentation:**
-- [Microsoft Trusted Signing Documentation](https://learn.microsoft.com/en-us/azure/trusted-signing/)
-- [Trusted Signing Quickstart](https://learn.microsoft.com/en-us/azure/trusted-signing/quickstart)
+- [Azure Artifact Signing documentation](https://learn.microsoft.com/en-us/azure/artifact-signing/)
+- [Artifact Signing quickstart](https://learn.microsoft.com/en-us/azure/artifact-signing/quickstart)
 
 #### Azure Key Vault
 
@@ -181,6 +200,7 @@ Store certificates and private keys securely in Azure Key Vault for centralized 
 
 **Required Configuration:**
 - **Azure Key Vault Name**: Name of the Azure Key Vault instance
+- **Azure Key Vault URL** (optional): Full vault URL for sovereign clouds or a non-default endpoint
 - **Azure Key Vault Certificate Name**: Name of the certificate stored in the vault
 
 **Authentication:**
@@ -251,7 +271,7 @@ Use Google Cloud Key Management Service for secure private key storage. The cert
 
 **Required Configuration:**
 - **Google Access Token**: OAuth 2.0 access token for authentication
-- **Google Signing Keyring**: Full path to the keyring in format: `projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]`
+- **Google Signing Keyring**: Keyring path in format: `projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEYRING]`
 - **Google Signing Certificate File**: Path to the certificate file
 - **Google Signing Certificate Version** (optional): Specific version of the key (uses most recent if omitted)
 

--- a/tools/parcel/setup.md
+++ b/tools/parcel/setup.md
@@ -133,7 +133,7 @@ CLI is not available in the free community license.
 
 When Parcel opens, sign in with the Avalonia Portal account that has the tool license.
 
-For the CLI, use the `--license-key` option, set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable, or sign in through the Parcel GUI and reuse that session.
+For the CLI, use the `--license-key` option. Alternatively, set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable, or sign in through the Parcel GUI and reuse that session.
 
 ## Further Reading
 

--- a/tools/parcel/setup.md
+++ b/tools/parcel/setup.md
@@ -11,7 +11,7 @@ tags:
   - avalonia enterprise
 ---
 
-Avalonia Parcel is a packaging tool for Avalonia applications. It's designed as a two-app solution (GUI and console tool) that handles building, signing and packaging applications across Windows, macOS, and Linux platforms.
+Avalonia Parcel is a packaging tool for Avalonia applications. It provides a graphical user interface (GUI) and a command-line interface (CLI). You can use Parcel to build, sign, and package applications for Windows, macOS, and Linux.
 
 ## Prerequisites
 
@@ -22,10 +22,11 @@ Avalonia Parcel is a packaging tool for Avalonia applications. It's designed as 
 | macOS | 13 or newer |
 | Linux | X11 and glibc 2.27 or musl 1.22.2 compatible distros |
 
-## Step 1: Installing Avalonia Parcel
+## Step 1: Install Avalonia Parcel
 
-`Avalonia Parcel` is a native [.NET tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools), with an update mechanism provided by the SDK.
-This guide demonstrates global installation of the tool. Local installation is also possible but be aware: the tool will only work in the project that it's installed into.
+Avalonia Parcel is a [.NET tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools). Use the .NET SDK to install and update it.
+
+This guide shows how to install Parcel globally. You can install it locally, but a local installation works only in the project where you install it.
 
 <Tabs>
 <TabItem value="net10" label=".NET 10+" default>
@@ -34,9 +35,9 @@ This guide demonstrates global installation of the tool. Local installation is a
 dotnet tool install --global AvaloniaUI.Parcel
 ```
 
-If you are upgrading app from .NET 8/9 installation, you should first uninstall it with `dotnet tool uninstall --global AvaloniaUI.Parcel.Windows`  or `parcel uninstall`.
+If you installed Parcel for .NET 8 or .NET 9, first run `dotnet tool uninstall --global AvaloniaUI.Parcel.Windows` or `parcel uninstall`.
 
-Parcel can then be updated by running the `dotnet tool update` command.
+Use the following command to update Parcel:
 
 ```bash
 dotnet tool update --global AvaloniaUI.Parcel
@@ -45,7 +46,7 @@ dotnet tool update --global AvaloniaUI.Parcel
 </TabItem>
 <TabItem value="net8" label=".NET 8/9">
 
-If you're using .NET SDK older than 10, you must install a specific package depending on the running platform.
+If you use a .NET SDK version earlier than 10, install the package for your platform.
 
 <details>
 <summary>Installation commands</summary>
@@ -70,7 +71,7 @@ dotnet tool install --global AvaloniaUI.Parcel.Linux
 
 </details>
 
-Parcel can then be updated by running the `dotnet tool update` command.
+Use the command for your platform to update Parcel.
 
 <details>
 <summary>Update commands</summary>
@@ -99,30 +100,30 @@ dotnet tool update --global AvaloniaUI.Parcel.Linux
 </Tabs>
 
 :::warning
-On macOS or Linux, the installation location may not be automatically added to the PATH environment variable. This surfaces as a "command not found" error when trying to run `parcel`.
+On macOS or Linux, the installer might not add the installation directory to the `PATH` environment variable. In this case, the shell reports a "command not found" error when you run `parcel`.
 
-To resolve this issue, you must append the tool location to the PATH environment variable. The default location is usually `$HOME/.dotnet/tools`.
+Add the tool directory to `PATH`. The default directory is usually `$HOME/.dotnet/tools`.
 
 For more information, see [Troubleshooting .NET tool usage issues](https://learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#executable-file-not-found).
 :::
 
 ## Step 2: Run the tool
 
-After installation, you can launch it from terminal using:
+After installation, run Parcel from a terminal:
 
 ```bash
 parcel
 ```
 
-This command will run a GUI application where you can open or create parcel projects.
+This command opens the Parcel GUI. In the GUI, you can open or create Parcel projects.
 
-Alternatively, it's possible to run CLI commands from the terminal on an existing parcel project:
+You can also run CLI commands on an existing Parcel project:
 
 ```bash
 parcel pack ./SampleApp.parcel -r osx-x64 -p dmg -o ./artifacts
 ```
 
-This command will bundle, sign and package the application into a dmg file from the pre-configured parcel project.
+This command uses the Parcel project to bundle and sign the application. It then creates a DMG file.
 
 :::note
 CLI is not available in the free community license.
@@ -130,7 +131,7 @@ CLI is not available in the free community license.
 
 ## Step 3: Activate the tool
 
-Once the Parcel has opened, you will be asked to input `AvaloniaUI Portal` credentials that were used to license the tool.
+When Parcel opens, sign in with the Avalonia Portal account that has the tool license.
 
 For the CLI, use the `--license-key` option, set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable, or sign in through the Parcel GUI and reuse that session.
 

--- a/tools/parcel/setup.md
+++ b/tools/parcel/setup.md
@@ -137,6 +137,7 @@ For the CLI, use the `--license-key` option, set the `AVALONIA_TOOLS_LICENSE_KEY
 ## Further Reading
 
 - [Parcel command line reference](/tools/parcel/command-line-reference)
+- [Parcel configuration reference](/tools/parcel/configuration-reference)
 - [Model context protocol (MCP)](/tools/parcel/mcp)
 - [Windows packaging](/tools/parcel/packaging-for-windows)
 - [macOS packaging](/tools/parcel/packaging-for-macos)

--- a/tools/parcel/setup.md
+++ b/tools/parcel/setup.md
@@ -132,7 +132,7 @@ CLI is not available in the free community license.
 
 Once the Parcel has opened, you will be asked to input `AvaloniaUI Portal` credentials that were used to license the tool.
 
-For the CLI, you can set `--licenseKey` option or `PARCEL_LICENSE_KEY` env variable.
+For the CLI, use the `--license-key` option, set the `AVALONIA_TOOLS_LICENSE_KEY` environment variable, or sign in through the Parcel GUI and reuse that session.
 
 ## Further Reading
 


### PR DESCRIPTION
Major changes in 1.1 include new packaging formats (MSIX, PKG) and new project settings (file/url associations and more).
But this PR also updates the doc here and there, and includes configuration reference page (list of all settings, with their names in json config file and way to override with env variables).