### PR TITLE
Document method overloading rules and improve docs on binding commands in general

### DIFF
--- a/docs/data-binding/binding-debugging.md
+++ b/docs/data-binding/binding-debugging.md
@@ -5,11 +5,9 @@ description: Debug data binding errors in Avalonia using trace-level logging and
 doc-type: how-to
 ---
 
-When a data binding does not produce the expected result, Avalonia provides tools and techniques to diagnose the problem.
-
 ## Binding error logging
 
-Avalonia logs binding errors to the trace output. In a debug build, these messages appear in the IDE Output window or the console. A typical binding error looks like:
+Avalonia logs binding errors to the trace output. In a debug build, these messages appear in the IDE Output window or the console. Here is an example of a typical binding error:
 
 ```text
 [Binding] Error in binding to 'Avalonia.Controls.TextBlock'.'Text': 'Could not find a matching property accessor for 'UserNam' on 'MyApp.ViewModels.MainViewModel'
@@ -17,57 +15,55 @@ Avalonia logs binding errors to the trace output. In a debug build, these messag
 
 This message tells you:
 - The target control and property (`TextBlock.Text`)
-- What went wrong (property `UserNam` not found, likely a typo for `UserName`)
+- What went wrong (Property `UserNam` not found, likely a typo for `UserName`)
 - The source type being searched (`MainViewModel`)
 
 ### Enabling verbose binding logging
 
-To see all binding activity (not just errors), configure the logging level at startup:
+To see all binding activity (not just errors), configure the logging level in the `Program.cs` file of your project. With this configuration, logs record every binding resolution, value change, and fallback applied.
 
 ```csharp
 public static AppBuilder BuildAvaloniaApp()
     => AppBuilder.Configure<App>()
         .UsePlatformDetect()
         .LogToTrace(LogEventLevel.Warning)
-        // Add binding-specific verbose logging:
+        // highlight-next-line
         .LogToTrace(LogEventLevel.Verbose, LogArea.Binding);
 ```
-
-This produces output for every binding resolution, value change, and fallback applied.
 
 ## Common binding problems
 
 ### Property not found
 
-**Symptom**: The control shows nothing or a fallback value. The log shows "Could not find a matching property accessor."
+**Symptom:** The control shows nothing or a fallback value. The log shows "Could not find a matching property accessor."
 
-**Causes**:
-- Typo in the binding path
-- The DataContext is not the type you expect
-- The property is not public
+**Causes:**
+- Typo in the binding path.
+- The data context is not the type you expect.
+- The property is not public.
 
-**Fix**: Verify the property name and check the DataContext with DevTools (see below).
+**Fix:** Verify the property name. Check the `DataContext` with [DevTools](#using-avalonia-devtools).
 
-### DataContext is null
+### `DataContext` is null
 
-**Symptom**: All bindings on a control produce no value.
+**Symptom:** All bindings on a control produce no value.
 
-**Causes**:
-- The DataContext was never set
-- The DataContext was set on the wrong element
-- A parent control has `DataContext="{Binding SomeProperty}"` where `SomeProperty` is null
+**Causes:**
+- The data context was never set.
+- The data context was set on the wrong element.
+- A parent control has `DataContext="{Binding SomeProperty}"` where `SomeProperty` is null.
 
-**Fix**: Use DevTools to inspect the DataContext at the control level.
+**Fix:** Use [DevTools](#using-avalonia-devtools) to inspect the `DataContext` at the control level.
 
 ### Binding mode mismatch
 
-**Symptom**: Changes in the UI do not propagate to the view model (or vice versa).
+**Symptom:** Changes in the UI do not propagate to the view model, or vice versa.
 
-**Causes**:
-- The default binding mode for the property is `OneWay`, but you need `TwoWay`
-- The source property does not raise `PropertyChanged`
+**Causes:**
+- The default binding mode for the property is `OneWay`, but you need `TwoWay`.
+- The source property does not raise `PropertyChanged`.
 
-**Fix**: Set `Mode=TwoWay` explicitly, and verify the view model implements `INotifyPropertyChanged`.
+**Fix:** Set `Mode=TwoWay` explicitly. Verify the view model implements `INotifyPropertyChanged`.
 
 ```xml
 <TextBox Text="{Binding Name, Mode=TwoWay}" />
@@ -75,48 +71,49 @@ This produces output for every binding resolution, value change, and fallback ap
 
 ### Compiled binding type mismatch
 
-**Symptom**: Build error mentioning "Cannot resolve property" or "Binding path is not valid for type."
+**Symptom:** Build error "Cannot resolve property" or "Binding path is not valid for type."
 
-**Causes**:
-- The `x:DataType` does not match the actual DataContext type
-- The property does not exist on the declared data type
+**Causes:**
+- The `x:DataType` does not match the actual `DataContext` type.
+- The property does not exist on the declared data type.
 
-**Fix**: Verify `x:DataType` matches your view model. Use `ReflectionBinding` to bypass compile-time checking if needed:
+**Fix:** Verify `x:DataType` matches your view model. Use a reflection binding to bypass compile-time checking if needed.
 
 ```xml
 <TextBlock Text="{ReflectionBinding DynamicProperty}" />
 ```
 
-### Converter returning UnsetValue
+### Method binding overload not resolved
 
-**Symptom**: The binding applies the FallbackValue instead of the converted result.
+**Symptom:** A command bound to an overloaded method fails.
 
-**Cause**: Your `IValueConverter.Convert` method returns `AvaloniaProperty.UnsetValue` or `BindingOperations.DoNothing`.
+- Build error "Found 2 overloads accepting one parameter."
+- Runtime exception when the command runs.
 
