### PR TITLE
docs(get-started): update stale ViewModel name x:DataType XAML directive

### DIFF
--- a/docs/get-started/starter-tutorial/customizing-the-avalonia-window.mdx
+++ b/docs/get-started/starter-tutorial/customizing-the-avalonia-window.mdx
@@ -39,7 +39,7 @@ Scroll to the top of the file **MainWindow.axaml** and examine the `<Window>` op
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="GetStartedApp.Views.MainWindow"
-        x:DataType="vm:MainWindowViewModel"
+        x:DataType="vm:MainViewModel"
         Icon="/Assets/avalonia-logo.ico"
         Title="GetStartedApp">
 ```


### PR DESCRIPTION
Update `x:DataType="vm:MainWindowViewModel"` to `x:DataType="vm:MainViewModel"` to accurately reflect the new ViewModel name