### PR TITLE
docs(get-started): fix project structure description error

### DIFF
--- a/docs/get-started/create-your-first-project.mdx
+++ b/docs/get-started/create-your-first-project.mdx
@@ -96,7 +96,7 @@ The MVVM template creates a project with the following structure:
 | File/Folder | Purpose |
 |---|---|
 | **App.axaml** | Application-level resources and styles. The `.axaml` extension is short for Avalonia XAML. |
-| **ViewModels/** | Contains `MainWindowModel`, which holds data and logic for the main window. |
+| **ViewModels/** | Contains `MainViewModel`, which holds data and logic for the main window. |
 | **Views/MainWindow.axaml** | The XAML markup that defines the main window's appearance. |
 | **Views/MainWindow.axaml.cs** | The code-behind file for the main window. |
 | **Program.cs** | The application entry point that configures and launches Avalonia. |

--- a/docs/get-started/create-your-first-project.mdx
+++ b/docs/get-started/create-your-first-project.mdx
@@ -96,7 +96,7 @@ The MVVM template creates a project with the following structure:
 | File/Folder | Purpose |
 |---|---|
 | **App.axaml** | Application-level resources and styles. The `.axaml` extension is short for Avalonia XAML. |
-| **ViewModels/** | Contains `MainWindowViewModel`, which holds data and logic for the main window. |
+| **ViewModels/** | Contains `MainWindowModel`, which holds data and logic for the main window. |
 | **Views/MainWindow.axaml** | The XAML markup that defines the main window's appearance. |
 | **Views/MainWindow.axaml.cs** | The code-behind file for the main window. |
 | **Program.cs** | The application entry point that configures and launches Avalonia. |


### PR DESCRIPTION
Under `What's in the project?` > `ViewModels/`, the documentation incorrectly says `Contains MainWindowViewModel, which holds data and logic for the main window.`

The MVVM template creates MainViewModel, not MainWindowViewModel. This pull request fixes that.
<img width="1190" height="253" alt="MVVM template `MainViewModel` file and class" src="https://github.com/user-attachments/assets/acc3d2d6-22e5-4672-9a0d-2b0ba453933d" />
