### PR TITLE
Fix docs note on relative points in gradients start and end

### DIFF
--- a/docs/graphics-animation/gradients.md
+++ b/docs/graphics-animation/gradients.md
@@ -30,7 +30,7 @@ All gradient brushes share the `GradientStops` collection and `SpreadMethod` pro
 
 ### `StartPoint` and `EndPoint`
 
-These two properties control the direction of the gradient. You can specify values as percentages (for example, `"0%,50%"`) or as absolute points in the bounding box (for example, `"0,0.5"`).
+These two properties control the direction of the gradient. You can specify values as percentages (for example, `"0%,50%"`) or as absolute points in the bounding box (for example, `"10,15"`).
 
 Common direction patterns:
 

--- a/docs/graphics-animation/gradients.md
+++ b/docs/graphics-animation/gradients.md
@@ -30,7 +30,7 @@ All gradient brushes share the `GradientStops` collection and `SpreadMethod` pro
 
 ### `StartPoint` and `EndPoint`
 
-These two properties control the direction of the gradient. You can specify values as percentages (for example, `"0%,50%"`) or as decimals relative to the bounding box (for example, `"0,0.5"`). Both forms are equivalent.
+These two properties control the direction of the gradient. You can specify values as percentages (for example, `"0%,50%"`) or as absolute points in the bounding box (for example, `"0,0.5"`).
 
 Common direction patterns:
 


### PR DESCRIPTION
Fix a comment in https://docs.avaloniaui.net/docs/graphics-animation/gradients#startpoint-and-endpoint where it says that both percentages and decimals are relative and equivalent, which is incorrect. In Avalonia, decimal values are parsed as absolute units.