-**Fix**: Return an actual value or `null` (which triggers `TargetNullValue` instead).
+**Causes:**
+- Two or more overloads take one parameter and none takes `object`, so the choice is ambiguous.
+- Every overload takes two or more parameters, which method binding does not support.
+- The command parameter does not match the method parameter type, when using a compiled binding. (Compiled bindings do not convert `CommandParameter`.)
+
+**Fix:** Give the method a single `object` parameter, or remove the competing overloads. Make sure `CommandParameter` supplies the exact type. See [Binding directly to a method](/docs/data-binding/binding-to-commands#binding-directly-to-a-method) for the full rules.
+
+### Converter returns `UnsetValue`
+
+**Symptom:** The binding applies the fallback value instead of the converted result.
+
+**Cause:** Your `IValueConverter.Convert` method returns `AvaloniaProperty.UnsetValue` or `BindingOperations.DoNothing`.
+
+**Fix:** Return an actual value or `null` (which triggers `TargetNullValue` instead).
 
 ## Using Avalonia DevTools
 
-Press **F12** in a debug build to open the Avalonia DevTools. The DevTools provide several views for debugging bindings:
-
-### Properties tab
-
-Select any control in the tree and examine its properties. For each property, DevTools shows:
-- The current value
-- The value source (Local, Style, Binding, and similar)
-- Whether a binding is active
-
-Look for properties showing their default value when you expect a bound value. This indicates the binding failed.
-
-### Logical tree tab
-
-Navigate the logical tree to find controls and verify their DataContext. Select a control and check the `DataContext` property to confirm it is the expected view model instance.
+Press <kbd>F12</kbd> in the running app to open Avalonia DevTools. Then, use the [Elements tool](/tools/developer-tools/elements-tool) to examine the control's properties, or navigate the logical tree to verify its data context.
 
 ## Debugging bindings in code
 
 ### Observing binding values
 
-Use `GetObservable` to watch a property's value changes in real time:
+Use `GetObservable` to watch value changes of a property in real time:
 
 ```csharp
 myTextBlock.GetObservable(TextBlock.TextProperty).Subscribe(value =>
@@ -133,7 +130,7 @@ Debug.WriteLine($"DataContext type: {myControl.DataContext?.GetType().Name}");
 Debug.WriteLine($"DataContext value: {myControl.DataContext}");
 ```
 
-### Using FallbackValue for diagnostics
+### Using `FallbackValue` for diagnostics
 
 Temporarily add a `FallbackValue` to identify whether the binding path is failing:
 
@@ -141,34 +138,29 @@ Temporarily add a `FallbackValue` to identify whether the binding path is failin
 <TextBlock Text="{Binding UserName, FallbackValue='BINDING FAILED'}" />
 ```
 
-If you see "BINDING FAILED" in the UI, the binding path is wrong or the DataContext is null.
+If you see "BINDING FAILED" in the UI, the binding path is wrong or the data context is null.
 
 ## Compiled bindings diagnostics
 
-Compiled bindings are validated at compile time when `x:CompileBindings="True"` is set. If a binding path is invalid, you get a build error instead of a silent runtime failure.
+Compiled bindings are validated at compile time. If a binding path is invalid, you get a build error instead of a silent runtime failure.
 
-To enable compiled bindings project-wide, add to your `.csproj`:
+You have two options to resolve an invalid compiled binding:
 
-```xml
-<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-```
-
-When compiled bindings encounter a property that cannot be resolved at compile time, you have two options:
-1. Fix the `x:DataType` declaration to match the actual data type
-2. Use `ReflectionBinding` for dynamic properties that cannot be statically resolved
+1. Fix the `x:DataType` declaration to match the actual data type.
+2. Use `ReflectionBinding` for dynamic properties that cannot be statically resolved.
 
 ## Diagnostic checklist
 
 When a binding does not work:
 
-1. Check the Output window for binding error messages
-2. Open DevTools (F12) and verify the control's DataContext
-3. Verify the property name matches exactly (case-sensitive)
-4. Verify the property is `public` with a `get` accessor
-5. For `TwoWay` bindings, verify the property has a `set` accessor and the source implements `INotifyPropertyChanged`
-6. Check that the DataContext is set before the binding is evaluated
-7. Add `FallbackValue` to confirm whether the path resolution is the problem
-8. For compiled bindings, verify `x:DataType` matches the actual runtime type
+1. Check the Output window for binding error messages.
+2. Open [DevTools](#using-avalonia-devtools) to verify the control's data context.
+3. Verify the property name matches exactly (case-sensitive).
+4. Verify the property is `public` with a `get` accessor.
+5. For `TwoWay` bindings, verify the property has a `set` accessor and the source implements `INotifyPropertyChanged`.
+6. Check that the `DataContext` is set before the binding is evaluated.
+7. Add a `FallbackValue` to confirm whether the path resolution is the problem.
+8. For compiled bindings, verify `x:DataType` matches the actual runtime type.
 
 ## See also
 

--- a/docs/data-binding/binding-debugging.md
+++ b/docs/data-binding/binding-debugging.md
@@ -96,7 +96,11 @@ public static AppBuilder BuildAvaloniaApp()
 - Every overload takes two or more parameters, which method binding does not support.
 - The command parameter does not match the method parameter type, when using a compiled binding. (Compiled bindings do not convert `CommandParameter`.)
 
-**Fix:** Give the method a single `object` parameter, or remove the competing overloads. Make sure `CommandParameter` supplies the exact type. See [Binding directly to a method](/docs/data-binding/binding-to-commands#binding-directly-to-a-method) for the full rules.
+**Fix:**
+1. Remove competing overloads.
+2. Add a new overload taking a single `object` parameter (which is chosen with higher priority).
+
+See [Binding directly to a method](/docs/data-binding/binding-to-commands#binding-directly-to-a-method) for the full overload resolution rules.
 
 ### Converter returns `UnsetValue`
 

--- a/docs/data-binding/binding-debugging.md
+++ b/docs/data-binding/binding-debugging.md
@@ -97,10 +97,7 @@ public static AppBuilder BuildAvaloniaApp()
 - The command parameter does not match the method parameter type, when using a compiled binding. (Compiled bindings do not convert `CommandParameter`.)
 
 **Fix:**
-1. Remove competing overloads.
-2. Add a new overload taking a single `object` parameter (which is chosen with higher priority).
-
-See [Binding directly to a method](/docs/data-binding/binding-to-commands#binding-directly-to-a-method) for the full overload resolution rules.
+Remove competing overloads. Or add a new overload taking a single `object` parameter (which is chosen with higher priority). See [Binding directly to a method](/docs/data-binding/binding-to-commands#binding-directly-to-a-method) for the full overload resolution rules.
 
 ### Converter returns `UnsetValue`
 

--- a/docs/data-binding/binding-debugging.md
+++ b/docs/data-binding/binding-debugging.md
@@ -87,7 +87,8 @@ public static AppBuilder BuildAvaloniaApp()
 
 **Symptom:** A command bound to an overloaded method fails.
 
-- Build error "Found 2 overloads accepting one parameter."
+- Build error reports an unresolved overload when using compiled binding.
+- Runtime binding error reports an unresolved overload when using reflection binding.
 - Runtime exception when the command runs.
 
 **Causes:**

--- a/docs/data-binding/binding-to-commands.md
+++ b/docs/data-binding/binding-to-commands.md
@@ -1,23 +1,25 @@
 ---
 id: binding-to-commands
 title: Binding to commands
-description: Bind UI controls to ICommand implementations for handling user actions in the MVVM pattern.
+description: Bind UI controls to commands to handle user actions, using the MVVM pattern.
 doc-type: explanation
 ---
 
-Commands provide a clean way to connect user interactions (button clicks, menu selections, keyboard shortcuts) to logic in your view model. This page covers binding controls to commands using `ICommand`.
+Commands connect user interactions to logic in your code. This page covers how a binding reaches a command: the binding syntax, how a `Command` binding resolves a method, and how `CommandParameter` behaves.
 
-## Basic command binding
+For how to write the commands themselves—the `ICommand` interface, `CanExecute`, async commands, and keyboard shortcuts—see [Commanding](/docs/input-interaction/commanding).
 
-Any control that implements `ICommandSource` (such as `Button`, `MenuItem`, and `ToggleButton`) has a `Command` property:
+## Binding with `ICommand`
 
-```xml
+Any control that implements `ICommandSource` (such as `Button`, `MenuItem` or `ToggleButton`) has a `Command` property, which you can use in the view model.
+
+The example below uses the `[RelayCommand]` attribute from `CommunityToolkit.Mvvm` to generate a `SaveCommand` property of type `IRelayCommand`.
+
+```xml title="XAML"
 <Button Content="Save" Command="{Binding SaveCommand}" />
 ```
 
-The view model exposes a command property:
-
-```csharp
+```csharp title="View model"
 public partial class MainViewModel : ObservableObject
 {
     [RelayCommand]
@@ -28,20 +30,72 @@ public partial class MainViewModel : ObservableObject
 }
 ```
 
-The `[RelayCommand]` attribute from CommunityToolkit.Mvvm generates a `SaveCommand` property of type `IRelayCommand`. The naming convention appends "Command" to the method name.
+:::note
+The naming convention for commands is to append "Command" to the method name e.g., `SaveCommand`, `UndoCommand`.
+:::
 
-## CommandParameter
+## Binding directly to a method
 
-Pass data from the UI to the command using `CommandParameter`:
+As an alternative to `ICommand`, you can bind the `Command` property directly to a method in the data context.
 
-```xml
+```xml title="XAML"
+<Button Content="Save" Command="{Binding Save}" />
+```
+
+```csharp title="Data context"
+public void Save()
+{
+    // Save logic
+}
+```
+
+### How the overload is chosen
+
+If you [overload a method](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/member-overloading), Avalonia resolves the overload using the following rules:
+
+| Same-name methods | Result |
+|---|---|
+| One overload taking one parameter | Chosen, whatever the parameter type |
+| Two or more one-parameter overloads, one taking `object` | `object` overload is chosen |
+| Two or more one-parameter overloads, none taking `object` | Build error |
+| One overload with no parameters | Chosen |
+| Two or more overloads taking more than one parameter | Build error |
+
+Overloads taking two or more parameters are always ignored.
+
+:::caution
+Compiled bindings do not convert `CommandParameter` to the parameter type. If the types do not match, the cast throws an exception when the command runs. Reflection bindings do convert the value.
+:::
+
+### Enabled state
+
+To determine the enabled state on the bound control when you use method binding, add a `bool` method with a name in the format of `Can` followed by the bound method:
+
+```csharp
+public void Save()
+{
+    // Save logic
+}
+
+public bool CanSave(object? parameter) => !string.IsNullOrWhiteSpace(Name);
+```
+
+:::note
+This convention applies to method binding only. With `ICommand`, the control uses the command's own `CanExecute` instead. See [Commanding](/docs/input-interaction/commanding#icommand-interface) to learn more about `CanExecute`.
+:::
+
+## Command parameter
+
+Pass data from the UI to the command using `CommandParameter`. In this example, the view model receives the parameter to delete an item.
+
+```xml title="XAML"
 <ListBox ItemsSource="{Binding Items}">
     <ListBox.ItemTemplate>
         <DataTemplate>
             <StackPanel Orientation="Horizontal" Spacing="8">
                 <TextBlock Text="{Binding Name}" />
                 <Button Content="Delete"
-                        Command="{Binding $parent[ListBox].((vm:MainViewModel)DataContext).DeleteCommand}"
+                        Command="{Binding $parent[ListBox].DataContext.DeleteCommand}"
                         CommandParameter="{Binding}" />
             </StackPanel>
         </DataTemplate>
@@ -49,9 +103,7 @@ Pass data from the UI to the command using `CommandParameter`:
 </ListBox>
 ```
 
-The view model receives the parameter:
-
-```csharp
+```csharp title="Data context"
 [RelayCommand]
 private void Delete(Item item)
 {
@@ -59,110 +111,9 @@ private void Delete(Item item)
 }
 ```
 
-## CanExecute
+## Binding commands from a different data context
 
-Commands can conditionally enable or disable the bound control. When `CanExecute` returns `false`, the control is automatically disabled.
-
-### With CommunityToolkit.Mvvm
-
-Use the `[RelayCommand(CanExecute = ...)]` attribute to specify a `CanExecute` method:
-
-```csharp
-[ObservableProperty]
-[NotifyCanExecuteChangedFor(nameof(SaveCommand))]
-private string _name = "";
-
-[RelayCommand(CanExecute = nameof(CanSave))]
-private void Save()
-{
-    // Save logic
-}
-
-private bool CanSave() => !string.IsNullOrWhiteSpace(Name);
-```
-
-The `[NotifyCanExecuteChangedFor]` attribute ensures the `SaveCommand` re-evaluates its `CanExecute` whenever `Name` changes.
-
-### Manual ICommand implementation
-
-```csharp
-public class RelayCommand : ICommand
-{
-    private readonly Action _execute;
-    private readonly Func<bool>? _canExecute;
-
-    public RelayCommand(Action execute, Func<bool>? canExecute = null)
-    {
-        _execute = execute;
-        _canExecute = canExecute;
-    }
-
-    public event EventHandler? CanExecuteChanged;
-
-    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
-    public void Execute(object? parameter) => _execute();
-
-    public void RaiseCanExecuteChanged()
-        => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-}
-```
-
-## Async commands
-
-Long-running operations should use async commands to avoid blocking the UI thread:
-
-```csharp
-[RelayCommand]
-private async Task SaveAsync(CancellationToken token)
-{
-    await _repository.SaveAsync(token);
-}
-```
-
-CommunityToolkit.Mvvm generates a `SaveCommand` of type `IAsyncRelayCommand`, which:
-- Executes the method asynchronously
-- Disables the control while the command is running (prevents double-clicks)
-- Provides a `CancellationToken` parameter for cancellation support
-- Exposes an `IsRunning` property for showing progress indicators
-
-```xml
-<Button Content="Save" Command="{Binding SaveCommand}" />
-<ProgressBar IsVisible="{Binding SaveCommand.IsRunning}" IsIndeterminate="True" />
-```
-
-## Keyboard shortcuts
-
-Bind commands to keyboard shortcuts using `HotKey` or `KeyBinding`:
-
-```xml
-<!-- HotKey on a Button -->
-<Button Content="_Save"
-        Command="{Binding SaveCommand}"
-        HotKey="Ctrl+S" />
-
-<!-- KeyBinding on a window or control -->
-<Window.KeyBindings>
-    <KeyBinding Gesture="Ctrl+Z" Command="{Binding UndoCommand}" />
-    <KeyBinding Gesture="Ctrl+Shift+Z" Command="{Binding RedoCommand}" />
-</Window.KeyBindings>
-```
-
-The underscore in `Content="_Save"` creates an access key (Alt+S on Windows/Linux).
-
-## Controls that support commands
-
-| Control | Command Property | When Invoked |
-|---|---|---|
-| `Button` | `Command` | Click |
-| `MenuItem` | `Command` | Click |
-| `ToggleButton` | `Command` | Toggle |
-| `RadioButton` | `Command` | Selection change |
-| `HyperlinkButton` | `Command` | Click |
-| `SplitButton` | `Command` | Primary click |
-
-## Binding commands from a different DataContext
-
-When the command is on a parent view model but the binding occurs inside a template:
+When the command is on a parent view model, but the binding occurs inside a template:
 
 ```xml
 <!-- Using $parent to reach an ancestor's DataContext -->
@@ -174,10 +125,13 @@ When the command is on a parent view model but the binding occurs inside a templ
         CommandParameter="{Binding}" />
 ```
 
-With compiled bindings, cast the DataContext explicitly using the `((Type)expression)` syntax.
+See [`DataContext` type inference](/docs/data-binding/compiled-bindings#datacontext-type-inference) for more information.
 
 ## See also
 
-- [Commanding](/docs/input-interaction/commanding): Full commanding reference including manual ICommand patterns.
+- [Commanding](/docs/input-interaction/commanding): Writing commands — `ICommand`, `CanExecute`, async commands, and manual implementations.
 - [Keyboard and Hotkeys](/docs/input-interaction/keyboard-and-hotkeys): Hotkey and keybinding setup.
+- [How to bind can execute](/docs/data-binding/how-to-bind-can-execute): Worked example of a button enabled by `CanExecute`.
 - [Data Binding Syntax](/docs/data-binding/data-binding-syntax): Binding paths, modes, and converters.
+- [Binding debugging](/docs/data-binding/binding-debugging#method-binding-overload-not-resolved): Diagnosing method binding failures.
+- [Adding interactivity](/docs/input-interaction/adding-interactivity): Choosing between events and commands.

--- a/docs/data-binding/binding-to-commands.md
+++ b/docs/data-binding/binding-to-commands.md
@@ -57,9 +57,9 @@ If you [overload a method](https://learn.microsoft.com/en-us/dotnet/standard/des
 |---|---|
 | One overload taking one parameter | Chosen, whatever the parameter type |
 | Two or more one-parameter overloads, one taking `object` | `object` overload is chosen |
-| Two or more one-parameter overloads, none taking `object` | Build error |
+| Two or more one-parameter overloads, none taking `object` | Error |
 | One overload with no parameters | Chosen |
-| Two or more overloads taking more than one parameter | Build error |
+| Two or more overloads taking more than one parameter | Error |
 
 Overloads taking two or more parameters are always ignored.
 
@@ -129,9 +129,9 @@ See [`DataContext` type inference](/docs/data-binding/compiled-bindings#datacont
 
 ## See also
 
-- [Commanding](/docs/input-interaction/commanding): Writing commands — `ICommand`, `CanExecute`, async commands, and manual implementations.
+- [Commanding](/docs/input-interaction/commanding): Writing commands—`ICommand`, `CanExecute`, async commands, and manual implementations.
 - [Keyboard and Hotkeys](/docs/input-interaction/keyboard-and-hotkeys): Hotkey and keybinding setup.
-- [How to bind can execute](/docs/data-binding/how-to-bind-can-execute): Worked example of a button enabled by `CanExecute`.
+- [How to bind CanExecute](/docs/data-binding/how-to-bind-can-execute): Worked example of a button enabled by `CanExecute`.
 - [Data Binding Syntax](/docs/data-binding/data-binding-syntax): Binding paths, modes, and converters.
 - [Binding debugging](/docs/data-binding/binding-debugging#method-binding-overload-not-resolved): Diagnosing method binding failures.
 - [Adding interactivity](/docs/input-interaction/adding-interactivity): Choosing between events and commands.

--- a/docs/data-binding/compiled-bindings.md
+++ b/docs/data-binding/compiled-bindings.md
@@ -5,49 +5,42 @@ description: Use compiled bindings for compile-time validation and improved perf
 doc-type: how-to
 ---
 
-Bindings defined in XAML use reflection to find and access the requested property in your `ViewModel`. In Avalonia, you can also use compiled bindings, which have some benefits:
+Avalonia uses compiled bindings by default (as of [version 12](/docs/avalonia12-breaking-changes)) to access requested properties in the view model. Compiled bindings offer the following benefits:
 
-* If you use compiled bindings and the property you bind to is not found, you get a compile-time error. This gives you a much better debugging experience.
-* Reflection is known to be slow. Using compiled bindings can therefore improve the performance of your application.
+* If the property you bind to is not found, you get a compile-time error to aid debugging.
+* Reflection is known to be slow. Compiled bindings can improve the performance of your application.
 
-## Enable and disable compiled bindings
+## Enabling and disabling compiled bindings
 
-:::info
+Since version 12, Avalonia templates set `<AvaloniaUseCompiledBindingsByDefault>` to `true` by default. This means you only need to provide `x:DataType` for the objects you want to bind to, and do not need to set `x:CompileBindings="[True|False]"` on controls and windows.
 
-Depending on the template used to create your Avalonia project, compiled bindings may or may not be enabled by default. You can check this in your project file.
+If you wish to disable compiled bindings, you can change the flag to `false` in the `.csproj` file of your project.
 
-::: 
+Projects created with earlier versions of Avalonia may not have `<AvaloniaUseCompiledBindingsByDefault>` defined. If this is the case, compiled bindings are disabled.
 
-### Enable and disable globally
+## Setting the data type
 
-If you want your application to use compiled bindings globally by default, add
+Compiled bindings must have the `DataType` of the object you want to bind to.
 
-```xml
-<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-```
+[`DataTemplates`](/docs/data-templates/introduction-to-data-templates) have a `DataType` property. For all other elements, set the data type with an `x:DataType` in the root node, typically `Window` or `UserControl`.
 
-to your project file. You still need to provide `x:DataType` for the objects you want to bind to, but you don't need to set `x:CompileBindings="[True|False]"` for each `UserControl` or `Window`.
-
-### Enable and disable per UserControl or Window
-
-To enable compiled bindings, first define the `DataType` of the object you want to bind to. In [`DataTemplates`](/docs/data-templates/introduction-to-data-templates) there is a `DataType` property. For all other elements, you can set it via `x:DataType`. You will most likely set `x:DataType` in your root node, for example in a `Window` or a `UserControl`. You can also specify the `DataType` in the `Binding` directly.
-
-You can now enable or disable compiled bindings by setting `x:CompileBindings="[True|False]"`. All child nodes will inherit this property, so you can enable it in your root node and disable it for a specific child, if needed.
+Alternatively, you can also specify the `DataType` in the `Binding` directly.
 
 ```xml
-<!-- Set DataType and enable compiled bindings -->
+<!-- Set DataType in the root node -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:MyApp.ViewModels"
-             x:DataType="vm:MyViewModel"
-             x:CompileBindings="True">
+             // highlight-next-line
+             x:DataType="vm:MyViewModel">
+
     <StackPanel>
         <TextBlock Text="Last name:" />
         <TextBox Text="{Binding LastName}" />
         <TextBlock Text="Given name:" />
         <TextBox Text="{Binding GivenName}" />
         <TextBlock Text="E-Mail:" />
-        <!-- Set DataType inside the Binding-markup -->
+        <!-- Set DataType inside the Binding -->
         <TextBox Text="{Binding MailAddress, DataType={x:Type vm:MyViewModel}}" />
 
         <Button Content="Send an E-Mail"
@@ -58,11 +51,9 @@ You can now enable or disable compiled bindings by setting `x:CompileBindings="[
 
 ## `DataContext` type inference
 
-With compiled bindings enabled and `x:DataType` set on your root element, the Avalonia XAML compiler can infer the target type, even when you reference it via a named element (`#MyElement.DataContext`) or a parent lookup (`$parent[ControlType].DataContext`).
+With compiled bindings, the Avalonia XAML compiler can infer the target type, even when you reference it via a named element (`#MyElement.DataContext`) or a parent lookup (`$parent[ControlType].DataContext`).
 
 You do not need explicit type casting in most cases.
-
-For example:
 
 ```xml
 <Window x:Name="MyWindow"
@@ -75,10 +66,6 @@ For example:
 
 :::note
 `DataContext` type inference was introduced in 11.3.0. Earlier versions of Avalonia needed explicit type casting for instances where the target type of the binding expression could not be automatically determined.
-:::
-
-:::note
-If you use [Rider](https://www.jetbrains.com/rider/) as your IDE, the syntax highlighting may flag an error. However, the compiler should still work.
 :::
 
 ### Explicit type casting
@@ -96,9 +83,40 @@ Explicit type casting is not generally recommended.
 </Window>
 ```
 
-## `CompiledBinding` markup
+## `ReflectionBinding` and `CompiledBinding` markup
 
-If you don't want to enable compiled bindings for all child nodes, you can also use the `CompiledBinding` markup. You still need to define the `DataType`, but you can omit `x:CompileBindings="True"`.
+If you want to use reflection binding in a specific binding, use the `ReflectionBinding` markup.
+
+The reverse is also true: If you have [disabled compiled bindings in your project](#enabling-and-disabling-compiled-bindings), you can still use the `CompiledBinding` markup to use compiled binding in a specific binding.
+
+<Tabs>
+
+<TabItem value="reflection-binding-markup" label="ReflectionBinding markup">
+
+```xml
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:MyApp.ViewModels"
+             x:DataType="vm:MyViewModel">
+    <StackPanel>
+        <!-- Use the default compiled bindings -->
+        <TextBlock Text="Last name:" />
+        <TextBox Text="{Binding LastName}" />
+        <TextBlock Text="Given name:" />
+        <TextBox Text="{Binding GivenName}" />
+        <TextBlock Text="E-Mail:" />
+        <TextBox Text="{Binding MailAddress}" />
+
+        <!-- This command uses reflection binding instead -->
+        <Button Content="Send an E-Mail"
+                Command="{ReflectionBinding SendEmailCommand}" />
+    </StackPanel>
+</UserControl>
+```
+
+</TabItem>
+
+<TabItem value="compiled-binding-markup" label="CompiledBinding markup">
 
 ```xml
 <!-- Set DataType -->
@@ -107,46 +125,32 @@ If you don't want to enable compiled bindings for all child nodes, you can also 
              xmlns:vm="using:MyApp.ViewModels"
              x:DataType="vm:MyViewModel">
     <StackPanel>
+        <!-- Use compiled bindings -->
         <TextBlock Text="Last name:" />
-        <!-- use CompiledBinding markup for your binding -->
         <TextBox Text="{CompiledBinding LastName}" />
         <TextBlock Text="Given name:" />
         <TextBox Text="{CompiledBinding GivenName}" />
         <TextBlock Text="E-Mail:" />
         <TextBox Text="{CompiledBinding MailAddress}" />
 
-        <!-- This command will use ReflectionBinding, as it's default -->
+        <!-- This command uses reflection binding instead -->
         <Button Content="Send an E-Mail"
                 Command="{Binding SendEmailCommand}" />
     </StackPanel>
 </UserControl>
 ```
 
-## `ReflectionBinding` markup
+</TabItem>
 
-If you have compiled bindings enabled in the root node (via `x:CompileBindings="True"`) and you don't want to use a compiled binding at a certain position, you can use the `ReflectionBinding` markup.
+</Tabs>
 
-```xml
-<!-- Set DataType -->
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:vm="using:MyApp.ViewModels"
-             x:DataType="vm:MyViewModel"
-             x:CompileBindings="True">
-    <StackPanel>
-        <TextBlock Text="Last name:" />
-        <TextBox Text="{Binding LastName}" />
-        <TextBlock Text="Given name:" />
-        <TextBox Text="{Binding GivenName}" />
-        <TextBlock Text="E-Mail:" />
-        <TextBox Text="{Binding MailAddress}" />
+## Differences from reflection bindings
 
-        <!-- We use ReflectionBinding instead -->
-        <Button Content="Send an E-Mail"
-                Command="{ReflectionBinding SendEmailCommand}" />
-    </StackPanel>
-</UserControl>
-```
+Both binding types resolve the same binding paths, but there are two behavioral differences:
+
+**Command parameter conversion.** When a `Command` binds to a method that accepts a typed parameter, a reflection binding converts the `CommandParameter` value to that type at runtime. A compiled binding casts the value instead, and throws an exception if the types do not match. For more information, see [Binding directly to a method](/docs/data-binding/binding-to-commands#binding-directly-to-a-method).
+
+**Error timing.** A compiled binding reports an unresolved path as a build error. A reflection binding reports it at runtime, as a binding error in the log. For more information, see [Binding debugging](/docs/data-binding/binding-debugging).
 
 ## Compiled bindings from code
 
@@ -156,3 +160,4 @@ You can also create compiled bindings in C# code using the `CompiledBinding.Crea
 
 - [Compiled bindings from code](/docs/data-binding/binding-from-code#creating-compiled-bindings-from-code)
 - [Data binding syntax](/docs/data-binding/data-binding-syntax)
+- [Binding to commands](/docs/data-binding/binding-to-commands)

--- a/docs/data-binding/compiled-bindings.md
+++ b/docs/data-binding/compiled-bindings.md
@@ -16,7 +16,7 @@ Since version 12, Avalonia templates set `<AvaloniaUseCompiledBindingsByDefault>
 
 If you wish to disable compiled bindings, you can change the flag to `false` in the `.csproj` file of your project.
 
-Projects created with earlier versions of Avalonia may not have `<AvaloniaUseCompiledBindingsByDefault>` defined. If this is the case, compiled bindings are disabled.
+Projects created with earlier versions of Avalonia may not have `<AvaloniaUseCompiledBindingsByDefault>` defined. The undefined flag defaulted to disabled in versions before v12.
 
 ## Setting the data type
 

--- a/docs/data-binding/compiled-bindings.md
+++ b/docs/data-binding/compiled-bindings.md
@@ -12,11 +12,11 @@ Avalonia uses compiled bindings by default (as of [version 12](/docs/avalonia12-
 
 ## Enabling and disabling compiled bindings
 
-Since version 12, Avalonia templates set `<AvaloniaUseCompiledBindingsByDefault>` to `true` by default. This means you only need to provide `x:DataType` for the objects you want to bind to, and do not need to set `x:CompileBindings="[True|False]"` on controls and windows.
+Since version 12, Avalonia enables compiled bindings by default. This means you only need to provide `x:DataType` for the objects you want to bind to, and do not need to set `x:CompileBindings="[True|False]"` on controls and windows.
 
-If you wish to disable compiled bindings, you can change the flag to `false` in the `.csproj` file of your project.
+If you wish to disable compiled bindings, you can go to the `.csproj` file of your project and add a `<AvaloniaUseCompiledBindingsByDefault>` flag, which you can set to `false`. Disabling compiled bindings is not recommended.
 
-Projects created with earlier versions of Avalonia may not have `<AvaloniaUseCompiledBindingsByDefault>` defined. The undefined flag defaulted to disabled in versions before v12.
+If `<AvaloniaUseCompiledBindingsByDefault>` is undefined in your project file, it defaults to `true` from v12, but is `false` in earlier versions of Avalonia.
 
 ## Setting the data type
 

--- a/docs/data-binding/how-to-bind-can-execute.md
+++ b/docs/data-binding/how-to-bind-can-execute.md
@@ -1,6 +1,6 @@
 ---
 id: how-to-bind-can-execute
-title: How to bind can execute
+title: How to bind CanExecute
 description: Enable and disable buttons automatically by binding to the CanExecute method of a command.
 doc-type: how-to
 ---

--- a/docs/data-binding/markup-extensions.md
+++ b/docs/data-binding/markup-extensions.md
@@ -24,8 +24,8 @@ Avalonia provides the following markup extensions:
 | [StaticResource](/docs/app-development/resource-dictionary#static-resource)                    | An existing keyed resource and does not update on changes          |
 | [DynamicResource](/docs/app-development/resource-dictionary#using-resources)                   | Deferred loading of a keyed resource that will update on changes   |
 | Binding                                                                                          | Based on the default binding preference: Compiled or Reflection    |
-| [CompiledBinding](/docs/data-binding/compiled-bindings#compiledbinding-markup)       | Based on a compiled binding                                        |
-| [ReflectionBinding](/docs/data-binding/compiled-bindings#reflectionbinding-markup)   | Based on a reflection binding                                      |
+| [CompiledBinding](/docs/data-binding/compiled-bindings#reflectionbinding-and-compiledbinding-markup)       | Based on a compiled binding                                        |
+| [ReflectionBinding](/docs/data-binding/compiled-bindings#reflectionbinding-and-compiledbinding-markup)   | Based on a reflection binding                                      |
 | [TemplateBinding](/docs/custom-controls/templated-controls)    | Based on a simplified binding used only within a `ControlTemplate` |
 | [OnPlatform](/docs/platform-specific-guides/xaml#onplatform-markup-extension)     | Conditionally when on the specified platform                       |
 | [OnFormFactor](/docs/platform-specific-guides/xaml#onformfactor-markup-extension) | Conditionally when on the specified factor                         |

--- a/docs/input-interaction/adding-interactivity.md
+++ b/docs/input-interaction/adding-interactivity.md
@@ -108,7 +108,7 @@ public partial class MainViewModel : ObservableObject
 
 ## See also
 
-- [Commanding](/docs/input-interaction/commanding): Writing commands — `ICommand`, `CanExecute`, and async commands.
+- [Commanding](/docs/input-interaction/commanding): Writing commands—`ICommand`, `CanExecute`, and async commands.
 - [Binding to commands](/docs/data-binding/binding-to-commands): Binding syntax, method binding, and `CommandParameter`.
 - [Routed events](/docs/input-interaction/routed-events): How events travel through the control tree.
 - [Keyboard and Hotkeys](/docs/input-interaction/keyboard-and-hotkeys): Key bindings for commands.

--- a/docs/input-interaction/adding-interactivity.md
+++ b/docs/input-interaction/adding-interactivity.md
@@ -1,136 +1,114 @@
 ---
 id: adding-interactivity
-title: Adding Interactivity
+title: Adding interactivity
+doc-type: how-to
+description: Add interactive elements to your app with events and commands.
 ---
 
-One of the fundamental things that a user interface must do is interact with the user. In Avalonia, you can add interactivity to your applications by leveraging events and commands. This guide will introduce events and commands with simple examples.
+This guide introduces events and commands with simple examples. Events and commands enable interactivity in your applications, ensuring users can click, type, select, etc. through the user interface.
 
 ## Handling events
 
-Events in Avalonia provide a way to respond to user interactions and control-specific actions. You can handle events by following these steps:
+Events in Avalonia provide a way to respond to user interactions and control-specific actions. To handle an event:
 
-1. **Implement the Event Handler**: Write an event handler in the [code-behind](/docs/fundamentals/code-behind) that will be executed when the event is triggered. The event handler should contain the logic you want to execute in response to the event.
+1. **Implement the event handler:** Write an event handler in the [code-behind](/docs/fundamentals/code-behind). The handler is executed when the event triggers. It should contain the logic you want to execute in response to the event.
 
-```csharp title='MainWindow.axaml.cs'
-public partial class MainWindow : Window
+2. **Subscribe to the event:** Identify the event you want to handle in your control. Most controls in Avalonia expose events, such as `Click` or `SelectionChanged`. Subscribe to the event in XAML by adding an attribute with the name of the event and setting its value to the name of the event handler method.
+
+The example below adds a handler called `HandleButtonClick` to the `Click` event of a button.
+
+<XamlPreview>
+
+```xml
+<UserControl xmlns="https://github.com/avaloniaui">
+    <Button Name="myButton"
+            Content="Click me"
+            Margin="20"
+            Click="HandleButtonClick" />
+</UserControl>
+```
+
+```csharp
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+public partial class MyButton : UserControl
 {
-    public MainWindow()
+    private void HandleButtonClick(object? sender, RoutedEventArgs e)
     {
-        InitializeComponent();
+        if (sender is Button button)
+        {
+            button.Content = "Clicked!";
+        }
     }
-
-    // highlight-start
-    private void HandleButtonClick(object sender, RoutedEventArgs e)
-    {
-        // Event handling logic goes here
-    }
-    // highlight-end
 }
+
 ```
 
-2. **Subscribe to the Event**: Identify the event you want to handle in your control. Most controls in Avalonia expose various events, such as `Click` or `SelectionChanged`. Subscribe to the event in XAML by adding an attribute with the name of the event and setting its value to the name of the event handler method.
-
-```xml title='MainWindow.axaml'
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="AvaloniaApplication1.Views.MainWindow">
-  // highlight-next-line
-  <Button Name="myButton" Content="Click Me" Click="HandleButtonClick" />
-</Window>
-```
-
-The above example adds a handler called `HandleButtonClick` to a `Button`'s `Click` event.
+</XamlPreview>
 
 ## Using commands
 
-Commands in Avalonia provide a higher-level approach to handling user interactions, decoupling the user action from the implementation logic. Whereas events are defined in a control's code-behind, commands are usually bound to a property or method on the [data context](/docs/data-binding/data-context).
+Commands in Avalonia provide a higher-level approach to handling user interactions, decoupling the user action from the implementation logic. Unlike events, which are defined in a control's code-behind, commands are usually bound to a property or method on the [data context](/docs/data-binding/data-context).
 
-:::info
-Commands are available in all controls which provide a `Command` property. The command is usually triggered when the control's primary method of interaction occurs, for example a button click.
+Commands are available in all controls with a `Command` property. The command is usually triggered when the control's primary method of interaction occurs, for example a button click.
+
+### Binding to a method
+
+The simplest way to use a command is to bind to a method in the object's data context.
+
+1. **Add a method to the data context:** Define a method in the data context to handle the command. In MVVM apps, the data context is usually the view model.
+
+2. **Bind the method:** Associate the method with the control that triggers it.
+
+```xml title="XAML"
+<Button Content="Save" Command="{Binding Save}" />
+```
+
+```csharp title="Data context"
+public void Save()
+{
+    // Save logic
+}
+```
+
+:::note
+If the method has [overloads](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/member-overloading), Avalonia follows a fixed set of rules to pick one. See [Binding directly to a method](/docs/data-binding/binding-to-commands#binding-directly-to-a-method).
 :::
 
-The simplest way of using commands is to bind to a method in the object's data context.
+### `CommunityToolkit.Mvvm`
 
-1. **Add a method to the view model**: Define a method in a view model which will handle the command.
+Commands can also be defined as `ICommand` objects on the view model. The recommended way to create them is the `[RelayCommand]` attribute from `CommunityToolkit.Mvvm`.
 
-```csharp title='C#'
-    public class MainWindowViewModel
-    {
-        // highlight-start
-        public bool HandleButtonClick()
-        {
-            // Event handling logic here
-        }
-        // highlight-end
-    }
-    ```
+See [Commanding](/docs/input-interaction/commanding) for how to write commands, and [Binding to commands](/docs/data-binding/binding-to-commands) for the binding syntax, including passing data with `CommandParameter`.
 
-2. **Bind the Method**: Associate the method with the control that triggers it.
+```xml title="XAML"
+<Button Content="Save" Command="{Binding SaveCommand}" />
+```
 
-    ```xml title='XAML'
-    <Button Content="Click Me" Command="{Binding HandleButtonClick}" />
-    ```
-
-## Commands with CommunityToolkit.Mvvm
-
-The recommended approach for commands is the `[RelayCommand]` attribute from CommunityToolkit.Mvvm:
-
-```csharp
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-
+```csharp title="View model"
 public partial class MainViewModel : ObservableObject
 {
     [RelayCommand]
     private void Save()
     {
-        // Generates a SaveCommand property
+        // Save logic
     }
-
-    [RelayCommand]
-    private async Task LoadAsync()
-    {
-        // Generates a LoadCommand with automatic busy state
-    }
-}
-```
-
-```xml
-<Button Content="Save" Command="{Binding SaveCommand}" />
-<Button Content="Load" Command="{Binding LoadCommand}" />
-```
-
-## Command with parameter
-
-Pass data to a command using `CommandParameter`:
-
-```xml
-<Button Content="Delete"
-        Command="{Binding DeleteCommand}"
-        CommandParameter="{Binding SelectedItem}" />
-```
-
-```csharp
-[RelayCommand]
-private void Delete(Item item)
-{
-    Items.Remove(item);
 }
 ```
 
 ## Events vs commands
 
-| Feature | Events | Commands |
+| &nbsp; | Events | Commands |
 |---|---|---|
-| Defined in | Code-behind | View model |
+| Defined in | Code-behind | Data context |
 | Testable | Difficult (requires UI) | Easy (plain C# method) |
-| Best for | UI-specific actions (drag, resize) | Application logic (save, navigate, delete) |
+| Best for | Control-specific actions (drag, resize) | Application logic (save, navigate, delete) |
 | MVVM pattern | Not preferred | Preferred |
-
-Use events for UI-specific behavior (animations, visual feedback). Use commands for application logic that should be testable and decoupled from the view.
 
 ## See also
 
-- [Binding to Commands](/docs/data-binding/binding-to-commands): Full command binding reference.
-- [Commanding](/docs/input-interaction/commanding): ICommand interface details.
+- [Commanding](/docs/input-interaction/commanding): Writing commands — `ICommand`, `CanExecute`, and async commands.
+- [Binding to commands](/docs/data-binding/binding-to-commands): Binding syntax, method binding, and `CommandParameter`.
+- [Routed events](/docs/input-interaction/routed-events): How events travel through the control tree.
 - [Keyboard and Hotkeys](/docs/input-interaction/keyboard-and-hotkeys): Key bindings for commands.

--- a/docs/input-interaction/commanding.md
+++ b/docs/input-interaction/commanding.md
@@ -1,6 +1,8 @@
 ---
 id: commanding
 title: Commanding
+description: Write commands with ICommand to connect user actions to view model logic.
+doc-type: explanation
 ---
 
 Commanding connects user actions (button clicks, menu selections, keyboard shortcuts) to logic in your view model. Avalonia uses the standard .NET `ICommand` interface, which enables clean separation between UI and business logic.
@@ -186,16 +188,6 @@ public class MainViewModel
 }
 ```
 
-## Controls that support commanding
-
-| Control | Command property | When it fires |
-|---|---|---|
-| `Button` | `Command` | On click |
-| `MenuItem` | `Command` | On click |
-| [`KeyBinding`](/api/avalonia/input/keybinding) | `Command` | On key gesture |
-| `ToggleButton` | `Command` | On toggle |
-| `SplitButton` | `Command` | On primary button click |
-
 ## Keyboard shortcuts and commands
 
 Bind a command to a keyboard shortcut using `KeyBinding`:
@@ -224,6 +216,8 @@ The `HotKey` triggers the button's command even when the button does not have fo
 
 ## See also
 
-- [How to Bind CanExecute](/docs/data-binding/how-to-bind-can-execute): Binding patterns for CanExecute.
+- [Binding to commands](/docs/data-binding/binding-to-commands): Binding syntax, binding a `Command` straight to a method, and `CommandParameter`.
+- [How to bind CanExecute](/docs/data-binding/how-to-bind-can-execute): Worked example of a button enabled by `CanExecute`.
+- [Adding interactivity](/docs/input-interaction/adding-interactivity): Choosing between events and commands.
 - [Keyboard and Hotkeys](/docs/input-interaction/keyboard-and-hotkeys): Key bindings and keyboard input.
 - [The MVVM Pattern](/docs/fundamentals/the-mvvm-pattern): Architecture for separating UI and logic.


### PR DESCRIPTION
- Add new content to document method overloading selection rules.
- Add new content to document binding commands to methods in general (which were previously under-documented).
- Remove redundant content on creating commands (which were repeated multiple times on separate pages).
- Correct outdated sections to present up-to-date information on compiled bindings being on by default.
- Add crosslinks to relevant pages.
- General style edits.